### PR TITLE
fix cstore set null bug

### DIFF
--- a/include/engine/transaction.h
+++ b/include/engine/transaction.h
@@ -127,12 +127,13 @@ public:
     // Value is null if engine = rocksdb_cstore;
     // First encode key with @record, and then erase the key fields from @record;
     int put_primary(int64_t region, IndexInfo& pk_index, SmartRecord record,
-                    bool delete_before_put_primary = false);
+                    std::set<int32_t>* update_fields = nullptr);
 
     // Key format: region_id(8 bytes) + table_id(4 bytes) + field_id(4 bytes) + primary_key_fields;
     // Value format: non-primary key fields encode value;
+    // update_fields: null for new row, not null for old row
     int put_primary_columns(const TableKey& primary_key, SmartRecord record,
-                            bool delete_before_put_primary);
+                            std::set<int32_t>* update_fields);
 
     // UNIQUE INDEX format: <region_id + index_id + null_flag + index_fields, primary_key>
     // NON-UNIQUE INDEX format: <region_id + index_id + null_flag + index_fields + primary_key, NULL>

--- a/include/exec/dml_node.h
+++ b/include/exec/dml_node.h
@@ -99,6 +99,7 @@ protected:
     std::vector<pb::SlotDescriptor> _primary_slots;
     std::vector<pb::SlotDescriptor> _update_slots;
     std::vector<ExprNode*> _update_exprs;
+    std::set<int32_t> _update_field_ids;
 
     SmartTransaction         _txn = nullptr; 
     SmartTable               _table_info;

--- a/src/exec/dml_node.cpp
+++ b/src/exec/dml_node.cpp
@@ -323,10 +323,10 @@ int DMLNode::insert_row(RuntimeState* state, SmartRecord record, bool is_update)
             return ret;
         }
     }
-    // 列存为节省空间, 插入默认值时不会put, 因此不会覆盖未被删除的旧值
-    // 更新时, _affect_primary=false时旧值会保留, 需要删除旧值
-    // 替换时, _affect_primary=true且旧行已存在时, 需要删除旧值
-    ret = _txn->put_primary(_region_id, *_pri_info, record, delete_before_put_primary);
+    // 列存为节省空间, 插入默认值或空值时不会put
+    // delete_before_put_primary为true时表示更新前旧值尚未被删除
+    ret = _txn->put_primary(_region_id, *_pri_info, record,
+                            delete_before_put_primary ? &_update_field_ids : nullptr);
     if (ret < 0) {
         DB_WARNING_STATE(state, "put table:%ld fail:%d", _table_id, ret);
         return -1;

--- a/src/exec/insert_node.cpp
+++ b/src/exec/insert_node.cpp
@@ -91,6 +91,15 @@ int InsertNode::open(RuntimeState* state) {
         DB_WARNING_STATE(state, "init schema failed fail:%d", ret);
         return ret;
     }
+    // cstore下只更新涉及列
+    if (_is_replace && _table_info->engine == pb::ROCKSDB_CSTORE) {
+        for (auto& field_info : _table_info->fields) {
+            if (_pri_field_ids.count(field_info.id) == 0 &&
+                    _update_field_ids.count(field_info.id) == 0) {
+                _update_field_ids.insert(field_info.id);
+            }
+        }
+    }
     int cnt = 0;
     for (auto& pb_record : _pb_node.derive_node().insert_node().records()) {
         SmartRecord record = _factory->new_record(*_table_info);


### PR DESCRIPTION
cstore时，update set null 不起作用，主要原因是set null时cstore不执行put操作，需要删除旧值，修复了这部分逻辑。