### PR TITLE
brpc enable CPU_PROFILER and HEAP_PROFILER

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -516,6 +516,10 @@ cc_binary(
         "include/engine",
         "include/common",
     ],
+    copts = [
+        "-DBAIDU_RPC_ENABLE_CPU_PROFILER",
+        "-DBAIDU_RPC_ENABLE_HEAP_PROFILER",
+    ],
     deps = [
         ":meta_server",
         ":cc_baikaldb_internal_proto",
@@ -524,6 +528,7 @@ cc_binary(
         ":raft",
         ":raft_meta",
         "@boost//:filesystem",
+        "//external:tcmalloc_and_profiler",
     ],
     linkstatic = True,
 )
@@ -533,6 +538,10 @@ cc_binary(
     srcs = ["src/store/main.cpp"],
     includes = [
         "include/store",
+    ],
+    copts = [
+        "-DBAIDU_RPC_ENABLE_CPU_PROFILER",
+        "-DBAIDU_RPC_ENABLE_HEAP_PROFILER",
     ],
     deps = [
         ":store",
@@ -550,6 +559,7 @@ cc_binary(
         ":physical_plan",
         ":logical_plan",
         ":mem_row",
+        "//external:tcmalloc_and_profiler",
     ],
     linkstatic = True,
 )
@@ -639,7 +649,10 @@ cc_library(
 cc_binary(
     name = "baikaldb",
     srcs = ["src/protocol/main.cpp"],
-    copts = COPTS,
+    copts = COPTS + [
+        "-DBAIDU_RPC_ENABLE_CPU_PROFILER",
+        "-DBAIDU_RPC_ENABLE_HEAP_PROFILER",
+    ],
     deps = [
         ":protocol2",
         ":common",
@@ -655,6 +668,7 @@ cc_binary(
         ":physical_plan2",
         ":logical_plan",
         ":mem_row",
+        "//external:tcmalloc_and_profiler",
     ],
     linkstatic = True,
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -133,7 +133,7 @@ bind(
 git_repository(
     name = "com_github_brpc_brpc",
     remote= "https://github.com/apache/incubator-brpc.git",
-    tag = "v0.9.0",
+    tag = "0.9.7-rc01",
 )
 
 bind(
@@ -159,4 +159,18 @@ bind(
 bind(
     name = "json2pb",
     actual = "@com_github_brpc_brpc//:json2pb",
+)
+
+# gperftools
+new_http_archive(
+    name = "com_github_gperftools_gperftools",
+    url = "https://github.com/gperftools/gperftools/archive/gperftools-2.7.tar.gz",
+    strip_prefix = "gperftools-gperftools-2.7",
+    sha256 = "3a88b4544315d550c87db5c96775496243fb91aa2cea88d2b845f65823f3d38a",
+    build_file = "third-party/gperftools.BUILD",
+)
+
+bind(
+    name = "tcmalloc_and_profiler",
+    actual = "@com_github_gperftools_gperftools//:tcmalloc_and_profiler",
 )

--- a/third-party/gperftools.BUILD
+++ b/third-party/gperftools.BUILD
@@ -1,0 +1,34 @@
+licenses(["notice"])  # Apache v2
+# @see: https://github.com/bazelbuild/bazel/issues/818
+# @see: https://github.com/envoyproxy/envoy/issues/1069
+genrule(
+    name = "build",
+    srcs = glob(["**/*"]),
+    outs = [
+        "src/gperftools/tcmalloc.h",
+        ".libs/libtcmalloc_and_profiler.a",
+    ],
+    cmd = "\n".join([
+        "gperf=\"external/com_github_gperftools_gperftools\"",
+        "outs=($(OUTS))",
+        "cp -r $${gperf} build",
+        "(cd build" +
+        " && ./autogen.sh >/dev/null 2>&1" +
+        " && ./configure -q --enable-frame-pointers --disable-libunwind" +
+        " && make --silent libtcmalloc_and_profiler.la)",
+        "cp build/src/gperftools/tcmalloc.h $(location src/gperftools/tcmalloc.h)",
+        "cp build/.libs/libtcmalloc_and_profiler.a  $(location .libs/libtcmalloc_and_profiler.a)",
+    ]),
+)
+
+cc_library(
+    name = "tcmalloc_and_profiler",
+    srcs = [".libs/libtcmalloc_and_profiler.a"],
+    hdrs = glob(["src/gperftools/*.h"]) +
+                ["src/gperftools/tcmalloc.h"], 
+    strip_include_prefix = "src",                                                                      
+    linkopts = ["-pthread",],
+    linkstatic = True,
+    visibility = ["//visibility:public"],
+)
+


### PR DESCRIPTION
1. brpc版本号升级到0.9.7-rc01以支持火焰图
2. 增加gperftools的BUILD文件
3. [开启CPU_PROFILER](https://github.com/apache/incubator-brpc/blob/master/docs/cn/cpu_profiler.md)
4. [开启HEAP_PROFILER](https://github.com/apache/incubator-brpc/blob/master/docs/cn/heap_profiler.md)