### PR TITLE
support binlog

### DIFF
--- a/include/common/baikal_heartbeat.h
+++ b/include/common/baikal_heartbeat.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2018-present Baidu, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "proto/meta.interface.pb.h"
+#include "schema_factory.h"
+#include "meta_server_interact.hpp"
+
+namespace baikaldb {
+class BaikalHeartBeat {
+public:
+    static void construct_heart_beat_request(pb::BaikalHeartBeatRequest& request);
+    static void process_heart_beat_response_sync(const pb::BaikalHeartBeatResponse& response);
+    static void process_heart_beat_response(const pb::BaikalHeartBeatResponse& response);
+};
+
+class BinlogNetworkServer  {
+public:
+    ~BinlogNetworkServer() = default;
+    typedef ::google::protobuf::RepeatedPtrField<pb::RegionInfo> RegionVec; 
+    typedef ::google::protobuf::RepeatedPtrField<pb::SchemaInfo> SchemaVec;
+    
+    void config(const std::string& namespace_name, const std::string& table) {
+        _table_names.push_back(namespace_name + "." + table);
+    }
+
+    bool init();
+
+    static BinlogNetworkServer* get_instance() {
+        static BinlogNetworkServer server;
+        return &server;
+    }
+
+    int64_t get_binlog_target_id() const {
+        return _binlog_id;
+    }
+
+    const std::unordered_set<int64_t>& get_binlog_origin_ids() const {
+        return _binlog_table_ids;
+    }
+
+    void report_heart_beat();
+
+    void schema_heartbeat() {
+        _heartbeat_bth.run([this]() {report_heart_beat();});
+    }
+
+    void process_heart_beat_response(const pb::BaikalHeartBeatResponse& response);
+
+    bool process_heart_beat_response_sync(const pb::BaikalHeartBeatResponse& response);
+
+private:
+    std::vector<std::string> _table_names;
+    std::unordered_set<int64_t> _binlog_table_ids;
+    int64_t _binlog_id {-1};
+    bool _shutdown {false};
+    Bthread _heartbeat_bth;
+};
+}

--- a/include/common/common.h
+++ b/include/common/common.h
@@ -129,6 +129,7 @@ enum ExplainType {
     SHOW_PLAN               = 4,
     SHOW_TRACE              = 5,
     SHOW_TRACE2             = 6,
+    EXPLAIN_SHOW_COST       = 7,
 };
 
 inline bool explain_is_trace(ExplainType& type) {
@@ -767,6 +768,22 @@ inline int set_insert(std::unordered_set<std::string>& set, const std::string& i
 //map double buffer
 template<typename Key, typename Val>
 using DoubleBufferMap = butil::DoublyBufferedData<std::unordered_map<Key, Val>>;
+
+namespace tso {
+constexpr int64_t update_timestamp_interval_ms = 50LL; // 50ms
+constexpr int64_t update_timestamp_guard_ms = 1LL; // 1ms
+constexpr int64_t save_interval_ms = 3000LL;  // 3000ms
+constexpr int64_t base_timestamp_ms = 1577808000000LL; // 2020-01-01 12:00:00
+constexpr int    logical_bits = 18;
+constexpr int64_t max_logical = 1 << logical_bits;
+
+inline int64_t clock_realtime_ms() {
+  struct timespec tp;
+  ::clock_gettime(CLOCK_REALTIME, &tp);
+  return tp.tv_sec * 1000ULL + tp.tv_nsec / 1000000ULL - base_timestamp_ms;
+}
+
+} // namespace tso
 
 } // namespace baikaldb
 

--- a/include/common/expr_value.h
+++ b/include/common/expr_value.h
@@ -111,35 +111,36 @@ struct ExprValue {
         return min_len;
     }
 
-    float float_value(int prefix_len) const {
+    double float_value(int prefix_len) {
         uint64_t val = 0;
         switch (type) {
             case pb::BOOL:
-                return static_cast<float>(_u.bool_val);
+                return static_cast<double>(_u.bool_val);
             case pb::INT8:
-                return static_cast<float>(_u.int8_val);
+                return static_cast<double>(_u.int8_val);
             case pb::INT16:
-                return static_cast<float>(_u.int16_val);
+                return static_cast<double>(_u.int16_val);
             case pb::INT32:
-            case pb::TIME:
-                return static_cast<float>(_u.int32_val);
+                return static_cast<double>(_u.int32_val);
             case pb::INT64:
-                return static_cast<float>(_u.int64_val);
+                return static_cast<double>(_u.int64_val);
             case pb::UINT8:
-                return static_cast<float>(_u.uint8_val);
+                return static_cast<double>(_u.uint8_val);
             case pb::UINT16:
-                return static_cast<float>(_u.uint16_val );
+                return static_cast<double>(_u.uint16_val );
             case pb::UINT32:
             case pb::TIMESTAMP:
-            case pb::DATE:
-                return static_cast<float>(_u.uint32_val);
+                return static_cast<double>(_u.uint32_val);
             case pb::UINT64:
-            case pb::DATETIME:
-                return static_cast<float>(_u.uint64_val);
+                return static_cast<double>(_u.uint64_val);
             case pb::FLOAT:
-                return _u.float_val;
+                return static_cast<double>(_u.float_val);
             case pb::DOUBLE:
-                return static_cast<float>(_u.double_val);
+                return _u.double_val;
+            case pb::TIME:
+            case pb::DATE:
+            case pb::DATETIME:
+                return static_cast<double>(cast_to(pb::TIMESTAMP)._u.uint32_val);
             case pb::STRING:
             case pb::HEX:
                 if (prefix_len >= (int)str_val.size()) {
@@ -152,7 +153,7 @@ struct ExprValue {
                         val += val << 8;
                     }
                 }
-                return static_cast<float>(val);
+                return static_cast<double>(val);
             default:
                 return 0.0;
         }

--- a/include/engine/my_listener.h
+++ b/include/engine/my_listener.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2018-present Baidu, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "rocksdb/listener.h"
+#include "rocks_wrapper.h"
+
+namespace baikaldb {
+class MyListener : public rocksdb::EventListener {
+    virtual void OnStallConditionsChanged(const rocksdb::WriteStallInfo& info) {
+        bool is_stall = info.condition.cur != rocksdb::WriteStallCondition::kNormal;
+        RocksWrapper::get_instance()->set_is_stall(info.cf_name, is_stall);
+        DB_WARNING("OnStallConditionsChanged, cf:%s is_stall:%d", info.cf_name.c_str(), is_stall);
+    }
+};
+}

--- a/include/engine/split_compaction_filter.h
+++ b/include/engine/split_compaction_filter.h
@@ -56,7 +56,7 @@ public:
         if (ret < 0) {
             return false;
         }
-        if (/*start_key.empty() &&*/end_key.empty()) {
+        if (/*start_key.empty() &&*/ end_key.empty()) {
             return false;
         }
         int64_t index_id = table_key.extract_i64(sizeof(int64_t));

--- a/include/engine/sst_file_writer.h
+++ b/include/engine/sst_file_writer.h
@@ -32,6 +32,9 @@ public:
     rocksdb::Status finish(rocksdb::ExternalSstFileInfo* file_info = nullptr) {
         return _sst_writer.Finish(file_info);
     }
+    uint64_t file_size() {
+        return _sst_writer.FileSize();
+    }
     virtual ~SstFileWriter() {}
 private:
     rocksdb::SstFileWriter _sst_writer;

--- a/include/exec/access_path.h
+++ b/include/exec/access_path.h
@@ -89,9 +89,10 @@ enum IndexHint {
     
     double calc_field_selectivity(int32_t field_id, range::FieldRange& range);
 
-    double fields_to_selectivity(const std::unordered_set<int32_t>& field_ids);
+    double fields_to_selectivity(const std::unordered_set<int32_t>& field_ids, std::map<int32_t, double>& filed_selectivity);
     // TODO 后续做成index的统计信息，现在只是单列统计聚合
-    void calc_cost();
+    void calc_cost(std::map<std::string, std::string>* cost_info, std::map<int32_t, double>& filed_selectivity);
+    void show_cost(std::map<std::string, std::string>* cost_info, std::map<int32_t, double>& filed_selectivity);
 
     void insert_no_cut_condition(const std::map<ExprNode*, std::unordered_set<int32_t>>& expr_field_map) {
         for (auto& pair : expr_field_map) {

--- a/include/exec/commit_manager_node.h
+++ b/include/exec/commit_manager_node.h
@@ -54,6 +54,9 @@ public:
             new_begin_node = _children[3];
         }
         client_conn->seq_id++;
+        if (client_conn->open_binlog) {
+            state->set_open_binlog(true);
+        }
         ret = exec_prepared_node(state, prepare_node, client_conn->seq_id);
         if (ret < 0) {
             DB_WARNING("TransactionNote: prepare failed, rollback txn_id: %lu log_id:%lu", state->txn_id, state->log_id());
@@ -69,6 +72,9 @@ public:
         if (state->optimize_1pc() == false) {
             client_conn->seq_id++;
             ret = exec_commit_node(state, commit_node);
+            if (ret < 0) {
+                ret = exec_rollback_node(state, rollback_node);
+            }
         } else {
             DB_WARNING("TransactionNote: optimize_1pc, no commit: txn_id: %lu log_id:%lu", state->txn_id, state->log_id());
         }

--- a/include/exec/packet_node.h
+++ b/include/exec/packet_node.h
@@ -63,6 +63,7 @@ private:
     int open_trace(RuntimeState* state);
     int handle_trace(RuntimeState* state);
     int handle_trace2(RuntimeState* state);
+    int handle_show_cost(RuntimeState* state);
     void pack_trace2(std::vector<std::map<std::string, std::string>>& info, const pb::TraceNode& trace_node,
         int64_t& total_scan_rows, int64_t& total_index_filter, int64_t& total_get_primary, int64_t& total_where_filter);
     int handle_explain(RuntimeState* state);

--- a/include/exec/rocksdb_scan_node.h
+++ b/include/exec/rocksdb_scan_node.h
@@ -78,6 +78,18 @@ public:
     const std::vector<int64_t>& index_ids() {
         return _index_ids;
     }
+
+    int32_t get_partition_field() {
+        return _table_info->partition_info.partition_field();
+    }
+
+    int64_t get_partition_num() {
+        return _table_info->partition_num;
+    }
+
+    std::vector<int64_t>& get_partition() {
+        return _partitions;
+    }
 private:
     int get_next_by_table_get(RuntimeState* state, RowBatch* batch, bool* eos);
     int get_next_by_table_seek(RuntimeState* state, RowBatch* batch, bool* eos);
@@ -153,6 +165,7 @@ private:
     std::map<int64_t, pb::PossibleIndex> _region_primary;
     std::map<int32_t, int32_t> _index_slot_field_map;
     pb::StorageType _storage_type = pb::ST_UNKNOWN;
+    std::vector<int64_t> _partitions {0};
 };
 }
 

--- a/include/exec/transaction_manager_node.h
+++ b/include/exec/transaction_manager_node.h
@@ -26,13 +26,6 @@ public:
     }
     virtual ~TransactionManagerNode() {
     }
-    static int add_commit_log_entry(
-            uint64_t txn_id, 
-            int32_t  seq_id,
-            ExecNode* commit_fetch,
-            std::map<int64_t, pb::RegionInfo>& region_infos);
-
-    static int remove_commit_log_entry(uint64_t txn_id);
     void set_op_type(pb::OpType op_type) {
         _op_type = op_type;
     }

--- a/include/exec/update_manager_node.h
+++ b/include/exec/update_manager_node.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #include "dml_manager_node.h"
+#include "binlog_context.h"
+
 namespace baikaldb {
 class UpdateNode;
 
@@ -65,6 +67,8 @@ private:
     std::vector<int64_t>     _local_affected_index_ids;
     SmartTable               _table_info;
     bool _affect_global_index = false;
+    pb::TableMutation     _update_binlog;
+    SmartRecord _partition_record;
 };
 }
 /* vim: set ts=4 sw=4 sts=4 tw=100 */

--- a/include/expr/expr_node.h
+++ b/include/expr/expr_node.h
@@ -225,8 +225,9 @@ protected:
     // 过滤条件对应的index_id值，用于过滤条件剪枝使用
     std::unordered_set<int64_t> _index_ids;
     
-private:
+public:
     static int create_expr_node(const pb::ExprNode& node, ExprNode** expr_node);
+private:
     static int create_tree(const pb::Expr& expr, int* idx, ExprNode* parent, ExprNode** root);
 };
 }

--- a/include/logical_plan/query_context.h
+++ b/include/logical_plan/query_context.h
@@ -183,7 +183,7 @@ public:
     bool                is_full_export = false;
     ExplainType         explain_type = EXPLAIN_NULL;
 
-    uint8_t             mysql_cmd;      // Command number in mysql protocal.
+    uint8_t             mysql_cmd = COM_SLEEP;      // Command number in mysql protocal.
     int                 type;           // Query type. finer than mysql_cmd.
     int32_t             thread_idx;
     int64_t             row_ttl_duration = 0; // used for /*{"duration": xxx}*/ insert ...
@@ -219,6 +219,7 @@ public:
     // tuple_id: slot_id: column_id
     std::map<int64_t, std::map<int32_t, int32_t>>     slot_column_mapping;
     std::map<int64_t, std::shared_ptr<QueryContext>> derived_table_ctx_mapping;
+    bool                open_binlog = false;
 
     // user can scan data in specific region by comments 
     // /*{"region_id":$region_id}*/ preceding a Select statement 

--- a/include/meta_server/auto_incr_state_machine.h
+++ b/include/meta_server/auto_incr_state_machine.h
@@ -37,9 +37,6 @@ public:
     virtual void on_snapshot_save(braft::SnapshotWriter* writer, braft::Closure* done);
 
     virtual int on_snapshot_load(braft::SnapshotReader* reader);
-    bool have_data() {
-        return _have_data;
-    }
 private:
     void save_auto_increment(std::string& max_id_string);
     void save_snapshot(braft::Closure* done, 
@@ -50,7 +47,6 @@ private:
     int parse_json_string(const std::string& json_string);
 
     std::unordered_map<int64_t, uint64_t>               _auto_increment_map;
-    bool _have_data = false;
 };
 
 } //namespace baikaldb

--- a/include/meta_server/common_state_machine.h
+++ b/include/meta_server/common_state_machine.h
@@ -38,6 +38,22 @@ struct MetaServerClosure : public braft::Closure {
     TimeCost time_cost;
 };
 
+struct TsoClosure : public braft::Closure {
+    TsoClosure() : sync_cond(nullptr) {};
+    TsoClosure(BthreadCond* cond) : sync_cond(cond) {};
+    virtual void Run();
+    
+    brpc::Controller* cntl;
+    CommonStateMachine* common_state_machine;
+    google::protobuf::Closure* done;
+    pb::TsoResponse* response;
+    int64_t raft_time_cost;
+    int64_t total_time_cost;
+    TimeCost time_cost;
+    bool is_sync = false;
+    BthreadCond* sync_cond;
+};
+
 struct ApplyraftClosure : public google::protobuf::Closure {
     virtual void Run() {
         cond.decrease_signal();
@@ -69,7 +85,16 @@ public:
                           const pb::RaftControlRequest* request,
                           pb::RaftControlResponse* response,
                           google::protobuf::Closure* done) {
-        common_raft_control(controller, request, response, done, &_node);
+        brpc::ClosureGuard done_guard(done);
+        if (!is_leader() && !request->force()) {
+            DB_WARNING("node is not leader when raft control, region_id: %ld", request->region_id());
+            response->set_errcode(pb::NOT_LEADER);
+            response->set_region_id(request->region_id());
+            response->set_leader(butil::endpoint2str(_node.leader_id().addr).c_str());
+            response->set_errmsg("not leader");
+            return;
+        }
+        common_raft_control(controller, request, response, done_guard.release(), &_node);
     }
     virtual void process(google::protobuf::RpcController* controller,
                  const pb::MetaManagerRequest* request,
@@ -110,20 +135,27 @@ public:
         _node.join();
         DB_WARNING("raft node join completely");
     }
+    void start_check_bns();
     virtual bool is_leader() const {
         return _is_leader;
+    }
+    bool have_data() {
+        return _have_data;
+    }
+    void set_have_data(bool flag) {
+         _have_data = flag;
     }
 private:
     virtual int send_set_peer_request(bool remove_peer, const std::string& change_peer);
 protected:
     braft::Node          _node;
     std::atomic<bool>   _is_leader;
-private:
     int64_t             _dummy_region_id;
     std::string         _file_path;
-
+private:
     Bthread             _check_migrate;
     bool                _check_start = false;
+    bool                _have_data = false;
 };
 
 } //namespace baikaldb

--- a/include/meta_server/meta_server.h
+++ b/include/meta_server/meta_server.h
@@ -26,6 +26,7 @@
 namespace baikaldb {
 class MetaStateMachine;
 class AutoIncrStateMachine;
+class TSOStateMachine;
 class MetaServer : public pb::MetaService {
 public:
     static const std::string CLUSTER_IDENTIFY;
@@ -91,7 +92,12 @@ public:
     virtual void console_heartbeat(google::protobuf::RpcController* controller,
                                   const pb::ConsoleHeartBeatRequest* request,
                                   pb::ConsoleHeartBeatResponse* response,
-                                  google::protobuf::Closure* done); 
+                                  google::protobuf::Closure* done);
+
+    virtual void tso_service(google::protobuf::RpcController* controller,
+                                  const pb::TsoRequest* request,
+                                  pb::TsoResponse* response,
+                                  google::protobuf::Closure* done);
 
     virtual void migrate(google::protobuf::RpcController* controller,
             const pb::MigrateRequest* /*request*/,
@@ -119,6 +125,7 @@ private:
     
     MetaStateMachine* _meta_state_machine = NULL;
     AutoIncrStateMachine* _auto_incr_state_machine = NULL;
+    TSOStateMachine*      _tso_state_machine = NULL;
     std::map<std::string, MetaServerInteract*> _meta_interact_map;
     Bthread _flush_bth;
     //region区间修改等信息应用raft

--- a/include/meta_server/meta_state_machine.h
+++ b/include/meta_server/meta_state_machine.h
@@ -111,9 +111,6 @@ public:
     bool get_unsafe_decision() {
         return _unsafe_decision;
     }
-    bool have_data() {
-        return _have_data;
-    }
 private:
     void save_snapshot(braft::Closure* done,
                         rocksdb::Iterator* iter,
@@ -131,7 +128,6 @@ private:
     std::map<std::string, bool> _resource_migrate;
 
     bool _unsafe_decision = false;
-    bool _have_data = false;
     int64_t _applied_index = 0;
 };
 

--- a/include/meta_server/region_manager.h
+++ b/include/meta_server/region_manager.h
@@ -63,7 +63,7 @@ public:
     void pre_process_add_peer_for_store(const std::string& instance, pb::Status status,
             std::unordered_map<std::string, std::vector<pb::AddPeer>>& add_peer_requests);
     bool add_region_is_exist(int64_t table_id, const std::string& start_key, 
-                                            const std::string& end_key);
+                                            const std::string& end_key, int64_t partition_id);
     void check_update_region(const pb::BaikalHeartBeatRequest* request,
                 pb::BaikalHeartBeatResponse* response);
     void add_region_info(const std::vector<int64_t>& new_add_region_ids, 

--- a/include/meta_server/tso_state_machine.h
+++ b/include/meta_server/tso_state_machine.h
@@ -1,0 +1,98 @@
+// Copyright (c) 2018-present Baidu, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "common_state_machine.h"
+
+#ifdef BAIDU_INTERNAL
+#include <raft/repeated_timer_task.h>
+#else
+#include <braft/repeated_timer_task.h>
+#endif
+#include <time.h>
+
+namespace baikaldb {
+
+class TSOStateMachine;
+class TsoTimer : public braft::RepeatedTimerTask {
+public:
+    TsoTimer() : _node(NULL) {}
+    virtual ~TsoTimer() {}
+    int init(TSOStateMachine* node, int timeout_ms);
+    virtual void run();
+protected:
+    virtual void on_destroy() {}
+    TSOStateMachine* _node;
+};
+
+struct TsoObj {
+    pb::TsoTimestamp current_timestamp;
+    int64_t last_save_physical;
+};
+
+class TSOStateMachine : public baikaldb::CommonStateMachine {
+public:
+    TSOStateMachine(const braft::PeerId& peerId):
+                CommonStateMachine(2, "tso_raft", "/tso", peerId) {
+        bthread_mutex_init(&_tso_mutex, nullptr);
+    }
+    
+    virtual ~TSOStateMachine() {
+        _tso_update_timer.stop();
+        _tso_update_timer.destroy();
+        bthread_mutex_destroy(&_tso_mutex);
+    }
+
+    virtual int init(const std::vector<braft::PeerId>& peers);
+
+    // state machine method
+    virtual void on_apply(braft::Iterator& iter);
+    void process(google::protobuf::RpcController* controller,
+                               const pb::TsoRequest* request,
+                               pb::TsoResponse* response,
+                               google::protobuf::Closure* done);
+    
+    void gen_tso(const pb::TsoRequest* request, pb::TsoResponse* response);
+    void reset_tso(const pb::TsoRequest& request, braft::Closure* done);
+    void update_tso(const pb::TsoRequest& request, braft::Closure* done);
+
+    int load_tso(const std::string& tso_file);
+    int sync_timestamp(const pb::TsoTimestamp& current_timestamp, int64_t save_physical);
+    void update_timestamp();
+
+    virtual void on_snapshot_save(braft::SnapshotWriter* writer, braft::Closure* done);
+    void save_snapshot(braft::Closure* done,
+                       braft::SnapshotWriter* writer,
+                       std::string sto_str);
+
+    virtual int on_snapshot_load(braft::SnapshotReader* reader);
+
+    virtual void on_leader_start();
+
+    virtual void on_leader_stop();
+
+    static const  std::string SNAPSHOT_TSO_FILE;;
+    static const  std::string SNAPSHOT_TSO_FILE_WITH_SLASH;
+
+private:
+    TsoTimer  _tso_update_timer;
+    TsoObj    _tso_obj;
+    bthread_mutex_t _tso_mutex;  // 保护_tso_obj，C++20 atomic<std::shared_ptr<U>>
+    bool    _is_healty = true;
+};
+
+} //namespace baikaldb
+
+/* vim: set expandtab ts=4 sw=4 sts=4 tw=100: */

--- a/include/physical_plan/plan_router.h
+++ b/include/physical_plan/plan_router.h
@@ -39,11 +39,18 @@ private:
 
     int scan_node_analyze(RocksdbScanNode* scan_node, 
         QueryContext* ctx, bool has_join);
+    
     int truncate_node_analyze(TruncateNode* trunc_node, QueryContext* ctx);
     int kill_node_analyze(KillNode* kill_node, QueryContext* ctx);
     int transaction_node_analyze(TransactionNode* txn_node, QueryContext* ctx);
     int select_index(pb::ScanNode* scan_node, std::vector<int>& multi_reverse_index);
 };
+
+class PartitionAnalyze {
+public:
+    int analyze(QueryContext* ctx);
+};
+
 }
 
 /* vim: set ts=4 sw=4 sts=4 tw=100 */

--- a/include/physical_plan/separate.h
+++ b/include/physical_plan/separate.h
@@ -79,6 +79,8 @@ private:
 
     TransactionNode* create_txn_node(pb::TxnCmdType cmd_type);
     SelectManagerNode* create_select_manager_node();
+    bool need_separate_single_txn(QueryContext* ctx, const int64_t main_table_id);
+    bool need_separate_plan(QueryContext* ctx, const int64_t main_table_id);
 };
 }
 

--- a/include/protocol/network_server.h
+++ b/include/protocol/network_server.h
@@ -23,6 +23,7 @@
 #include "schema_factory.h"
 #include "common.h"
 #include "meta_server_interact.hpp"
+#include "baikal_heartbeat.h"
 
 namespace baikaldb {
 class NetworkServer {
@@ -51,27 +52,20 @@ public:
     EpollInfo* get_epoll_info() {
         return _epoll_info;
     }
-    
-    static uint8_t transaction_prefix;
 
 private:
     // For instance.
     NetworkServer();
     NetworkServer& operator=(const NetworkServer& other);
-
     bool set_fd_flags(int fd);
     SmartSocket create_listen_socket();
-    int make_worker_process();
-    void construct_heart_beat_request(pb::BaikalHeartBeatRequest& request);
-    void process_heart_beat_response(const pb::BaikalHeartBeatResponse& response);
-    void process_heart_beat_response_sync(const pb::BaikalHeartBeatResponse& response);
     void construct_other_heart_beat_request(pb::BaikalOtherHeartBeatRequest& request);
     void process_other_heart_beat_response(const pb::BaikalOtherHeartBeatResponse& response);
 
     std::string state2str(SmartSocket client);
 
     int fetch_instance_info();
-
+    int make_worker_process();
     void connection_timeout_check();
     void report_heart_beat();
     void report_other_heart_beat();
@@ -82,7 +76,6 @@ private:
     void fill_field_info(int64_t table_id, std::map<int64_t, int>& distinct_field_map, 
         std::string type, std::ostringstream& os);
     void print_agg_sql();
-    void recovery_transactions();
     
 private:
     // Server info.
@@ -92,9 +85,6 @@ private:
     // Socket info.
     SmartSocket     _service = nullptr;  // Server socket.
     EpollInfo*      _epoll_info = nullptr;      // Epoll info and fd mapping.
-    
-    RocksWrapper*   _meta_db = nullptr;
-    rocksdb::ColumnFamilyHandle* _meta_handle = nullptr;
 
     // the last action time for each thread
     std::vector<ThreadTimeStamp> _last_time;
@@ -105,7 +95,5 @@ private:
     Bthread         _agg_sql_bth;
     uint32_t        _driver_thread_num;
     uint64_t        _instance_id = 0;
-
 };
-
 } // namespace baikal

--- a/include/protocol/state_machine.h
+++ b/include/protocol/state_machine.h
@@ -22,6 +22,7 @@
 #include "mysql_wrapper.h"
 #include "logical_planner.h"
 #include "physical_planner.h"
+#include "binlog_context.h"
 
 namespace baikaldb {
 
@@ -47,6 +48,7 @@ const std::string SQL_SHOW_CREATE_TABLE          = "show create table";
 const std::string SQL_SHOW_FULL_COLUMNS          = "show full columns";
 const std::string SQL_SHOW_TABLE_STATUS          = "show table status";
 const std::string SQL_SHOW_ABNORMAL_REGIONS      = "show abnormal regions";
+const std::string SQL_SHOW_COST                  = "show cost";
 const std::string SQL_SHOW_SESSION_VARIABLES     = "show session variables";
 const std::string SQL_SHOW_COLLATION             = "show collation";
 const std::string SQL_SHOW_WARNINGS              = "show warnings";
@@ -130,6 +132,7 @@ private:
     bool _handle_client_query_show_full_columns(SmartSocket client);
     bool _handle_client_query_show_table_status(SmartSocket client);
     bool _handle_client_query_show_abnormal_regions(SmartSocket client);
+    bool _handle_client_query_show_cost(SmartSocket client);
     bool _handle_client_query_show_region(SmartSocket client);
     bool _handle_client_query_show_socket(SmartSocket client);
     bool _handle_client_query_show_processlist(SmartSocket client);

--- a/include/protocol/state_machine.h
+++ b/include/protocol/state_machine.h
@@ -55,6 +55,8 @@ const std::string SQL_SHOW_WARNINGS              = "show warnings";
 const std::string SQL_SHOW_REGION                = "show region";
 const std::string SQL_SHOW_SOCKET                = "show socket";
 const std::string SQL_SHOW_PROCESSLIST           = "show processlist";
+const std::string SQL_SHOW_META                  = "show meta";
+const std::string SQL_SHOW_NAMESPACE             = "show namespace";
 
 enum QUERY_TYPE {
     SQL_UNKNOWN_NUM                         = 0,

--- a/include/runtime/runtime_state.h
+++ b/include/runtime/runtime_state.h
@@ -79,7 +79,7 @@ public:
         const pb::Plan& plan, 
         const RepeatedPtrField<pb::TupleDescriptor>& tuples,
         TransactionPool* pool,
-        bool store_compute_separate);
+        bool store_compute_separate, bool is_binlog_region = false);
 
     // baikaldb init
     int init(QueryContext* ctx, DataBuffer* send_buf);
@@ -290,6 +290,15 @@ public:
     void set_eos() {
         _eos = true;
     }
+
+    bool open_binlog() {
+        return _open_binlog;
+    }
+
+    void set_open_binlog(bool flag) {
+        _open_binlog = flag;
+    }
+
     std::vector<TraceTimeCost>* get_trace_cost() {
         return &_trace_cost_vec;
     } 
@@ -322,6 +331,7 @@ private:
     bool _is_inited    = false;
     bool _is_cancelled = false;
     bool _eos          = false;
+    bool _open_binlog  = false;
     std::vector<pb::TupleDescriptor> _tuple_descs;
     MemRowDescriptor _mem_row_desc;
     int64_t          _region_id = 0;

--- a/include/session/binlog_context.h
+++ b/include/session/binlog_context.h
@@ -1,0 +1,109 @@
+// Copyright (c) 2020-present Baidu, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include "proto/binlog.pb.h"
+#include "table_record.h"
+#include "expr_value.h"
+#include "schema_factory.h"
+#include "meta_server_interact.hpp"
+
+#ifdef BAIDU_INTERNAL
+#include <base/endpoint.h>
+#include <baidu/rpc/channel.h>
+#include <baidu/rpc/server.h>
+#include <baidu/rpc/controller.h>
+#else
+#include <butil/endpoint.h>
+#include <brpc/channel.h>
+#include <brpc/server.h>
+#include <brpc/controller.h>
+#endif
+
+#include <memory>
+
+namespace baikaldb {
+
+DECLARE_string(meta_server_bns);
+class TsoFetcher {
+public:
+    static MetaServerInteract tso_meta_inter;
+
+    static int init_meta_inter() {
+        return tso_meta_inter.init_internal(FLAGS_meta_server_bns);
+    }
+
+    static int64_t get_tso();
+};
+
+class BinlogContext {
+public:
+    BinlogContext() {
+        _factory = SchemaFactory::get_instance();
+    };
+    ~BinlogContext() { };
+
+    int get_binlog_regions(uint64_t log_id);
+
+    pb::PrewriteValue* mutable_binlog_value() {
+        return &_binlog_value;
+    }
+    const pb::PrewriteValue& binlog_value() const {
+        return _binlog_value;
+    }
+
+    int64_t start_ts() const {
+        return _start_ts;
+    }
+
+    void set_start_ts(int64_t start_ts) {
+        _start_ts = start_ts;
+    }
+
+    int64_t commit_ts() const {
+        return _commit_ts;
+    }
+
+    void set_commit_ts(int64_t commit_ts) {
+        _commit_ts = commit_ts;
+    }
+    
+    pb::RegionInfo& binglog_region() {
+        return _binlog_region;
+    }
+
+    ExprValue& partition_key() {
+        return _partition_key;
+    }
+
+    void set_partition_record(SmartRecord partition_record) {
+        _partition_record = partition_record;
+    }
+
+    void set_table_info(SmartTable table_info) {
+        _table_info = table_info;
+    }
+
+private:
+    SmartTable            _table_info = nullptr;
+    int64_t               _start_ts = -1;
+    int64_t               _commit_ts = -1;
+    pb::PrewriteValue     _binlog_value;
+    SmartRecord           _partition_record;
+    ExprValue             _partition_key;
+    pb::RegionInfo        _binlog_region;
+    SchemaFactory*        _factory = nullptr;
+};
+
+} // namespace baikaldb

--- a/include/session/network_socket.h
+++ b/include/session/network_socket.h
@@ -34,9 +34,11 @@ const uint32_t SELF_BUF_DEFAULT_SIZE        = 4096;
 
 class NetworkSocket;
 class QueryContext;
+class BinlogContext;
 class DataBuffer;
 class ExecNode;
 typedef std::shared_ptr<NetworkSocket> SmartSocket;
+typedef std::shared_ptr<BinlogContext> SmartBinlogContext;
 
 enum SocketType {
     SERVER_SOCKET = 0,
@@ -71,8 +73,9 @@ struct NetworkSocket {
     void on_commit_rollback();
     void update_old_txn_info();
     bool transaction_has_write();
+    bool need_send_binlog();
     uint64_t get_global_conn_id();
-
+    SmartBinlogContext get_binlog_ctx();
     // Socket basic infomation.
     bool                shutdown;
     int                 fd;           // Socket fd.
@@ -113,12 +116,13 @@ struct NetworkSocket {
     std::string     username;
     std::shared_ptr<UserInfo>       user_info;      // userinfo for current connection
     std::shared_ptr<QueryContext>   query_ctx;      // Current query.
+    SmartBinlogContext              binlog_ctx;     // for binlog
+    bool                            open_binlog = false;
 
     int64_t         conn_id = -1;            // The client connection ID in Mysql Client-Server Protocol
 
     // Transaction related members
     int64_t         primary_region_id = -1;  // used for txn like Percolator
-    bool            primary_region_exec_failed = false;
     bool            autocommit = true;       // The autocommit flag set by SET AUTOCOMMIT=0/1
     uint64_t        txn_id = 0;              // ID of the current transaction, 0 means out-transaction query
     uint64_t        new_txn_id = 0;          // For implicit commit commands (i.e. BEGIN after another BEGIN)

--- a/include/sqlparser/ddl.h
+++ b/include/sqlparser/ddl.h
@@ -119,7 +119,8 @@ enum TableOptionType : unsigned char {
     TABLE_OPT_ROW_FORMAT,
     TABLE_OPT_STATS_PERSISTENT,
     TABLE_OPT_SHARD_ROW_ID,
-    TABLE_OPT_PACK_KEYS
+    TABLE_OPT_PACK_KEYS,
+    TABLE_OPT_PARTITION
 };
 
 enum DatabaseOptionType : unsigned char {
@@ -142,6 +143,12 @@ enum AlterSpecType : unsigned char {
     ALTER_SPEC_RENAME_TABLE,
     ALTER_SPEC_TABLE_OPTION
 };
+
+enum PartitionType : unsigned char {
+    PARTITION_HASH = 0,
+    PARTITION_RANGE
+};
+
 
 struct TypeOption : public Node {
     bool is_unsigned = false;
@@ -222,6 +229,12 @@ struct TableOption : public Node {
     TableOption() {
         node_type = NT_TABLE_OPT;
     }
+};
+
+struct PartitionOption : public TableOption {
+    PartitionType type;
+    ExprNode* expr = nullptr;
+    Vector<ExprNode*> range;
 };
 
 struct Constraint : public Node {

--- a/include/sqlparser/gen_source.sh
+++ b/include/sqlparser/gen_source.sh
@@ -1,2 +1,19 @@
 #!/bin/bash
-cd include/sqlparser && /opt/compiler/gcc-4.8.2/bin/flex sql_lex.l && /opt/compiler/gcc-4.8.2/bin/bison sql_parse.y
+
+prefix='/opt/compiler/gcc-4.8.2/bin/'
+
+cur_dir='.'
+if [ $2 == "opensource" ]; then
+  prefix=''
+  cur_dir=$1
+fi
+
+echo "prefix: ${prefix}"
+echo "output: ${out_dir}"
+
+cd ${cur_dir}/include/sqlparser && ${prefix}flex sql_lex.l && ${prefix}bison sql_parse.y
+
+dest_dir=$3
+if [ ! -z "${dest_dir}" ]; then
+  mv *.flex.* ${dest_dir}/ && mv *.yacc.* ${dest_dir}/
+fi 

--- a/include/store/region_control.h
+++ b/include/store/region_control.h
@@ -30,7 +30,7 @@ public:
     static int remove_meta(int64_t drop_region_id);
     static int remove_snapshot_path(int64_t drop_region_id);
     static int clear_all_infos_for_region(int64_t drop_region_id);
-    static int ingest_data_sst(const std::string& data_sst_file, int64_t region_id);
+    static int ingest_data_sst(const std::string& data_sst_file, int64_t region_id, bool move_files);
     static int ingest_meta_sst(const std::string& meta_sst_file, int64_t region_id);
 
     RegionControl(Region* region, int64_t region_id): _region(region), _region_id(region_id) {}

--- a/proto/binlog.proto
+++ b/proto/binlog.proto
@@ -1,0 +1,39 @@
+syntax="proto2";
+package baikaldb.pb;
+
+enum BinlogType {
+    PREWRITE  = 0;
+    COMMIT    = 1;
+    ROLLBACK  = 2;
+    DDL       = 3;
+    FAKE      = 4;
+}
+  
+message Binlog {
+    optional BinlogType       type           = 1;
+    optional int64            start_ts       = 2;
+    optional int64            commit_ts      = 3;
+    optional bytes            prewrite_key   = 4;
+    optional PrewriteValue    prewrite_value = 5;
+    optional bytes            ddl_query      = 6;
+    optional bytes            stmts          = 7;
+}
+
+message PrewriteValue {
+    optional int64 schema_version    = 1;
+    repeated TableMutation mutations = 2;
+}
+ 
+enum MutationType {
+    INSERT = 0;
+    UPDATE = 1;
+    DELETE = 2;
+}
+ 
+message TableMutation {
+    optional int64 table_id        = 1;
+    repeated bytes insert_rows     = 2;
+    repeated bytes update_rows     = 3;
+    repeated bytes deleted_rows    = 4;
+    repeated MutationType sequence = 5;
+}

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -32,6 +32,9 @@ enum ErrCode {
     TXN_IS_ROLLBACK     = 25;
     BACKUP_SAME_LOG_INDEX = 26;
     BACKUP_ERROR = 27;
+    RETRY_LATER  = 28;
+    LESS_THAN_OLDEST_TS  = 29;
+    IN_PROCESS   = 30;
 };
 
 enum PrimitiveType {
@@ -76,6 +79,7 @@ enum Engine {
     ROCKSDB = 1;
     REDIS = 2;
     ROCKSDB_CSTORE = 3;
+    BINLOG = 4;
 };
 
 message SlotDescriptor {

--- a/proto/console.proto
+++ b/proto/console.proto
@@ -256,5 +256,6 @@ message ShowxResponse {
 service ConsoleService {
     rpc watch(ConsoleRequest) returns (ConsoleResponse);
     rpc showx(ShowxRequest) returns (ShowxResponse);
+    rpc sql_alarm(ShowxRequest) returns (ShowxResponse);
 };
 

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -67,5 +67,7 @@ message Expr {
     repeated ExprNode nodes = 1;
     // 过滤条件对应的index_id值，用于过滤条件剪枝使用
     repeated int64 index_ids = 2;
+    optional string database = 3;
+    optional string table = 4;
 };
 

--- a/proto/meta.interface.proto
+++ b/proto/meta.interface.proto
@@ -3,6 +3,7 @@ import "common.proto";
 import "optype.proto";
 import "raft.proto";
 import "statistics.proto";
+import "expr.proto";
 package baikaldb.pb;
 option cc_generic_services = true;
 //option cc_enable_arenas = true;
@@ -46,7 +47,12 @@ enum IndexState {
     IS_DELETE_LOCAL    = 5;
     IS_NONE            = 6;
     IS_UNKNOWN         = 7;  //用于状态流转，不会作为schema状态
-}
+};
+
+enum IndexHintStatus {
+    IHS_NORMAL = 1;
+    IHS_DISABLE = 2;
+};
 
 enum Charset {
     UTF8 = 0;
@@ -62,6 +68,23 @@ message ReplicaDist {
 message SplitKey {
     optional bytes index_name               = 1;
     repeated bytes split_keys               = 2;
+};
+
+message BinlogInfo {
+    repeated int64 target_table_ids = 1;
+    optional int64 binlog_table_id = 2;
+};
+
+enum PartitionType {
+    PT_HASH = 1;
+    PT_RANGE = 2;
+};
+message PartitionInfo {
+    required PartitionType type = 1;
+    optional FieldInfo field_info = 2;
+    optional int32 partition_field = 3;
+    optional Expr range_partition_field = 4;
+    repeated Expr range_partition_values = 5;
 };
 
 message SchemaInfo {
@@ -103,6 +126,11 @@ message SchemaInfo {
     repeated SplitKey split_keys            = 36;
     optional SchemaConf schema_conf         = 37; //一些可以随意修改的配置放在这里
     optional int64 ttl_duration             = 38; //0表示无ttl，>0表示有ttl，建表时指定，后续不能修改
+    optional BinlogInfo    binlog_info = 39;
+    optional PartitionInfo partition_info = 40;
+    optional bool is_binlog = 41;
+    optional FieldInfo link_field = 42;
+    optional int32 region_num = 43;
 };
 
 message PartitionRegion {
@@ -167,6 +195,7 @@ message IndexInfo {
     optional SegmentType segment_type   = 8; //FULLTEXT use for segment
     optional IndexState state           = 9;
     optional StorageType storage_type   = 10;
+    optional IndexHintStatus hint_status = 11;
 };
 
 //address format: ip:port
@@ -191,6 +220,8 @@ message RegionInfo {
     optional uint32 timestamp              = 18; //region创建时间
     optional int64 num_table_lines         = 19; //region包含的主表行数
     optional int64 main_table_id           = 20; //如果是全局二级索引的region保存主表的table_id
+    optional bool is_binlog_region         = 21; //是否为binlog region
+    optional int64 partition_num           = 22;
 };
 
 message StoreRegionDdlInfo {
@@ -280,6 +311,7 @@ message RegionMergeRequest {
     required bytes src_start_key    = 2;
     required bytes src_end_key      = 3;
     required int64 table_id         = 4;
+    optional int64 partition_id = 5;
 };
 
 message RegionMergeResponse {
@@ -358,6 +390,7 @@ message MetaManagerRequest {
     optional DdlWorkInfo ddlwork_info                   = 20; //更新ddl work
     optional bool                add_delete_region      = 21; //添加被删除的region
     optional Statistics          statistics             = 22;
+    optional SchemaInfo binlog_info = 23;  //关联binlog表及普通表
 };
 
 message MetaManagerResponse {
@@ -775,6 +808,30 @@ message ConsoleHeartBeatResponse {
     repeated TableInfo          table_change_infos   = 7;
 };
 
+message TsoTimestamp {
+    optional int64    physical = 1;
+    optional int64    logical  = 2;
+}
+
+message TsoRequest {
+    required OpType        op_type           = 1;
+    optional int64         count             = 2;
+    optional TsoTimestamp  current_timestamp = 3;
+    optional int64         save_physical     = 4;
+    optional bool          force             = 5;
+};
+
+message TsoResponse {
+    required OpType          op_type           = 1;
+    optional ErrCode         errcode           = 2;
+    optional TsoTimestamp    start_timestamp   = 3;
+    optional int64           count             = 4;    
+    optional string          errmsg            = 5;
+    optional int64           save_physical     = 6;
+    optional int64           system_time       = 7;
+    optional string          leader            = 8;
+};
+
 service MetaService {
     //meta_server raft的控制接口
     rpc raft_control(RaftControlRequest) returns (RaftControlResponse);
@@ -784,6 +841,7 @@ service MetaService {
     rpc query(QueryRequest) returns (QueryResponse);
     rpc migrate(MigrateRequest) returns (MigrateResponse);
     rpc console_heartbeat(ConsoleHeartBeatRequest) returns (ConsoleHeartBeatResponse);
+    rpc tso_service(TsoRequest) returns (TsoResponse);
     rpc baikal_other_heartbeat(BaikalOtherHeartBeatRequest) returns (BaikalOtherHeartBeatResponse);
 };
 

--- a/proto/optype.proto
+++ b/proto/optype.proto
@@ -35,6 +35,14 @@ enum OpType {
     OP_TXN_COMPLETE                         = 26; // 手动完成特定事务处理
     // fake op
     OP_UNION                                = 51;
+    
+    // for binlog
+    OP_READ_BINLOG                          = 60; //read     binlog
+    OP_PREWRITE_BINLOG                      = 61; //prewrite binlog
+    OP_COMMIT_BINLOG                        = 62; //commit   binlog
+    OP_ROLLBACK_BINLOG                      = 63; //rollback binlog
+    OP_FAKE_BINLOG                          = 64; //fake     binlog
+
     // for meta 
     OP_ADD_LOGICAL                          = 114; //建逻辑机房
     OP_ADD_PHYSICAL                         = 115; //建物理机房
@@ -73,7 +81,7 @@ enum OpType {
     OP_RESTORE_REGION                       = 148; //恢复store误删的region
     OP_OPEN_UNSAFE_DECISION                 = 149; //开启删表和log_index=0时自动删除region逻辑10分钟
     OP_SET_INSTANCE_MIGRATE                 = 150; //手工置实例状态为MIGRATE，迁移用
-    OP_PREPARE_V2                           = 151; 
+    OP_PREPARE_V2                           = 151; // deprecated
     OP_ADD_ID_FOR_AUTO_INCREMENT            = 152; //添加自增主键
     OP_DROP_ID_FOR_AUTO_INCREMENT           = 153; //删除自增主键
     OP_CLOSE_LOAD_BALANCE                   = 154;
@@ -95,4 +103,11 @@ enum OpType {
     OP_DROP_TABLE_TOMBSTONE                 = 170; //清理TABLE的残留墓碑
     OP_RECOVERY_ALL_REGION                  = 171; //恢复region状态
     OP_UPDATE_STATISTICS                    = 172; //update statistics
+    OP_GEN_TSO                              = 173; // 获取时间戳
+    OP_RESET_TSO                            = 174; // 重置时间戳
+    OP_UPDATE_TSO                           = 175; // 更新时间戳
+    OP_QUERY_TSO_INFO                       = 176; 
+    OP_LINK_BINLOG                          = 177; //创建binlog关联
+    OP_UNLINK_BINLOG                        = 178; //清除binlog关联
+    OP_SET_INDEX_HINT_STATUS                 = 179; //设置索引提示状态
 };

--- a/proto/store.interface.proto
+++ b/proto/store.interface.proto
@@ -6,6 +6,7 @@ import "plan.proto";
 import "optype.proto";
 import "statistics.proto";
 import "meta.interface.proto";
+import "binlog.proto";
 option cc_generic_services = true;
 //option cc_enable_arenas = true;
 
@@ -43,6 +44,10 @@ message TransactionInfo {
     optional int64   primary_region_id = 9;
     optional TxnState txn_state        = 10;
     optional int64   live_time         = 11;
+    optional int64   start_ts     = 12;
+    optional int64   commit_ts    = 13;  //事务commit的tso，用于恢复超时的prewrite binlog
+    optional bool    open_binlog  = 14;
+    optional bool    from_store        = 15;
 };
 
 message KvOp {
@@ -57,6 +62,18 @@ message AnalyzeInfo {
     required int32     width   = 2;
     required int32     sample_rows = 3;
     required int64     table_rows  = 4;     
+};
+
+//prewrite binlog需要填写binlog_ts、txn_id、primary_region_id、partion_key
+//commit/rollback binlog 只填binlog_ts、txn_id、start_ts
+//read binlog只填binlog_ts、read_binlog_cnt
+message BinlogDesc {
+    required int64     binlog_ts         = 1;
+    optional int64     txn_id            = 2;
+    optional int64     start_ts          = 3;
+    optional int64     primary_region_id = 4;
+    optional int64     partion_key       = 5;
+    optional int64     read_binlog_cnt   = 6;
 };
 
 message StoreReq {
@@ -85,6 +102,8 @@ message StoreReq {
     optional AnalyzeInfo   analyze_info = 23;
     repeated uint64    rollback_txn_ids = 24;
     repeated uint64    commit_txn_ids   = 25;
+    optional BinlogDesc binlog_desc     = 26;
+    optional Binlog      binlog         = 27;
 };
 
 message RowValue {
@@ -119,7 +138,9 @@ message StoreRes {
     repeated IndexRecords  records        = 15;
     optional int64  scan_rows     = 16;
     optional CMsketch cmsketch    = 17;
-    optional int64  filter_rows     = 18;
+    optional int64  filter_rows   = 18;
+    repeated bytes binlogs       = 19; //直接存储binlog序列化结果，由capture反序列化
+    repeated int64 commit_ts     = 20; //与上面的binlog一一对应
 };
 message InitRegion {
     required RegionInfo region_info     = 1;
@@ -180,6 +201,9 @@ service StoreService {
     
     //增删改查功能，需要走raft状态机的都通过此接口
     rpc query(StoreReq) returns (StoreRes);
+
+    //binlog相关操作
+    rpc query_binlog(StoreReq) returns (StoreRes);
     
     //删除region，包括数据
     rpc remove_region(RemoveRegion) returns (StoreRes);

--- a/src/common/baikal_heartbeat.cpp
+++ b/src/common/baikal_heartbeat.cpp
@@ -241,7 +241,7 @@ bool BinlogNetworkServer::process_heart_beat_response_sync(const pb::BaikalHeart
             DB_NOTICE("skip region info table_id %lld", region_info.table_id());
             continue;
         }
-        auto region_info_move = region_info;
+        *rv.Add() = region_info;
     }
     factory->update_regions(rv);
     factory->update_show_db(response.db_info());

--- a/src/common/baikal_heartbeat.cpp
+++ b/src/common/baikal_heartbeat.cpp
@@ -1,0 +1,259 @@
+// Copyright (c) 2018-present Baidu, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "baikal_heartbeat.h"
+namespace baikaldb {
+
+void BaikalHeartBeat::construct_heart_beat_request(pb::BaikalHeartBeatRequest& request) {
+    SchemaFactory* factory = SchemaFactory::get_instance();
+    auto schema_read_recallback = [&request, factory](const SchemaMapping& schema){
+        auto& table_statistics_mapping = schema.table_statistics_mapping;
+        for (auto& info_pair : schema.table_info_mapping) {
+            if (info_pair.second->engine != pb::ROCKSDB &&
+                    info_pair.second->engine != pb::ROCKSDB_CSTORE && 
+                    info_pair.second->engine != pb::BINLOG) {
+                continue;
+            }
+            //主键索引和全局二级索引都需要传递region信息
+            for (auto& index_id : info_pair.second->indices) {
+                auto& index_info_mapping = schema.index_info_mapping;
+                if (index_info_mapping.count(index_id) == 0) {
+                    continue;
+                }
+                IndexInfo index = *index_info_mapping.at(index_id);
+                //主键索引
+                if (index.type != pb::I_PRIMARY && !index.is_global) {
+                    continue;
+                }
+                auto req_info = request.add_schema_infos();
+                req_info->set_table_id(index_id);
+                req_info->set_version(1);
+                int64_t version = 0;
+                auto iter = table_statistics_mapping.find(index_id);
+                if (iter != table_statistics_mapping.end()) {
+                    version = iter->second->version();
+                }
+                req_info->set_statis_version(version);
+
+                if (index_id == info_pair.second->id) {
+                    req_info->set_version(info_pair.second->version);
+                }
+                /*
+                std::map<int64_t, pb::RegionInfo> region_infos;
+                //
+                // TODO：读多个double buffer，可能死锁？
+                //
+                factory->get_region_by_key(index, NULL, region_infos);
+                for (auto& pair : region_infos) {
+                    auto region = req_info->add_regions();
+                    auto& region_info = pair.second;
+                    region->set_region_id(region_info.region_id());
+                    region->set_version(region_info.version());
+                    region->set_conf_version(region_info.conf_version());
+                }*/
+            }
+        }
+    };
+    request.set_last_updated_index(factory->last_updated_index());
+    factory->schema_info_scope_read(schema_read_recallback);
+    
+}
+
+void BaikalHeartBeat::process_heart_beat_response(const pb::BaikalHeartBeatResponse& response) {
+    SchemaFactory* factory = SchemaFactory::get_instance();
+    for (auto& info : response.schema_change_info()) {
+        factory->update_table(info);
+    }
+    factory->update_regions(response.region_change_info());
+    if (response.has_idc_info()) {
+        factory->update_idc(response.idc_info());
+    }
+    for (auto& info : response.privilege_change_info()) {
+        factory->update_user(info);
+    }
+    factory->update_show_db(response.db_info());
+    if (response.statistics().size() > 0) {
+        factory->update_statistics(response.statistics());
+    }
+    if (response.has_last_updated_index() && 
+        response.last_updated_index() > factory->last_updated_index()) {
+        factory->set_last_updated_index(response.last_updated_index());
+    }
+}
+
+void BaikalHeartBeat::process_heart_beat_response_sync(const pb::BaikalHeartBeatResponse& response) {
+    TimeCost cost;
+    SchemaFactory* factory = SchemaFactory::get_instance();
+    factory->update_tables_double_buffer_sync(response.schema_change_info());
+
+    if (response.has_idc_info()) {
+        factory->update_idc(response.idc_info());
+    }
+    for (auto& info : response.privilege_change_info()) {
+        factory->update_user(info);
+    }
+    factory->update_show_db(response.db_info());
+    if (response.statistics().size() > 0) {
+        factory->update_statistics(response.statistics());
+    }
+
+    factory->update_regions_double_buffer_sync(response.region_change_info());
+    if (response.has_last_updated_index() && 
+        response.last_updated_index() > factory->last_updated_index()) {
+        factory->set_last_updated_index(response.last_updated_index());
+    }
+    DB_NOTICE("sync time:%ld", cost.get_time());
+}
+
+//binlog network
+bool BinlogNetworkServer::init() {
+    // init val 
+    TimeCost cost;
+    // 先把meta数据都获取到
+    pb::BaikalHeartBeatRequest request;
+    pb::BaikalHeartBeatResponse response;
+    //1、构造心跳请求
+   BaikalHeartBeat::construct_heart_beat_request(request);
+    //2、发送请求
+    if (MetaServerInteract::get_instance()->send_request("baikal_heartbeat", request, response) == 0) {
+        //处理心跳
+        return process_heart_beat_response_sync(response);
+        //DB_WARNING("req:%s  \nres:%s", request.DebugString().c_str(), response.DebugString().c_str());
+    } else {
+        DB_FATAL("send heart beat request to meta server fail");
+        return false;
+    }
+
+    return true;
+}
+
+void BinlogNetworkServer::report_heart_beat() {
+    while (!_shutdown) {
+        TimeCost cost;
+        pb::BaikalHeartBeatRequest request;
+        pb::BaikalHeartBeatResponse response;
+        //1、construct heartbeat request
+        BaikalHeartBeat::construct_heart_beat_request(request);
+        int64_t construct_req_cost = cost.get_time();
+        cost.reset();
+        //2、send heartbeat request to meta server
+        if (MetaServerInteract::get_instance()->send_request("baikal_heartbeat", request, response) == 0) {
+            //处理心跳
+            process_heart_beat_response(response);
+            DB_WARNING("report_heart_beat, construct_req_cost:%ld, process_res_cost:%ld",
+                    construct_req_cost, cost.get_time());
+        } else {
+            DB_WARNING("send heart beat request to meta server fail");
+        }
+        bthread_usleep_fast_shutdown(1000 * 1000 * 10, _shutdown);
+    }
+}
+
+void BinlogNetworkServer::process_heart_beat_response(const pb::BaikalHeartBeatResponse& response) {
+    DB_DEBUG("response %s", response.ShortDebugString().c_str());
+    SchemaFactory* factory = SchemaFactory::get_instance();
+    
+    for (auto& info : response.schema_change_info()) {
+        factory->update_table(info);
+    }
+    RegionVec rv;
+    auto& region_change_info = response.region_change_info();
+    for (auto& region_info : region_change_info) {
+        if (_binlog_id != region_info.table_id()) {
+            DB_WARNING("skip region info table_id %lld", region_info.table_id());
+            continue;
+        }
+        *rv.Add() = region_info;
+    }
+    factory->update_regions(rv);
+    if (response.has_idc_info()) {
+        factory->update_idc(response.idc_info());
+    }
+    for (auto& info : response.privilege_change_info()) {
+        factory->update_user(info);
+    }
+    factory->update_show_db(response.db_info());
+    if (response.statistics().size() > 0) {
+        factory->update_statistics(response.statistics());
+    }
+    if (response.has_last_updated_index() && 
+        response.last_updated_index() > factory->last_updated_index()) {
+        factory->set_last_updated_index(response.last_updated_index());
+    }
+}
+
+bool BinlogNetworkServer::process_heart_beat_response_sync(const pb::BaikalHeartBeatResponse& response) {
+    DB_DEBUG("response %s", response.ShortDebugString().c_str());
+    TimeCost cost;
+    SchemaFactory* factory = SchemaFactory::get_instance();
+    SchemaVec sv;
+    std::vector<int64_t> tmp_tids;
+    tmp_tids.reserve(10);
+    factory->update_tables_double_buffer_sync(response.schema_change_info());
+
+    for (const auto& table_name : _table_names) {
+        int64_t tid;
+        if (factory->get_table_id(table_name, tid) != 0) {
+            DB_FATAL("get table[%s] id error", table_name.c_str());
+        }
+        DB_NOTICE("get table_name[%s] table_id[%ld]", table_name.c_str(), tid);
+        _binlog_table_ids.insert(tid);
+    }
+    //获取binlog table_id
+    int64_t binlog_id = 0;
+    for (auto tid : _binlog_table_ids) {
+        if (factory->get_binlog_id(tid, binlog_id) != 0) {
+            DB_FATAL("config binlog error. %lld", tid);
+            return false;
+        }
+        DB_NOTICE("insert binlog table id %ld", binlog_id);
+        if (_binlog_id != -1) {
+            if (binlog_id != _binlog_id) {
+                DB_FATAL("tables has different binlog id");
+                return false;
+            }
+        } else {
+            _binlog_id = binlog_id;
+        }
+    }
+
+    if (response.has_idc_info()) {
+        factory->update_idc(response.idc_info());
+    }
+    for (auto& info : response.privilege_change_info()) {
+        factory->update_user(info);
+    }
+    RegionVec rv;
+    auto& region_change_info = response.region_change_info();
+    for (auto& region_info : region_change_info) {
+        if (_binlog_id != region_info.table_id()) {
+            DB_NOTICE("skip region info table_id %lld", region_info.table_id());
+            continue;
+        }
+        auto region_info_move = region_info;
+    }
+    factory->update_regions(rv);
+    factory->update_show_db(response.db_info());
+    if (response.statistics().size() > 0) {
+        factory->update_statistics(response.statistics());
+    }
+
+    if (response.has_last_updated_index() && 
+        response.last_updated_index() > factory->last_updated_index()) {
+        factory->set_last_updated_index(response.last_updated_index());
+    }
+    DB_NOTICE("sync time:%ld", cost.get_time());
+    return true;
+}
+}

--- a/src/engine/table_iterator.cpp
+++ b/src/engine/table_iterator.cpp
@@ -25,7 +25,9 @@ TableIterator* Iterator::scan_primary(
         std::vector<int32_t>& field_slot,
         bool                    check_region, 
         bool                    forward) {
-    txn->reset_active_time();
+    if (txn != nullptr) {
+        txn->reset_active_time();
+    }
     TableIterator* iter = new (std::nothrow)TableIterator(check_region, forward);
     if (nullptr == iter) {
         return nullptr;
@@ -44,7 +46,9 @@ IndexIterator* Iterator::scan_secondary(
         std::vector<int32_t>& field_slot,
         bool                check_region, 
         bool                forward) {
-    txn->reset_active_time();
+    if (txn != nullptr) {
+        txn->reset_active_time();
+    }
     IndexIterator* iter = new (std::nothrow)IndexIterator(check_region, forward);
     if (nullptr == iter) {
         return nullptr;
@@ -382,7 +386,9 @@ bool Iterator::_fits_region(rocksdb::Slice key, rocksdb::Slice value) {
     }
     //check range end_key
     key.remove_prefix(_prefix_len);
-    bool ret = Transaction::fits_region_range(key, value, nullptr, 
+    // 按理说start_key不需要判断，之前global index
+    // 有bug，分裂后put_row有在start_key之前的记录写入
+    bool ret = Transaction::fits_region_range(key, value, &_region_info->start_key(), 
         &_region_info->end_key(), *_pri_info, *_index_info);
     return ret;
 }

--- a/src/engine/transaction_pool.cpp
+++ b/src/engine/transaction_pool.cpp
@@ -32,7 +32,8 @@ DEFINE_int32(long_live_txn_interval_ms, 900 * 1000,
         "delay duration to clear prepared and expired transactions");
 DEFINE_int64(clean_finished_txn_interval_us, 600 * 1000 * 1000LL,
         "clean_finished_txn_interval_us");
-DEFINE_int32(transaction_query_primary_region_interval_ms, 10 * 1000,
+// 分裂slow down max time：5s
+DEFINE_int32(transaction_query_primary_region_interval_ms, 15 * 1000,
         "interval duration send request to primary region");
 
 int TransactionPool::init(int64_t region_id, bool use_ttl) {
@@ -74,12 +75,14 @@ int TransactionPool::begin_txn(uint64_t txn_id, SmartTransaction& txn, int64_t p
     return 0;
 }
 
-void TransactionPool::remove_txn(uint64_t txn_id) {
+void TransactionPool::remove_txn(uint64_t txn_id, bool mark_finished) {
     std::unique_lock<std::mutex> lock(_map_mutex);
     if (_txn_map.count(txn_id) == 0) {
         return;
     }
-    (*_finished_txn_map.read())[txn_id] = _txn_map[txn_id]->dml_num_affected_rows;
+    if (mark_finished) {
+        (*_finished_txn_map.read())[txn_id] = _txn_map[txn_id]->dml_num_affected_rows;
+    }
     //DB_WARNING("txn_removed: %p, %lu", txn, txn->GetName().c_str());
     _txn_map.erase(txn_id);
     _txn_count--;
@@ -105,17 +108,24 @@ void TransactionPool::txn_query_primary_region(SmartTransaction txn, Region* reg
     int retry_times = 1;
     bool success = false;
     do {
-        if (txn->is_finished()) {
+        if (txn->is_finished() || region->removed()) {
             break;
         }
         RpcSender::send_query_method(request, response, region_info.leader(), region_info.region_id());
         switch (response.errcode()) {
             case pb::SUCCESS: {
                 auto txn_info = response.txn_infos(0);
+                bool need_remove = true;
                 if (txn_info.txn_state() == pb::TXN_ROLLBACKED) {
-                    txn_commit_through_raft(txn, region->region_info(), pb::OP_ROLLBACK);
+                    need_remove = txn_commit_through_raft(txn, region->region_info(), pb::OP_ROLLBACK);
                 } else if (txn_info.txn_state() == pb::TXN_COMMITTED) {
-                    txn_commit_through_raft(txn, region->region_info(), pb::OP_COMMIT);
+                    need_remove = txn_commit_through_raft(txn, region->region_info(), pb::OP_COMMIT);
+                } else if (!txn->has_write() && !txn->in_process()) {
+                    if (butil::gettimeofday_us() - txn->last_active_time > FLAGS_transaction_clear_delay_ms * 1000LL) {
+                        DB_WARNING("read only txn ROLLBLACK region_id:%ld,primary_region_id: %ld txn_id: %lu",
+                            region->region_info().region_id(), region_info.region_id(), txn->txn_id());
+                        need_remove = txn_commit_through_raft(txn, region->region_info(), pb::OP_ROLLBACK);
+                    }
                 } else {
                     // primary没有查到rollback_tag，认为是commit，但是secondary不是PREPARE状态
                     DB_FATAL("primary committed, secondary need catchup log, region_id:%ld,"
@@ -124,9 +134,12 @@ void TransactionPool::txn_query_primary_region(SmartTransaction txn, Region* reg
                     success = true;
                     return;
                 }
-                remove_txn(txn->txn_id());
+                if (need_remove) {
+                    remove_txn(txn->txn_id());
+                }
                 success = true;
-                DB_WARNING("send txn query success request:%s response: %s",
+                DB_WARNING("send txn query success primary_region_id: %ld request:%s response: %s",
+                    region_info.region_id(),
                     request.ShortDebugString().c_str(),
                     response.ShortDebugString().c_str());
                 break;
@@ -151,7 +164,6 @@ void TransactionPool::txn_query_primary_region(SmartTransaction txn, Region* reg
                 DB_WARNING("send txn query VERSION_OLD , request:%s response: %s",
                     request.ShortDebugString().c_str(),
                     response.ShortDebugString().c_str());
-                bthread_usleep(retry_times * FLAGS_retry_interval_us);
                 break;
             }
             case pb::REGION_NOT_EXIST: {
@@ -160,7 +172,8 @@ void TransactionPool::txn_query_primary_region(SmartTransaction txn, Region* reg
                 break;
             }
             case pb::TXN_IS_EXISTING: {
-                DB_WARNING("send txn query TXN_IS_EXISTING , request:%s response: %s",
+                DB_WARNING("region_id:%ld send txn query TXN_IS_EXISTING , request:%s response: %s",
+                    region->get_region_id(),
                     request.ShortDebugString().c_str(),
                     response.ShortDebugString().c_str());
                 success = true;
@@ -201,7 +214,10 @@ void TransactionPool::get_txn_state(const pb::StoreReq* request, pb::StoreRes* r
     }
 }
 
-void TransactionPool::read_only_txn_process(SmartTransaction txn, pb::OpType op_type, bool optimize_1pc) {
+void TransactionPool::read_only_txn_process(int64_t region_id,
+                    SmartTransaction txn,
+                    pb::OpType op_type,
+                    bool optimize_1pc) {
     uint64_t txn_id = txn->txn_id();
     switch (op_type) {
         case pb::OP_PREPARE:
@@ -217,7 +233,8 @@ void TransactionPool::read_only_txn_process(SmartTransaction txn, pb::OpType op_
             remove_txn(txn_id);
             break;
         case pb::OP_COMMIT:
-            txn->commit();
+            // rollback性能有提升
+            txn->rollback();
             remove_txn(txn_id);
             break;
         default:
@@ -227,24 +244,21 @@ void TransactionPool::read_only_txn_process(SmartTransaction txn, pb::OpType op_
             _region_id, txn_id, optimize_1pc);
 }
 
-void TransactionPool::txn_commit_through_raft(SmartTransaction txn,
+// 返回true时从txn_pool删除txn
+bool TransactionPool::txn_commit_through_raft(SmartTransaction txn,
             pb::RegionInfo& region_info,
             pb::OpType op_type) {
-    // 只读事务       
-    if (!txn->has_write()) {
-        DB_WARNING("read-only txn rollback directly region_id:%ld txn_id:%ld:%d",
-            region_info.region_id(), txn->txn_id(), txn->seq_id());
-        txn->rollback();
-        return;
-    }
     pb::StoreReq request;
     pb::StoreRes response;
+    int64_t region_id = region_info.region_id();
     request.set_op_type(op_type);
-    request.set_region_id(region_info.region_id());
+    request.set_region_id(region_id);
     request.set_region_version(region_info.version());
     pb::TransactionInfo* pb_txn = request.add_txn_infos();
     pb_txn->set_txn_id(txn->txn_id());
+    pb_txn->set_start_seq_id(txn->seq_id());
     pb_txn->set_seq_id(txn->seq_id() + 1);
+    pb_txn->set_from_store(true);
     pb::Plan* plan = request.mutable_plan();
     pb::PlanNode* pb_node = plan->add_nodes();
     pb_node->set_node_type(pb::TRANSACTION_NODE);
@@ -257,69 +271,117 @@ void TransactionPool::txn_commit_through_raft(SmartTransaction txn,
         txn_node->set_txn_cmd(pb::TXN_ROLLBACK_STORE);
     }
     int retry_times = 1;
+    bool need_remove = true;
     bool success = false;
     do {
-        RpcSender::send_query_method(request, response, region_info.leader(), region_info.region_id());
+        RpcSender::send_query_method(request, response, region_info.leader(), region_id);
         switch (response.errcode()) {
-        case pb::SUCCESS:
-        case pb::TXN_IS_ROLLBACK: {
-            DB_WARNING("txn process success , request:%s response: %s",
-                request.ShortDebugString().c_str(),
-                response.ShortDebugString().c_str());
-            success = true;
-            break;
-        }
-        case pb::NOT_LEADER: {
-            if (response.leader() != "0.0.0.0:0") {
-                region_info.set_leader(response.leader());
-            } else {
-                other_peer_to_leader(region_info);
+            case pb::SUCCESS:
+            case pb::TXN_IS_ROLLBACK: {
+                DB_WARNING("txn process success , request:%s response: %s",
+                    request.ShortDebugString().c_str(),
+                    response.ShortDebugString().c_str());
+                success = true;
+                break;
             }
-            DB_WARNING("send txn commit NOT_LEADER , request:%s response: %s",
-                request.ShortDebugString().c_str(),
-                response.ShortDebugString().c_str());
-            bthread_usleep(retry_times * FLAGS_retry_interval_us);
-            break;
-        }
-        case pb::VERSION_OLD: {
-            for (auto r : response.regions()) {
-                if (r.region_id() == region_info.region_id()) {
-                    region_info.CopyFrom(r);
-                    request.set_region_version(region_info.version());
+            case pb::IN_PROCESS: {
+                DB_WARNING("txn in process , request:%s response: %s",
+                    request.ShortDebugString().c_str(),
+                    response.ShortDebugString().c_str());
+                success = true;
+                need_remove = false;
+                break;
+            }
+            case pb::NOT_LEADER: {
+                if (response.leader() != "0.0.0.0:0") {
+                    region_info.set_leader(response.leader());
                 } else {
-                    txn_commit_through_raft(txn, r, op_type);
+                    other_peer_to_leader(region_info);
                 }
+                DB_WARNING("send txn commit NOT_LEADER , request:%s response: %s",
+                    request.ShortDebugString().c_str(),
+                    response.ShortDebugString().c_str());
+                bthread_usleep(retry_times * FLAGS_retry_interval_us);
+                break;
             }
-            DB_WARNING("send txn commit VERSION_OLD , request:%s response: %s",
-                request.ShortDebugString().c_str(),
-                response.ShortDebugString().c_str());
-            bthread_usleep(retry_times * FLAGS_retry_interval_us);
-            break;
-        }
-        case pb::REGION_NOT_EXIST: {
-            // todo region_info信息可能需要查meta
-            other_peer_to_leader(region_info);
-            break;
-        }
-        default: {
-            DB_WARNING("send txn commit failed , request:%s response: %s",
-                request.ShortDebugString().c_str(),
-                response.ShortDebugString().c_str());
-            bthread_usleep(retry_times * FLAGS_retry_interval_us);
-            break;
+            case pb::TXN_FOLLOW_UP: {
+                pb_txn->set_start_seq_id(1);
+                DB_WARNING("send txn commit TXN_FOLLOW_UP , request:%s response: %s",
+                    request.ShortDebugString().c_str(),
+                    response.ShortDebugString().c_str());
+                break;
+            }
+            case pb::VERSION_OLD: {
+                DB_WARNING("send txn commit VERSION_OLD , request:%s response: %s",
+                    request.ShortDebugString().c_str(),
+                    response.ShortDebugString().c_str());
+                success = true;
+                need_remove = false;
+                break;
+            }
+            case pb::REGION_NOT_EXIST: {
+                int ret = get_region_info_from_meta(region_id, region_info);
+                if (ret < 0) {
+                    if (ret == -2) {
+                        DB_WARNING("region_id:%ld REGION_NOT_EXIST txn_id:%lu seq_id: %d txn rollback",
+                            region_id, txn->txn_id(), txn->seq_id());
+                        SmartRegion region_ptr = Store::get_instance()->get_region(region_id);
+                        if (region_ptr != nullptr && region_info.peers_size() > 1) {
+                            region_info = region_ptr->region_info();
+                            other_peer_to_leader(region_info);
+                        } else {
+                            txn->rollback();
+                            remove_txn(txn->txn_id());
+                            success = true;
+                        }
+                    } else {
+                        DB_FATAL("send query request to meta server fail primary_region_id: %ld "
+                            "region_id:%ld txn_id: %lu seq_id: %d",
+                        txn->primary_region_id(), region_id, txn->txn_id(), txn->seq_id());
+                    }
+                } else {
+                    other_peer_to_leader(region_info);
+                }
+                bthread_usleep(retry_times * FLAGS_retry_interval_us);
+                break;
+            }
+            default: {
+                DB_WARNING("send txn commit failed , request:%s response: %s",
+                    request.ShortDebugString().c_str(),
+                    response.ShortDebugString().c_str());
+                bthread_usleep(retry_times * FLAGS_retry_interval_us);
+                break;
+            }
         }
         if (retry_times < 10) {
             retry_times++;
         }
-        }
    } while (!success);
+   return need_remove;
+}
+
+int TransactionPool::get_region_info_from_meta(int64_t region_id, pb::RegionInfo& region_info) {
+    MetaServerInteract&   meta_server_interact = Store::get_instance()->get_meta_server_interact();
+    pb::QueryRequest query_request;
+    pb::QueryResponse query_response;
+    query_request.set_op_type(pb::QUERY_REGION);
+    query_request.set_region_id(region_id);
+    if (meta_server_interact.send_request("query", query_request, query_response) != 0) {
+        DB_FATAL("send query request to meta server fail region_id:%ld res: %s",
+            region_id, query_response.ShortDebugString().c_str());
+        if (query_response.errcode() == pb::REGION_NOT_EXIST) {
+            return -2;
+        }
+        return -1;
+    }
+    region_info = query_response.region_infos(0);
+    return 0;
 }
 
 // 清理僵尸事务：包括长时间（clear_delay_ms）未更新的事务
 void TransactionPool::clear_transactions(Region* region) {
     std::vector<SmartTransaction>  txns_need_reverse;
     std::vector<SmartTransaction>  primary_txns_need_clear;
-    std::vector<SmartTransaction>  secondary_txns_need_clear;
     {
         std::unique_lock<std::mutex> lock(_map_mutex);
         // 10分钟清理过期幂等事务id
@@ -333,94 +395,57 @@ void TransactionPool::clear_transactions(Region* region) {
             auto cur_time = butil::gettimeofday_us();
             // 事务存在时间过长报警
             if (cur_time - txn->begin_time > FLAGS_long_live_txn_interval_ms *1000LL) {
-                DB_FATAL("TransactionWarning: txn %s is alive for %d ms, %ld, %ld, %ld, %ld",
+                DB_FATAL("TransactionWarning: txn %s is alive for %d ms, %ld, %ld, %lds",
                      txn->get_txn()->GetName().c_str(), FLAGS_long_live_txn_interval_ms,
                      cur_time,
                      txn->begin_time,
-                     cur_time - txn->begin_time,
-                     FLAGS_long_live_txn_interval_ms * 1000);
+                     (cur_time - txn->begin_time) / 1000000);
+            }
+            if (txn->in_process()) {
+                continue;
             }
             // 10min未更新的primary region事务直接rollback
             if (txn->is_primary_region() &&
                (cur_time - txn->last_active_time > FLAGS_transaction_clear_delay_ms * 1000LL)) {
                 primary_txns_need_clear.push_back(txn);
-                DB_FATAL("TransactionFatal: primary txn %s is idle for %d ms, %ld, %ld, %ld, %ld",
+                DB_FATAL("TransactionFatal: primary txn %s is idle for %d ms, %ld, %ld, %lds",
                      txn->get_txn()->GetName().c_str(), FLAGS_transaction_clear_delay_ms,
                      cur_time,
                      txn->last_active_time,
-                     cur_time - txn->last_active_time,
-                     FLAGS_transaction_clear_delay_ms * 1000);
-            } else if (cur_time - txn->last_active_time > FLAGS_transaction_clear_delay_ms * 1000LL) {
-                secondary_txns_need_clear.push_back(txn);
-                DB_FATAL("TransactionFatal: secondary txn %s is idle for %d ms, %ld, %ld, %ld, %ld",
-                     txn->get_txn()->GetName().c_str(), FLAGS_transaction_clear_delay_ms,
-                     cur_time,
-                     txn->last_active_time,
-                     cur_time - txn->last_active_time,
-                     FLAGS_transaction_clear_delay_ms * 1000);               
+                     (cur_time - txn->last_active_time) / 1000000);
             // 10s未更新的事务询问primary region事务状态
             } else if (cur_time - txn->last_active_time > FLAGS_transaction_query_primary_region_interval_ms * 1000LL) {
-                if (txn->primary_region_id_seted()) {
-                    txns_need_reverse.push_back(txn);
-                }
-            }
-        }
-    }
-
-    // region只读事务rollback，否则等leader反查
-    for (auto txn : secondary_txns_need_clear) {
-        if (!txn->has_write() || txn->seq_id() <= 1) {
-            DB_WARNING("read-only txn rollback directly region_id:%ld txn_id:%ld:%d",
-                region->get_region_id(), txn->txn_id(), txn->seq_id());
-            txn->rollback();
-            remove_txn(txn->txn_id());
-        } else {
-            if (txn->primary_region_id_seted()) {
                 txns_need_reverse.push_back(txn);
             }
         }
     }
-    auto it = primary_txns_need_clear.begin();
-    while (it != primary_txns_need_clear.end()) {
-        auto txn = *it;
-        if (!txn->has_write() || txn->seq_id() <= 1) {
-            DB_WARNING("read-only txn rollback directly region_id:%ld txn_id:%ld:%d",
-                region->get_region_id(), txn->txn_id(), txn->seq_id());
-            txn->rollback();
-            remove_txn(txn->txn_id());
-            it = primary_txns_need_clear.erase(it);
-        } else {
-            ++it;
-        }        
-    }
-
     if (!region->is_leader()) {
         return ;
     }
     // 只对primary region进行超时rollback
     for (auto txn : primary_txns_need_clear) {
-        txn_commit_through_raft(txn, region->region_info(), pb::OP_ROLLBACK);
-        remove_txn(txn->txn_id());
+        bool need_remove = txn_commit_through_raft(txn, region->region_info(), pb::OP_ROLLBACK);
+        if (need_remove) {
+            remove_txn(txn->txn_id());
+        }
     }
-    MetaServerInteract&   meta_server_interact = Store::get_instance()->get_meta_server_interact();
     for (auto txn : txns_need_reverse) {
         if (!txn->is_finished() && !txn->is_primary_region()) {
-            pb::QueryRequest query_request;
-            pb::QueryResponse query_response;
-            query_request.set_op_type(pb::QUERY_REGION);
-            query_request.set_region_id(txn->primary_region_id());
-            if (meta_server_interact.send_request("query", query_request, query_response) != 0) {
-                DB_FATAL("send query request to meta server fail primary_region_id: %ld "
-                        "region_id:%ld txn_id: %lu seq_id: %d res: %s",
-                    txn->primary_region_id(), region->get_region_id(), txn->txn_id(), txn->seq_id(),
-                    query_response.ShortDebugString().c_str());
-                if (query_response.errcode() == pb::REGION_NOT_EXIST) {
-                    txn->rollback();
-                    remove_txn(txn->txn_id());
+            pb::RegionInfo region_info;
+            int ret = get_region_info_from_meta(txn->primary_region_id(), region_info);
+            if (ret < 0) {
+                if (ret == -2) {
+                    DB_WARNING("region_id:%ld REGION_NOT_EXIST txn_id:%lu seq_id: %d txn rollback",
+                        txn->primary_region_id(), txn->txn_id(), txn->seq_id());
+                    // prmariy region可能还未上报meta，不能直接rollback
+                    //txn_commit_through_raft(txn, region->region_info(), pb::OP_ROLLBACK);
+                    //remove_txn(txn->txn_id());
                 }
+                DB_FATAL("send query request to meta server fail primary_region_id: %ld "
+                        "region_id:%ld txn_id: %lu seq_id: %d",
+                    txn->primary_region_id(), region->get_region_id(), txn->txn_id(), txn->seq_id());
                 continue;
             }
-            pb::RegionInfo region_info = query_response.region_infos(0);
             txn_query_primary_region(txn, region, region_info);
         }
     }
@@ -433,10 +458,6 @@ void TransactionPool::on_leader_start_recovery(Region* region) {
     for (auto iter : _txn_map) {
         auto& txn = iter.second;
         if (txn->is_finished()) {
-            continue;
-        }
-        // 兼容
-        if (!txn->primary_region_id_seted()) {
             continue;
         }
         DB_WARNING("TransactionNote: txn %s need replay due to leader transfer seq_id:%d",
@@ -456,13 +477,13 @@ void TransactionPool::on_leader_start_recovery(Region* region) {
     }
 }
 
-// rollback ALL un-prepared transactions when raft on_leader_stop callback is called
+// //只读事务清理
 void TransactionPool::on_leader_stop_rollback() {
     std::unique_lock<std::mutex> lock(_map_mutex);
     auto iter = _txn_map.begin();
     while (iter != _txn_map.end()) {
         auto& txn = iter->second;
-        if (!txn->is_prepared() && !txn->prepare_apply()) {
+        if (!txn->has_write() && !txn->in_process()) {
             DB_WARNING("TransactionNote: txn %s is rollback due to leader stop", 
                 txn->get_txn()->GetName().c_str());
             txn->rollback();
@@ -489,68 +510,8 @@ void TransactionPool::on_leader_stop_rollback(uint64_t txn_id) {
     }
 }
 
-int TransactionPool::on_shutdown_recovery(
-        std::vector<rocksdb::Transaction*>& recovered_txns,
-        std::unordered_map<uint64_t, pb::TransactionInfo>& prepared_txn) {
-
-    std::string region_prefix = std::to_string(_region_id);
-    //std::unique_lock<std::mutex> lock(_map_mutex);
-    auto iter = recovered_txns.begin();
-    while (iter != recovered_txns.end()) {
-        if ((*iter) == nullptr) {
-            DB_WARNING("txn is nullptr: %ld", _region_id);
-            continue;
-        }
-        std::string txn_name = (*iter)->GetName();
-        if (!boost::algorithm::starts_with(txn_name, region_prefix)) {
-            iter++;
-            continue;
-        }
-        uint64_t txn_id = strtoull(txn_name.substr(txn_name.find('_') + 1).c_str(), nullptr, 0);
-        SmartTransaction txn(new (std::nothrow)Transaction(txn_id, this, _use_ttl));
-        if (txn == nullptr) {
-            DB_FATAL("TransactionError: new txn failed, txn_id: %lu", txn_id);
-            return -1;
-        }
-        int ret = txn->begin(*iter);
-        if (ret != 0) {
-            DB_FATAL("TransactionError: begin txn failed, txn_id: %lu", txn_id);
-            return -1;
-        }
-        auto txn_iter = prepared_txn.find(txn_id);
-        if (txn_iter == prepared_txn.end()) {
-            DB_FATAL("TransactionError: txn_increase_rows not found, region_id: %ld, txn_id: %lu", 
-                _region_id, txn_id);
-            return -1;
-        }
-        auto& txn_info = txn_iter->second;
-        txn->num_increase_rows = txn_info.num_rows();
-        txn->set_seq_id(txn_info.seq_id());
-        for (auto& plan : txn_info.cache_plans()) {
-            txn->cache_plan_map().insert({plan.seq_id(), plan});
-        }
-        _txn_map.insert(std::make_pair(txn_id, txn));
-        _txn_count++;
-        iter = recovered_txns.erase(iter);
-        DB_WARNING("region_id: %ld, txn_id: %lu, txn_name: %s, num_rows: %ld, seq_id: %d, txn recovered", 
-            _region_id,
-            txn_id,
-            txn_name.c_str(), 
-            txn->num_increase_rows,
-            txn->seq_id());
-    }
-    return 0;
-}
-
-// int TransactionPool::on_crash_recovery(
-//         std::unordered_map<uint64_t, pb::TransactionInfo>& prepared_txn) {
-//     return _region->replay_txn_for_recovery(prepared_txn);
-// }
-
 // 该函数执行时需要保证没有事务的修改操作
-void TransactionPool::get_prepared_txn_info(
-        std::unordered_map<uint64_t, pb::TransactionInfo>& prepared_txn,
-        bool graceful_shutdown) {
+void TransactionPool::get_prepared_txn_info(std::unordered_map<uint64_t, pb::TransactionInfo>& prepared_txn) {
     std::unique_lock<std::mutex> lock(_map_mutex);
     for (auto& pair : _txn_map) {
         auto txn = pair.second;
@@ -567,17 +528,20 @@ void TransactionPool::get_prepared_txn_info(
     return;
 }
 
-void TransactionPool::update_txn_num_rows_after_split(const pb::TransactionInfo& txn_info) {
-    uint64_t txn_id = txn_info.txn_id();
-    if (_txn_map.count(txn_id) == 0) {
-        return;
+void TransactionPool::update_txn_num_rows_after_split(const std::vector<pb::TransactionInfo>& txn_infos) {
+    std::unique_lock<std::mutex> lock(_map_mutex);
+    for (auto& txn_info : txn_infos) {
+        uint64_t txn_id = txn_info.txn_id();
+        if (_txn_map.count(txn_id) == 0) {
+            continue;
+        }
+        DB_WARNING("TransactionNote: region_id: %ld, txn_id: %lu, old_lines: %ld, dec_lines: %ld",
+            _region_id, 
+            txn_id, 
+            _txn_map[txn_id]->num_increase_rows, 
+            txn_info.num_rows());
+        _txn_map[txn_id]->num_increase_rows -= txn_info.num_rows();
     }
-    DB_WARNING("TransactionNote: region_id: %ld, txn_id: %lu, old_lines: %ld, dec_lines: %ld",
-        _region_id, 
-        txn_id, 
-        _txn_map[txn_id]->num_increase_rows, 
-        txn_info.num_rows());
-    _txn_map[txn_id]->num_increase_rows -= txn_info.num_rows();
 }
 void TransactionPool::clear() {
     std::unique_lock<std::mutex> lock(_map_mutex);

--- a/src/exec/agg_node.cpp
+++ b/src/exec/agg_node.cpp
@@ -199,6 +199,7 @@ void AggNode::process_row_batch(RowBatch& batch) {
             // 以便于 select id,count(*) from t where id>1;这种sql时id不会时造出来的null
             if (_is_merger && _group_exprs.size() == 0) {
                 if (AggFnCall::all_is_initialize(_agg_fn_calls, *agg_row)) {
+                    delete cur_row;
                     continue;
                 }
             }

--- a/src/exec/dml_node.cpp
+++ b/src/exec/dml_node.cpp
@@ -212,10 +212,10 @@ int DMLNode::insert_row(RuntimeState* state, SmartRecord record, bool is_update)
             need_increase = false;
         }
         if (ret != -2 && ret != -4) {
-            if (_need_ignore) {
-                return 0;
-            }
             if (ret == 0) { 
+                if (_need_ignore) {
+                    return 0;
+                }
                 if (is_update) {
                     DB_WARNING_STATE(state, "update new primary row must not exist, "
                             "index:%ld, ret:%d", _table_id, ret);

--- a/src/exec/exec_node.cpp
+++ b/src/exec/exec_node.cpp
@@ -124,6 +124,9 @@ bool ExecNode::need_seperate() {
             if (static_cast<ScanNode*>(this)->engine() == pb::ROCKSDB) {
                 return true;
             }
+            if (static_cast<ScanNode*>(this)->engine() == pb::BINLOG) {
+                return true;
+            }
             if (static_cast<ScanNode*>(this)->engine() == pb::ROCKSDB_CSTORE) {
                 return true;
             }

--- a/src/exec/full_export_node.cpp
+++ b/src/exec/full_export_node.cpp
@@ -17,10 +17,7 @@
 #include "network_socket.h"
 
 namespace baikaldb {
-
-DECLARE_int32(retry_interval_us);
 DEFINE_int32(region_per_batch, 4, "request region number in a batch");
-DECLARE_int64(print_time_us);
 
 int FullExportNode::init(const pb::PlanNode& node) {
     int ret = 0;

--- a/src/exec/join_node.cpp
+++ b/src/exec/join_node.cpp
@@ -729,6 +729,7 @@ int JoinNode:: _construct_null_result_batch(RowBatch* batch, MemRow* outer_mem_r
 
 void JoinNode::close(RuntimeState* state) {
     ExecNode::close(state);
+    _conditions.insert(_conditions.end(), _have_removed.begin(), _have_removed.end());
     _have_removed.clear();
     _outer_join_values.clear();
     for (auto expr : _conditions) {

--- a/src/exec/rocksdb_scan_node.cpp
+++ b/src/exec/rocksdb_scan_node.cpp
@@ -596,7 +596,7 @@ int RocksdbScanNode::get_next_by_table_get(RuntimeState* state, RowBatch* batch,
             record = _left_records[_idx++];
         }
         ++_scan_rows;
-        int ret = txn->get_update_primary(_region_id, *_pri_info, record, _field_ids, GET_ONLY, true);
+        int ret = txn->get_update_primary(_region_id, *_pri_info, record, _field_ids, GET_ONLY, state->need_check_region());
         if (ret < 0) {
             continue;
         }
@@ -708,7 +708,7 @@ int RocksdbScanNode::get_next_by_table_seek(RuntimeState* state, RowBatch* batch
                         _like_prefixs[_idx]);
                 delete _table_iter;
                 _table_iter = Iterator::scan_primary(
-                        state->txn(), range, _field_ids, _field_slot, true, _scan_forward);
+                        state->txn(), range, _field_ids, _field_slot, state->need_check_region(), _scan_forward);
                 if (_table_iter == nullptr) {
                     DB_WARNING_STATE(state, "open TableIterator fail, table_id:%ld", _index_id);
                     return -1;

--- a/src/exec/scan_node.cpp
+++ b/src/exec/scan_node.cpp
@@ -63,6 +63,7 @@ int64_t ScanNode::select_index() {
             index_priority = 0;
         }
         // 普通索引如果都包含在主键里，则不选
+        // 外部pre_process_select_index上线生效后此处可以不用判断，TODO
         if (info.type == pb::I_UNIQ || info.type == pb::I_KEY) {
             bool contain_by_primary = true;
             for (int j = 0; j < field_count; j++) {
@@ -79,6 +80,8 @@ int64_t ScanNode::select_index() {
         if (pos_index.has_sort_index() && field_count > 0) {
             prefix_ratio_round = 100;
             index_priority = 150 + field_count;
+        } else if (pos_index.has_sort_index() && pos_index.sort_index().sort_limit() != -1) {
+            index_priority = 400;
         }
         uint32_t prefix_ratio_index_score = (prefix_ratio_round << 16) | index_priority;
         // ignore index用到最低优先级，其实只有primary会走到这里
@@ -216,19 +219,39 @@ void ScanNode::show_explain(std::vector<std::map<std::string, std::string>>& out
     output.push_back(explain_info);
 }
 
+void ScanNode::show_cost(std::vector<std::map<std::string, std::string>>& path_infos) {
+    for (auto& pair : _paths) {
+        auto& path = pair.second;
+        std::map<std::string, std::string> path_info;
+        if (path->is_possible || path->index_type == pb::I_PRIMARY) {
+            path->show_cost(&path_info, _filed_selectiy);
+            path_infos.push_back(path_info);
+        }
+    }
+}
+
+//干掉被另一个索引完全覆盖的
+
 int64_t ScanNode::select_index_by_cost() {
     double min_cost = DBL_MAX;
     int min_idx = 0;
     bool multi_0_0 = false;
     bool multi_1_0 = false;
     bool enable_use_cost = true;
+    // 优化：只有一个possible时直接使用
     for (auto& pair : _paths) {
         auto& path = pair.second;
-        if (!path->is_possible && path->index_type != pb::I_PRIMARY) {
+        if (!path->is_possible && path->index_type == pb::I_PRIMARY) {
+            if (_possible_index_cnt > 0 && _cover_index_cnt > 0) {
+                // 如果primary_key非possible，并且有其他索引可选时，跳过primary key
+                continue;
+            }
+        } else if (!path->is_possible) {
             continue;
         }
+        
         int64_t index_id = pair.first;
-        path->calc_cost();
+        path->calc_cost(nullptr, _filed_selectiy);
         if (path->cost < min_cost) {
             min_cost = path->cost;
             min_idx = index_id;
@@ -258,6 +281,158 @@ int64_t ScanNode::select_index_by_cost() {
     }
 }
 
+// 判断是否全覆盖，只有被全覆盖的索引可以被干掉
+bool ScanNode::full_coverage(const std::unordered_set<int32_t>& smaller, const std::unordered_set<int32_t>& bigger) {
+    for (int32_t field_id : smaller) {
+        if (bigger.count(field_id) == 0) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// 两个索引比较选择最优的，干掉另一个
+// return  0 没有干掉任何一个
+// return -1 outer被干掉
+// return -2 inner被干掉
+int ScanNode::compare_two_path(SmartPath outer_path, SmartPath inner_path) {
+    if (outer_path->hit_index_field_ids.size() == inner_path->hit_index_field_ids.size()) {
+        if (!full_coverage(outer_path->hit_index_field_ids, inner_path->hit_index_field_ids)) {
+            return 0;
+        }
+
+        if (!outer_path->is_covering_index && !outer_path->is_sort_index) {
+            outer_path->is_possible = false;
+            return -1;
+        }
+
+        if (!inner_path->is_covering_index && !inner_path->is_sort_index) {
+            inner_path->is_possible = false;
+            return -2;
+        }
+
+        if (outer_path->is_covering_index == inner_path->is_covering_index &&
+            outer_path->is_sort_index == inner_path->is_sort_index) {
+            inner_path->is_possible = false;
+            return -2;
+        }
+
+    } else if (outer_path->hit_index_field_ids.size() < inner_path->hit_index_field_ids.size()) {
+        if (!full_coverage(outer_path->hit_index_field_ids, inner_path->hit_index_field_ids)) {
+            return 0;
+        }
+
+        if (!outer_path->is_covering_index && !outer_path->is_sort_index) {
+            outer_path->is_possible = false;
+            return -1;
+        }
+
+        if (outer_path->is_covering_index == inner_path->is_covering_index &&
+            outer_path->is_sort_index == inner_path->is_sort_index) {
+            outer_path->is_possible = false;
+            return -1;
+        }
+    } else {
+        if (!full_coverage(inner_path->hit_index_field_ids, outer_path->hit_index_field_ids)) {
+            return 0;
+        }
+
+        if (!inner_path->is_covering_index && !inner_path->is_sort_index) {
+            inner_path->is_possible = false;
+            return -2;
+        }
+
+        if (outer_path->is_covering_index == inner_path->is_covering_index &&
+            outer_path->is_sort_index == inner_path->is_sort_index) {
+            inner_path->is_possible = false;
+            return -2;
+        }
+    }
+
+    return 0;
+}
+
+void ScanNode::inner_loop_and_compare(std::map<int64_t, SmartPath>::iterator outer_loop_iter) {
+    auto inner_loop_iter = outer_loop_iter;
+    while ((++inner_loop_iter) != _paths.end()) {
+        if (!inner_loop_iter->second->is_possible) {
+            continue;
+        }
+
+        if (inner_loop_iter->second->index_type != pb::I_PRIMARY && 
+            inner_loop_iter->second->index_type != pb::I_UNIQ &&
+            inner_loop_iter->second->index_type != pb::I_KEY) {
+            continue;
+        }
+
+        int ret = compare_two_path(outer_loop_iter->second, inner_loop_iter->second);
+        if (ret == -1) {
+            // outer被干掉，跳出循环
+            break;
+        }
+    }
+}
+
+// 两两比较，根据一些简单规则干掉次优索引
+int64_t ScanNode::pre_process_select_index() {
+    if (_paths.empty()) {
+        return 0;
+    }
+
+    if (_use_fulltext) {
+        return 0;
+    }
+
+    int possible_cnt = 0;
+    int cover_index_cnt = 0;
+    int64_t possible_index = 0;
+    for (auto outer_loop_iter = _paths.begin(); outer_loop_iter != _paths.end(); outer_loop_iter++) {
+        if (!outer_loop_iter->second->is_possible) {
+            continue;
+        }
+
+        if (outer_loop_iter->second->index_type != pb::I_PRIMARY && 
+            outer_loop_iter->second->index_type != pb::I_UNIQ &&
+            outer_loop_iter->second->index_type != pb::I_KEY) {
+            continue;
+        }
+
+        if (outer_loop_iter->second->index_type == pb::I_PRIMARY || 
+            outer_loop_iter->second->index_type == pb::I_UNIQ) {
+            if (outer_loop_iter->second->index_field_ids.size() 
+                == outer_loop_iter->second->hit_index_field_ids.size()) {
+                // 主键或唯一键全命中，直接选择
+                return outer_loop_iter->second->index_id;
+            }
+        }
+
+        inner_loop_and_compare(outer_loop_iter);
+        if (outer_loop_iter->second->is_possible) {
+            possible_cnt++;
+            possible_index = outer_loop_iter->second->index_id;
+        }
+        if (outer_loop_iter->second->is_covering_index) {
+            cover_index_cnt++;
+        }
+    }
+
+    _cover_index_cnt = cover_index_cnt;
+    _possible_index_cnt = possible_cnt;
+    // 仅有一个possible index直接选择这个索引
+    if (possible_cnt == 1) {
+        return possible_index;
+    }
+
+    // 没有possible index 选择 primary index
+    if (possible_cnt == 0) {
+        return _table_id;
+    }
+
+    return 0;
+
+}
+
 int64_t ScanNode::select_index_in_baikaldb() {
     auto table_ptr = SchemaFactory::get_instance()->get_table_info_ptr(_table_id);
     if (table_ptr == nullptr) {
@@ -267,14 +442,19 @@ int64_t ScanNode::select_index_in_baikaldb() {
     pb::ScanNode* pb_scan_node = mutable_pb_node()->mutable_derive_node()->mutable_scan_node();
     _router_index_id = _table_id; 
     _router_index = &_paths[_table_id]->pos_index;
-    int64_t select_idx = 0;
-    if (SchemaFactory::get_instance()->get_statistics_ptr(_table_id) != nullptr 
-        && SchemaFactory::get_instance()->is_switch_open(_table_id, TABLE_SWITCH_COST) && !_use_fulltext) {
-        DB_DEBUG("table %ld has statistics", _table_id);
-        select_idx = select_index_by_cost();
-    } else {
-        select_idx = select_index();
-    }
+    // 预处理，使用倒排索引的sql不进行预处理，如果select_idx大于0则已经选出索引
+    int64_t select_idx = pre_process_select_index();
+
+    if (select_idx == 0) {
+        if (SchemaFactory::get_instance()->get_statistics_ptr(_table_id) != nullptr 
+            && SchemaFactory::get_instance()->is_switch_open(_table_id, TABLE_SWITCH_COST) && !_use_fulltext) {
+            DB_DEBUG("table %ld has statistics", _table_id);
+            select_idx = select_index_by_cost();
+        } else {
+            select_idx = select_index();
+        }
+    } 
+
     //DB_WARNING("idx:%ld table:%ld", select_idx, _table_id);
     std::unordered_set<ExprNode*> other_condition;
     if (_multi_reverse_index.size() > 0) {
@@ -328,6 +508,7 @@ ScanNode* ScanNode::create_scan_node(const pb::PlanNode& node) {
         pb::Engine engine = node.derive_node().scan_node().engine();
         switch (engine) {
             case pb::ROCKSDB:
+            case pb::BINLOG:
                 return new RocksdbScanNode;
             case pb::ROCKSDB_CSTORE:
                 return new RocksdbScanNode(pb::ROCKSDB_CSTORE);

--- a/src/exec/select_manager_node.cpp
+++ b/src/exec/select_manager_node.cpp
@@ -34,7 +34,7 @@ int SelectManagerNode::open(RuntimeState* state) {
     client_conn->seq_id++;
     _mem_row_compare = std::make_shared<MemRowCompare>(_slot_order_exprs, _is_asc, _is_null_first);
     _sorter = std::make_shared<Sorter>(_mem_row_compare.get());
-    if (_has_sub_query) {
+    if (_sub_query_node != nullptr) {
         return subquery_open(state);
     }
     std::vector<ExecNode*> scan_nodes;

--- a/src/exec/transaction_manager_node.cpp
+++ b/src/exec/transaction_manager_node.cpp
@@ -18,71 +18,16 @@
 #include "network_server.h"
 
 namespace baikaldb {
-DECLARE_int32(retry_interval_us);
 DEFINE_int32(wait_after_prepare_us, 0, "wait time after prepare(us)");
-
-int TransactionManagerNode::add_commit_log_entry(
-        uint64_t txn_id,
-        int32_t  seq_id,
-        ExecNode* commit_fetch,
-        std::map<int64_t, pb::RegionInfo>& region_infos) {
-
-    pb::CachePlan commit_plan;
-    commit_plan.set_op_type(pb::OP_COMMIT);
-    commit_plan.set_seq_id(seq_id);
-    ExecNode::create_pb_plan(0, commit_plan.mutable_plan(), commit_fetch);
-
-    for (auto& pair : region_infos) {
-        commit_plan.add_regions()->CopyFrom(pair.second);
-    }
-    auto meta_db = RocksWrapper::get_instance();
-    MutTableKey txn_key;
-    txn_key.append_u8(NetworkServer::transaction_prefix);
-    txn_key.append_u64(txn_id);
-
-    std::string txn_value;
-    if (!commit_plan.SerializeToString(&txn_value)) {
-        DB_WARNING("serialize backup plan error: %s", commit_plan.ShortDebugString().c_str());
-        return -1;
-    }
-    rocksdb::Status ret = meta_db->put(
-            rocksdb::WriteOptions(), 
-            meta_db->get_meta_info_handle(), 
-            txn_key.data(), 
-            txn_value);
-    if (!ret.ok()) {
-        DB_WARNING("write backup plan error: %d, %s", ret.code(), ret.ToString().c_str());
-        return -1;
-    }
-    //DB_WARNING("add_backup_plan success, txn_id: %lu", txn_id);
-    return 0;
-}
-
-int TransactionManagerNode::remove_commit_log_entry(uint64_t txn_id) {
-    auto meta_db = RocksWrapper::get_instance();
-    MutTableKey txn_key;
-    txn_key.append_u8(NetworkServer::transaction_prefix);
-    txn_key.append_u64(txn_id);
-
-    rocksdb::Status ret = meta_db->remove(
-            rocksdb::WriteOptions(), 
-            meta_db->get_meta_info_handle(), 
-            txn_key.data());
-    if (!ret.ok()) {
-        DB_WARNING("remove backup plan error: %d, %s", ret.code(), ret.ToString().c_str());
-        return -1;
-    }
-    //DB_WARNING("remove_backup_plan success, txn_id: %lu", txn_id);
-    return 0;
-}
 
 int TransactionManagerNode::exec_begin_node(RuntimeState* state, ExecNode* begin_node) {
     return push_cmd_to_cache(state, pb::OP_BEGIN, begin_node);
 }
+
 int TransactionManagerNode::exec_prepared_node(RuntimeState* state, ExecNode* prepared_node, int64_t start_seq_id) {
     uint64_t log_id = state->log_id();
     auto client_conn = state->client_conn();
-    if (client_conn->region_infos.size() <= 1) {
+    if (client_conn->region_infos.size() <= 1 && !state->open_binlog()) {
         state->set_optimize_1pc(true);
         DB_WARNING("enable optimize_1pc: txn_id: %lu, seq_id: %d, log_id: %lu", 
                 state->txn_id, client_conn->seq_id, log_id);
@@ -98,42 +43,17 @@ int TransactionManagerNode::exec_commit_node(RuntimeState* state, ExecNode* comm
         DB_WARNING("connection is nullptr: %lu", state->txn_id);
         return -1;
     }
-    // for transaction recovery when BaikalDB crash
-    if (0 != add_commit_log_entry(state->txn_id, client_conn->seq_id, commit_node, client_conn->region_infos)) {
-        DB_WARNING("TransactionError: add_commit_log_entry failed: %lu log_id:%lu ", state->txn_id, state->log_id());
-        return -1;
-    }
     if (FLAGS_wait_after_prepare_us != 0) {
         bthread_usleep(FLAGS_wait_after_prepare_us);
     }
-    int retry = 0;
-    int ret = 0;
-    do {
-        auto seq_id = client_conn->seq_id;
-        ret = _fetcher_store.run(state, client_conn->region_infos, commit_node, seq_id, pb::OP_COMMIT);
-        if (ret < 0) {
-            DB_WARNING("TransactionWarn: commit failed, retry: %d. txn_id: %ld log_id:%lu", retry, 
-                   state->txn_id, state->log_id());
-            bthread_usleep(FLAGS_retry_interval_us);
-            // refresh the region infos, [start_key end_key) ranges are invarient despite regions splitting
-            pb::CachePlan commit_plan;
-            for (auto& pair : client_conn->region_infos) {
-                commit_plan.add_regions()->CopyFrom(pair.second);
-            }
-            client_conn->region_infos.clear();
-            SchemaFactory::get_instance()->get_region_by_key(commit_plan.regions(), client_conn->region_infos);
-            retry++;
-        } else {
-            break;
-        }
-    } while (true);
+    int seq_id = client_conn->seq_id;
+    int ret = _fetcher_store.run(state, client_conn->region_infos, commit_node, seq_id, pb::OP_COMMIT);
     if (ret < 0) {
-         // un-expected case since infinite retry of commit after prepare
-         DB_WARNING("TransactionError: commit failed. txn_id: %lu log_id:%lu ", state->txn_id, state->log_id());
-     } else {
-         remove_commit_log_entry(client_conn->txn_id);
-     }
-    return ret;
+        // un-expected case since infinite retry of commit after prepare
+        DB_WARNING("TransactionError: commit failed. txn_id: %lu log_id:%lu ", state->txn_id, state->log_id());
+        return -1;
+    }
+    return 0;
 }
 int TransactionManagerNode::exec_rollback_node(RuntimeState* state, ExecNode* rollback_node) {
     //DB_WARNING("rollback for single-sql trnsaction with optimize_1pc");
@@ -142,27 +62,15 @@ int TransactionManagerNode::exec_rollback_node(RuntimeState* state, ExecNode* ro
         DB_WARNING("connection is nullptr: %lu", state->txn_id);
         return -1;
     }
-    int32_t retry = 0;
-    auto ret = 0;
-    do {
-        auto seq_id = client_conn->seq_id;
-        ret = _fetcher_store.run(state, client_conn->region_infos, rollback_node, seq_id, pb::OP_ROLLBACK);
-        if (ret < 0) {
-            DB_WARNING("TransactionWarn: rollback is-single-sql:%d fail, retry: %d, txn_id: %lu log_id:%lu", 
-            state->single_sql_autocommit() ,retry, state->txn_id, state->log_id());
-            bthread_usleep(FLAGS_retry_interval_us);
-            retry++;
-        } else {
-            break;
-        }
-    } while (true);
+    int seq_id = client_conn->seq_id;
+    int ret = _fetcher_store.run(state, client_conn->region_infos, rollback_node, seq_id, pb::OP_ROLLBACK);
     if (ret < 0) {
         // un-expected case since infinite retry of commit after prepare
         DB_WARNING("TransactionError: rollback failed. txn_id: %lu log_id:%lu",
                 state->txn_id, state->log_id());
         return -1;
     }
-    return ret;
+    return 0;
 }
 }
 /* vim: set ts=4 sw=4 sts=4 tw=100 */

--- a/src/logical_plan/delete_planner.cpp
+++ b/src/logical_plan/delete_planner.cpp
@@ -22,7 +22,8 @@ DEFINE_bool(delete_all_to_truncate, false,  "delete from xxx; treat as truncate"
 int DeletePlanner::plan() {
     if (_ctx->stmt_type == parser::NT_TRUNCATE) {
         if (_ctx->client_conn->txn_id != 0) {
-            DB_FATAL("not allowed truncate table in txn connection");
+            DB_FATAL("not allowed truncate table in txn connection txn_id:%lu",
+                _ctx->client_conn->txn_id);
             return -1;
         }
         _truncate_stmt = (parser::TruncateStmt*)(_ctx->stmt);

--- a/src/meta_server/auto_incr_state_machine.cpp
+++ b/src/meta_server/auto_incr_state_machine.cpp
@@ -216,7 +216,7 @@ int AutoIncrStateMachine::on_snapshot_load(braft::SnapshotReader* reader) {
             }
         }
     }
-    _have_data = true;
+    set_have_data(true);
     return 0;
 }
 

--- a/src/meta_server/meta_state_machine.cpp
+++ b/src/meta_server/meta_state_machine.cpp
@@ -91,8 +91,8 @@ void MetaStateMachine::store_heartbeat(google::protobuf::RpcController* controll
     TableManager::get_instance()->process_ddl_heartbeat_for_store(request, response, log_id);
     int64_t ddlwork_time = step_time_cost.get_time();
 
-    DB_DEBUG("store_heart_beat req[%s]", request->ShortDebugString().c_str());
-    DB_DEBUG("store_heart_beat resp[%s]", response->ShortDebugString().c_str());
+    DB_DEBUG("store_heart_beat req[%s]", request->DebugString().c_str());
+    DB_DEBUG("store_heart_beat resp[%s]", response->DebugString().c_str());
 
     DB_NOTICE("store:%s heart beat, time_cost: %ld, "
                 "instance_time: %ld, peer_balance_time: %ld, schema_time: %ld,"
@@ -415,6 +415,18 @@ void MetaStateMachine::on_apply(braft::Iterator& iter) {
             TableManager::get_instance()->update_statistics(request, iter.index(), done);
             break;
         }
+        case pb::OP_LINK_BINLOG: {
+            TableManager::get_instance()->link_binlog(request, iter.index(), done);
+            break;
+        }
+        case pb::OP_UNLINK_BINLOG: {
+            TableManager::get_instance()->unlink_binlog(request, iter.index(), done);
+            break;
+        }
+        case pb::OP_SET_INDEX_HINT_STATUS: {
+            TableManager::get_instance()->set_index_hint_status(request, iter.index(), done);
+            break;
+        }
         default: {
             DB_FATAL("unsupport request type, type:%d", request.op_type());
             IF_DONE_SET_RESPONSE(done, pb::UNSUPPORT_REQ_TYPE, "unsupport request type");
@@ -572,7 +584,7 @@ int MetaStateMachine::on_snapshot_load(braft::SnapshotReader* reader) {
             }
         }
     }
-    _have_data = true;
+    set_have_data(true);
     return 0;
 }
 

--- a/src/meta_server/tso_state_machine.cpp
+++ b/src/meta_server/tso_state_machine.cpp
@@ -1,0 +1,475 @@
+// Copyright (c) 2018-present Baidu, Inc. All Rights Reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "tso_state_machine.h"
+#include "meta_util.h"
+#include <fstream>
+#include <boost/lexical_cast.hpp>
+#include "rapidjson/rapidjson.h"
+#include "rapidjson/reader.h"
+#include "rapidjson/writer.h"
+#include "rapidjson/document.h"
+#include "rapidjson/stringbuffer.h"
+#include "rapidjson/prettywriter.h" // for stringify JSON
+#ifdef BAIDU_INTERNAL
+#include "raft/util.h"
+#include "raft/storage.h"
+#else
+#include <braft/util.h>
+#include <braft/storage.h>
+#endif
+
+namespace baikaldb {
+DECLARE_int32(election_timeout_ms);
+DECLARE_string(log_uri);
+DECLARE_string(stable_uri);
+DECLARE_string(snapshot_uri);
+DEFINE_int32(tso_snapshot_interval_s, 60, "tso raft snapshot interval(s)");
+
+int TsoTimer::init(TSOStateMachine* node, int timeout_ms) {
+    int ret = RepeatedTimerTask::init(timeout_ms);
+    _node = node;
+    return ret;
+}
+
+void TsoTimer::run() {
+    _node->update_timestamp();
+}
+
+
+const std::string TSOStateMachine::SNAPSHOT_TSO_FILE              = "tso.file";
+const std::string TSOStateMachine::SNAPSHOT_TSO_FILE_WITH_SLASH   = "/" + SNAPSHOT_TSO_FILE;
+
+int TSOStateMachine::init(const std::vector<braft::PeerId>& peers) {
+    _tso_update_timer.init(this, tso::update_timestamp_interval_ms);
+    _tso_obj.current_timestamp.set_physical(0);
+    _tso_obj.current_timestamp.set_logical(0);
+    _tso_obj.last_save_physical = 0;
+    //int ret = CommonStateMachine::init(peers);
+    braft::NodeOptions options;
+    options.election_timeout_ms = FLAGS_election_timeout_ms; 
+    options.fsm = this;                                                               
+    options.initial_conf = braft::Configuration(peers);                                    
+    options.snapshot_interval_s = FLAGS_tso_snapshot_interval_s;
+    options.log_uri = FLAGS_log_uri + std::to_string(_dummy_region_id);
+    //options.stable_uri = FLAGS_stable_uri + "/meta_server";
+#if BAIDU_INTERNAL
+    options.stable_uri = FLAGS_stable_uri + _file_path;                      
+#else
+    options.raft_meta_uri = FLAGS_stable_uri + _file_path;                      
+#endif
+    options.snapshot_uri = FLAGS_snapshot_uri + _file_path;              
+    int ret = _node.init(options);                                                        
+    if (ret < 0) {                                                                    
+        DB_FATAL("raft node init fail");
+        return ret;                
+    }
+    DB_WARNING("raft init success, meat state machine init success");
+    return 0;
+}
+
+void TSOStateMachine::gen_tso(const pb::TsoRequest* request, pb::TsoResponse* response) {
+    int64_t count = request->count();
+    response->set_op_type(request->op_type());
+    if (count == 0) {
+        response->set_errcode(pb::INPUT_PARAM_ERROR);
+        response->set_errmsg("tso count should be positive");
+        return;
+    }
+    if (!_is_healty) {
+        DB_FATAL("TSO has wrong status, retry later");
+        response->set_errcode(pb::RETRY_LATER);
+        response->set_errmsg("timestamp not ok, retry later");
+        return;          
+    }
+    pb::TsoTimestamp current;
+    bool need_retry = false;
+    for (size_t i = 0; i < 50; i++) {
+        {
+            BAIDU_SCOPED_LOCK(_tso_mutex);
+            int64_t physical = _tso_obj.current_timestamp.physical();
+            if (physical != 0) {  
+                int64_t new_logical = _tso_obj.current_timestamp.logical() + count;
+                _tso_obj.current_timestamp.set_logical(new_logical);
+                if (new_logical < tso::max_logical) {
+                    current.CopyFrom(_tso_obj.current_timestamp);
+                    need_retry = false;
+                } else {
+                    DB_WARNING("logical part outside of max logical interval, retry later, please check ntp time");
+                    need_retry = true;
+                }
+            } else {
+                DB_WARNING("timestamp not ok physical == 0, retry later");
+                need_retry = true;
+            }
+        }
+        if (!need_retry) {
+            break;
+        } else {
+            bthread_usleep(tso::update_timestamp_interval_ms * 1000LL);
+        }
+    }
+    if (need_retry) {
+        response->set_errcode(pb::EXEC_FAIL);
+        response->set_errmsg("gen tso failed");
+        DB_FATAL("gen tso failed");
+        return;
+    }
+    //DB_WARNING("gen tso current: (%ld, %ld)", current.physical(), current.logical());
+    auto timestamp = response->mutable_start_timestamp();
+    timestamp->CopyFrom(current);
+    response->set_count(count);
+    response->set_errcode(pb::SUCCESS);
+}
+
+void TSOStateMachine::process(google::protobuf::RpcController* controller,
+                               const pb::TsoRequest* request,
+                               pb::TsoResponse* response,
+                               google::protobuf::Closure* done) {
+    brpc::ClosureGuard done_guard(done);
+    if (request->op_type() == pb::OP_QUERY_TSO_INFO) {
+        response->set_errcode(pb::SUCCESS);
+        response->set_errmsg("success");
+        response->set_op_type(request->op_type());
+        response->set_leader(butil::endpoint2str(_node.leader_id().addr).c_str());
+        response->set_system_time(tso::clock_realtime_ms());
+        response->set_save_physical(_tso_obj.last_save_physical);
+        auto timestamp = response->mutable_start_timestamp();
+        timestamp->CopyFrom(_tso_obj.current_timestamp);
+        return;
+    }
+    brpc::Controller* cntl = (brpc::Controller*)controller;
+    uint64_t log_id = 0;
+    if (cntl->has_log_id()) { 
+        log_id = cntl->log_id();
+    }
+    const auto& remote_side_tmp = butil::endpoint2str(cntl->remote_side());
+    const char* remote_side = remote_side_tmp.c_str();
+    if (!_is_leader) {
+        response->set_errcode(pb::NOT_LEADER);
+        response->set_errmsg("not leader");
+        response->set_op_type(request->op_type());
+        response->set_leader(butil::endpoint2str(_node.leader_id().addr).c_str());
+        DB_WARNING("state machine not leader, request: %s remote_side:%s log_id:%lu",
+            request->ShortDebugString().c_str(), remote_side, log_id);
+        return;
+    }
+    // 获取时间戳在raft外执行
+    if (request->op_type() == pb::OP_GEN_TSO) {
+        gen_tso(request, response);
+        return;
+    }
+    butil::IOBuf data;
+    butil::IOBufAsZeroCopyOutputStream wrapper(&data);
+    if (!request->SerializeToZeroCopyStream(&wrapper)) {
+        cntl->SetFailed(brpc::EREQUEST, "Fail to serialize request");
+        return;
+    }
+    TsoClosure* closure = new TsoClosure;
+    closure->cntl = cntl;
+    closure->response = response;
+    closure->done = done_guard.release();
+    closure->common_state_machine = this;
+    braft::Task task;
+    task.data = &data;
+    task.done = closure;
+    _node.apply(task);
+}
+
+void TSOStateMachine::on_apply(braft::Iterator& iter) {
+    for (; iter.valid(); iter.next()) {
+        braft::Closure* done = iter.done();
+        brpc::ClosureGuard done_guard(done);
+        if (done) {
+            ((TsoClosure*)done)->raft_time_cost = ((TsoClosure*)done)->time_cost.get_time();
+        }
+        butil::IOBufAsZeroCopyInputStream wrapper(iter.data());
+        pb::TsoRequest request;
+        if (!request.ParseFromZeroCopyStream(&wrapper)) {
+            DB_FATAL("parse from protobuf fail when on_apply");
+            if (done) {
+                if (((TsoClosure*)done)->response) {
+                    ((TsoClosure*)done)->response->set_errcode(pb::PARSE_FROM_PB_FAIL);
+                    ((TsoClosure*)done)->response->set_errmsg("parse from protobuf fail");
+                }
+                braft::run_closure_in_bthread(done_guard.release());
+            }
+            continue;
+        }
+        if (done && ((TsoClosure*)done)->response) {
+            ((TsoClosure*)done)->response->set_op_type(request.op_type());
+        }
+        switch (request.op_type()) {
+        case pb::OP_RESET_TSO: {
+            reset_tso(request, done);
+            break;                              
+        }
+        case pb::OP_UPDATE_TSO: {
+            update_tso(request, done);
+            break;
+        }
+        default: {
+            DB_FATAL("unsupport request type, type:%d", request.op_type());
+            IF_DONE_SET_RESPONSE(done, pb::UNSUPPORT_REQ_TYPE, "unsupport request type");
+        }
+        }
+        if (done) {
+            braft::run_closure_in_bthread(done_guard.release());
+        }
+    }
+}
+
+void TSOStateMachine::reset_tso(const pb::TsoRequest& request,
+        braft::Closure* done) {
+    if (request.has_current_timestamp() && request.has_save_physical()) {
+        int64_t physical = request.save_physical();
+        pb::TsoTimestamp current = request.current_timestamp();
+        if (physical < _tso_obj.last_save_physical
+            || current.physical() < _tso_obj.current_timestamp.physical()) {
+            if (!request.force()) {
+                DB_WARNING("time fallback save_physical:(%lld, %lld) current:(%lld, %lld, %lld, %lld)",
+                    physical, _tso_obj.last_save_physical, current.physical(), _tso_obj.current_timestamp.physical(),
+                    current.logical(), _tso_obj.current_timestamp.logical());
+                if (done && ((TsoClosure*)done)->response) {
+                    pb::TsoResponse* response = ((TsoClosure*)done)->response;
+                    response->set_errcode(pb::INTERNAL_ERROR);
+                    response->set_errmsg("time can't fallback");
+                    auto timestamp = response->mutable_start_timestamp();
+                    timestamp->CopyFrom(_tso_obj.current_timestamp);
+                    response->set_save_physical(_tso_obj.last_save_physical);
+                }
+                return;
+            }
+        }
+        _is_healty = true;
+        DB_WARNING("reset tso save_physical: %ld current: (%ld, %ld)", physical, current.physical(), current.logical());
+        {
+            BAIDU_SCOPED_LOCK(_tso_mutex);
+            _tso_obj.last_save_physical = physical;
+            _tso_obj.current_timestamp.CopyFrom(current);
+        }
+        if (done && ((TsoClosure*)done)->response) {
+            pb::TsoResponse* response = ((TsoClosure*)done)->response;
+            response->set_save_physical(physical);
+            auto timestamp = response->mutable_start_timestamp();
+            timestamp->CopyFrom(current);
+            response->set_errcode(pb::SUCCESS);
+            response->set_errmsg("SUCCESS");
+        }      
+    }
+}
+
+void TSOStateMachine::update_tso(const pb::TsoRequest& request,
+        braft::Closure* done) {
+    int64_t physical = request.save_physical();
+    pb::TsoTimestamp current = request.current_timestamp();
+    // 不能回退
+    if (physical < _tso_obj.last_save_physical
+        || current.physical() < _tso_obj.current_timestamp.physical()) {
+            DB_WARNING("time fallback save_physical:(%lld, %lld) current:(%lld, %lld, %lld, %lld)",
+            physical, _tso_obj.last_save_physical, current.physical(), _tso_obj.current_timestamp.physical(),
+            current.logical(), _tso_obj.current_timestamp.logical());
+        if (done && ((TsoClosure*)done)->response) {
+            pb::TsoResponse* response = ((TsoClosure*)done)->response;
+            response->set_errcode(pb::INTERNAL_ERROR);
+            response->set_errmsg("time can't fallback");
+        }
+        return;
+    }
+    {
+        BAIDU_SCOPED_LOCK(_tso_mutex);
+        _tso_obj.last_save_physical = physical;
+        _tso_obj.current_timestamp.CopyFrom(current);
+    }
+
+    if (done && ((TsoClosure*)done)->response) {
+        pb::TsoResponse* response = ((TsoClosure*)done)->response;
+        response->set_errcode(pb::SUCCESS);
+        response->set_errmsg("SUCCESS");
+    }
+}
+
+
+int TSOStateMachine::sync_timestamp(const pb::TsoTimestamp& current_timestamp, int64_t save_physical) {
+    pb::TsoRequest request;
+    pb::TsoResponse response;
+    request.set_op_type(pb::OP_UPDATE_TSO);
+    auto timestamp = request.mutable_current_timestamp();
+    timestamp->CopyFrom(current_timestamp);
+    request.set_save_physical(save_physical);
+    butil::IOBuf data;
+    butil::IOBufAsZeroCopyOutputStream wrapper(&data);
+    if (!request.SerializeToZeroCopyStream(&wrapper)) {
+        DB_WARNING("Fail to serialize request");
+        return -1;
+    }
+    BthreadCond sync_cond;
+    TsoClosure* c = new TsoClosure(&sync_cond);
+    c->response = &response;
+    c->done = nullptr;
+    c->common_state_machine = this;
+    sync_cond.increase();
+    braft::Task task;
+    task.data = &data;
+    task.done = c;
+    _node.apply(task);
+    sync_cond.wait();
+    if (response.errcode() != pb::SUCCESS) {
+        DB_FATAL("sync timestamp failed, request:%s response:%s",
+            request.ShortDebugString().c_str(), response.ShortDebugString().c_str());
+        return -1;
+    }
+    return 0;
+}
+
+void TSOStateMachine::update_timestamp() {
+    if (!_is_leader) {
+        return;
+    }
+    int64_t now = tso::clock_realtime_ms();
+    int64_t prev_physical = 0;
+    int64_t prev_logical = 0;
+    int64_t last_save = 0;
+    {
+        BAIDU_SCOPED_LOCK(_tso_mutex);
+        prev_physical = _tso_obj.current_timestamp.physical();
+        prev_logical  = _tso_obj.current_timestamp.logical();
+        last_save     = _tso_obj.last_save_physical;
+    }
+    int64_t delta = now - prev_physical;
+    if (delta < 0) {
+        DB_WARNING("physical time slow now:%lld prev:%lld", now, prev_physical);
+    }
+    int64_t next = now;
+    if (delta > tso::update_timestamp_guard_ms) {
+        next = now;
+    } else if (prev_logical > tso::max_logical / 2) {
+        next = now + tso::update_timestamp_guard_ms;
+    } else {
+        DB_WARNING("don't need update timestamp prev:%ld now:%ld save:%ld", prev_physical, now, last_save);
+        return;
+    }
+    int64_t save = last_save;
+    if (save - next <= tso::update_timestamp_guard_ms) {
+        save =  next + tso::save_interval_ms;
+    }
+    pb::TsoTimestamp tp;
+    tp.set_physical(next);
+    tp.set_logical(0);
+    sync_timestamp(tp, save);
+}
+
+void TSOStateMachine::on_leader_start() {
+    start_check_bns();
+    DB_WARNING("tso leader start");
+    int64_t now = tso::clock_realtime_ms();
+    pb::TsoTimestamp current;
+    current.set_physical(now);
+    current.set_logical(0);
+    int64_t last_save = _tso_obj.last_save_physical;
+    if (last_save - now < tso::update_timestamp_interval_ms) {
+        current.set_physical(last_save + tso::update_timestamp_guard_ms);
+        last_save = now + tso::save_interval_ms;
+    }
+    auto func = [this, last_save, current]() {
+        DB_WARNING("leader_start current(phy:%ld,log:%ld) save:%ld", current.physical(),
+        current.logical(), last_save);
+        int ret = sync_timestamp(current, last_save);
+        if (ret < 0) {
+            _is_healty = false;
+        }
+        DB_WARNING("sync timestamp ok");
+        _is_leader.store(true);
+        _tso_update_timer.start();
+    };
+    Bthread bth;
+    bth.run(func);
+}
+
+void TSOStateMachine::on_leader_stop() {
+    _tso_update_timer.stop();
+    DB_WARNING("leader stop");
+    CommonStateMachine::on_leader_stop();
+}
+
+void TSOStateMachine::on_snapshot_save(braft::SnapshotWriter* writer, braft::Closure* done) {
+    DB_WARNING("start on shnapshot save");
+    std::string sto_str = std::to_string(_tso_obj.last_save_physical);
+    Bthread bth(&BTHREAD_ATTR_SMALL);
+    std::function<void()> save_snapshot_function = [this, done, writer, sto_str]() {
+            save_snapshot(done, writer, sto_str);
+        };
+    bth.run(save_snapshot_function);
+}
+
+void TSOStateMachine::save_snapshot(braft::Closure* done,
+                                    braft::SnapshotWriter* writer,
+                                    std::string sto_str) {
+    brpc::ClosureGuard done_guard(done);
+    std::string snapshot_path = writer->get_path();
+    std::string save_path = snapshot_path + SNAPSHOT_TSO_FILE_WITH_SLASH;
+    std::ofstream extra_fs(save_path,
+            std::ofstream::out | std::ofstream::trunc);
+    extra_fs.write(sto_str.data(), sto_str.size());
+    extra_fs.close();
+    if (writer->add_file(SNAPSHOT_TSO_FILE_WITH_SLASH) != 0) {
+        done->status().set_error(EINVAL, "Fail to add file");
+        DB_WARNING("Error while adding file to writer");
+        return;
+    }
+    DB_WARNING("save physical string:%s when snapshot", sto_str.c_str());
+}
+
+int TSOStateMachine::on_snapshot_load(braft::SnapshotReader* reader) {
+    DB_WARNING("start on shnapshot load");
+    std::vector<std::string> files;
+    reader->list_files(&files);
+    for (auto& file : files) {
+        DB_WARNING("snapshot load file:%s", file.c_str());
+        if (file == SNAPSHOT_TSO_FILE_WITH_SLASH) {
+            std::string tso_file = reader->get_path() + SNAPSHOT_TSO_FILE_WITH_SLASH;
+            if (load_tso(tso_file) != 0) {
+                DB_WARNING("load tso fail");
+                return -1;
+            }
+            break;
+        }
+    }
+    set_have_data(true);
+    return 0;
+}
+
+int TSOStateMachine::load_tso(const std::string& tso_file) {
+    std::ifstream extra_fs(tso_file);
+    std::string extra((std::istreambuf_iterator<char>(extra_fs)),
+            std::istreambuf_iterator<char>());
+    try {
+        _tso_obj.last_save_physical = std::stol(extra);
+    } catch (std::invalid_argument&){
+        DB_WARNING("Invalid_argument: %s", extra);
+        return -1;
+    }
+    catch (std::out_of_range&){
+        DB_WARNING("Out of range: %s", extra);
+        return -1;
+    }
+    catch (...) {
+        DB_WARNING("error happen: %s", extra);
+        return -1;
+    }
+    return 0;
+}
+
+}//namespace
+/* vim: set expandtab ts=4 sw=4 sts=4 tw=100: */

--- a/src/physical_plan/index_selector.cpp
+++ b/src/physical_plan/index_selector.cpp
@@ -450,6 +450,11 @@ int64_t IndexSelector::index_selector(const std::vector<pb::TupleDescriptor>& tu
         if (info_ptr == nullptr) {
             continue;
         }
+
+        if (info_ptr->index_hint_status == pb::IHS_DISABLE) {
+            DB_DEBUG("index[%s] is disabled", info_ptr->name.c_str());
+            continue;
+        }
         IndexInfo& index_info = *info_ptr;
         pb::IndexType index_type = index_info.type;
         auto index_state = index_info.state;

--- a/src/physical_plan/physical_planner.cpp
+++ b/src/physical_plan/physical_planner.cpp
@@ -31,6 +31,12 @@ int PhysicalPlanner::analyze(QueryContext* ctx) {
     if (ret < 0) {
         return ret;
     }
+
+    ret = PartitionAnalyze().analyze(ctx);
+    if (ret < 0) {
+        return ret;
+    }
+    
     // for INSERT/REPLACE statements
     // insert user variables to records for prepared stmt
     ret = insert_values_to_record(ctx);

--- a/src/protocol/main.cpp
+++ b/src/protocol/main.cpp
@@ -69,6 +69,10 @@ int main(int argc, char **argv) {
         DB_FATAL("auto incr meta server interact init failed");
         return -1;
     }
+    if (baikaldb::TsoFetcher::init_meta_inter() != 0) {
+        DB_FATAL("tso meta server interact init failed");
+        return -1;
+    }
     // Initail server.
     baikaldb::NetworkServer* server = baikaldb::NetworkServer::get_instance();
     if (!server->init()) {

--- a/src/protocol/state_machine.cpp
+++ b/src/protocol/state_machine.cpp
@@ -339,9 +339,6 @@ void StateMachine::_print_query_time(SmartSocket client) {
             stat_info->send_stamp, stat_info->end_stamp);
     stat_info->total_time = timestamp_diff(
             stat_info->start_stamp, stat_info->end_stamp);
-    if (client->state == STATE_ERROR || client->state == STATE_ERROR_REUSE) {
-        return;
-    }
     PacketNode* root = (PacketNode*)(ctx->root);
     int rows = 0;
     pb::OpType op_type = pb::OP_NONE;
@@ -351,17 +348,19 @@ void StateMachine::_print_query_time(SmartSocket client) {
             stat_info->num_returned_rows : stat_info->num_affected_rows;
     }
 
-    int64_t index_id = 0; //0 没有使用索引，否则选index_ids中的第一个，对于join涉及多个索引可能展示不完整 TODO
-    if (ctx->index_ids.size() > 1) {
-        index_id = *ctx->index_ids.begin();
-    } else if (ctx->index_ids.size() == 1) {
-        index_id = *ctx->index_ids.begin();
-        index_recommend_st << BvarMap(stat_info->sample_sql.str(), index_id, stat_info->table_id, stat_info->total_time, 
-                            rows, stat_info->num_scan_rows, stat_info->num_filter_rows, ctx->field_range_type);
+    if (client->state != STATE_ERROR && client->state != STATE_ERROR_REUSE) {
+        int64_t index_id = 0; //0 没有使用索引，否则选index_ids中的第一个，对于join涉及多个索引可能展示不完整 TODO
+        if (ctx->index_ids.size() > 1) {
+            index_id = *ctx->index_ids.begin();
+        } else if (ctx->index_ids.size() == 1) {
+            index_id = *ctx->index_ids.begin();
+            index_recommend_st << BvarMap(stat_info->sample_sql.str(), index_id, stat_info->table_id, stat_info->total_time, 
+                                rows, stat_info->num_scan_rows, stat_info->num_filter_rows, ctx->field_range_type);
+        }
+        std::map<int32_t, int> field_range_type;
+        sql_agg_cost << BvarMap(stat_info->sample_sql.str(), index_id, stat_info->table_id, stat_info->total_time, 
+                                rows, stat_info->num_scan_rows, stat_info->num_filter_rows, field_range_type);
     }
-    std::map<int32_t, int> field_range_type;
-    sql_agg_cost << BvarMap(stat_info->sample_sql.str(), index_id, stat_info->table_id, stat_info->total_time, 
-                            rows, stat_info->num_scan_rows, stat_info->num_filter_rows, field_range_type);
 
     if (ctx->mysql_cmd == COM_QUERY
                 || ctx->mysql_cmd == COM_STMT_EXECUTE) {
@@ -390,7 +389,9 @@ void StateMachine::_print_query_time(SmartSocket client) {
             stat_info->table = "no";
         }
 #ifdef BAIDU_INTERNAL
-        if ((stat_info->family != "no" && stat_info->table != "no") || stat_info->error_code != 1000) {
+        if (FLAGS_log_plat_name == "test" || 
+                (stat_info->family != "no" && stat_info->table != "no") || 
+                stat_info->error_code != 1000) {
 #else
         if (stat_info->total_time > FLAGS_print_time_us || stat_info->error_code != 1000) {
 #endif
@@ -1000,6 +1001,8 @@ bool StateMachine::_query_process(SmartSocket client) {
                 ret = _handle_client_query_show_table_status(client);
             } else if (boost::istarts_with(client->query_ctx->sql, SQL_SHOW_ABNORMAL_REGIONS)) {
                 ret = _handle_client_query_show_abnormal_regions(client);
+            } else if (boost::istarts_with(client->query_ctx->sql, SQL_SHOW_COST)) {
+                ret = _handle_client_query_show_cost(client);
             } else if (boost::iequals(client->query_ctx->sql, SQL_SHOW_COLLATION)) {
                 ret = _handle_client_query_show_collation(client);
             } else if (boost::iequals(client->query_ctx->sql, SQL_SHOW_WARNINGS)) {
@@ -1441,6 +1444,9 @@ bool StateMachine::_handle_client_query_show_create_table(SmartSocket client) {
     int64_t table_id = -1;
     if (factory->get_table_id(full_name, table_id) != 0) {
         client->state = STATE_ERROR;
+        client->query_ctx->stat_info.error_code = ER_NO_SUCH_TABLE;
+        client->query_ctx->stat_info.error_msg << "Table '" << db << "." 
+                                    << table << "' not exist";
         return false;
     }
     // Make rows.
@@ -1518,7 +1524,8 @@ bool StateMachine::_handle_client_query_show_create_table(SmartSocket client) {
     static std::map<pb::Engine, std::string> engine_map = {
         {pb::ROCKSDB, "Rocksdb"},
         {pb::REDIS, "Redis"},
-        {pb::ROCKSDB_CSTORE, "Rocksdb_cstore"}
+        {pb::ROCKSDB_CSTORE, "Rocksdb_cstore"},
+        {pb::BINLOG, "Binlog"}
     };
     oss << ") ENGINE=" << engine_map[info.engine];
     oss << " DEFAULT CHARSET=" << charset_map[info.charset];
@@ -1542,6 +1549,15 @@ bool StateMachine::_handle_client_query_show_create_table(SmartSocket client) {
     }
     if (info.ttl_duration > 0) {
         oss << ", \"ttl_duration\":" << info.ttl_duration;
+    }
+    
+    if (info.partition_num > 1) {
+        oss << ", \"column\":\"" << info.partition_info.field_info().field_name() << "\"";
+        oss << ", \"partition_type\":\"" << pb::PartitionType_Name(info.partition_info.type()).c_str() << "\"";
+        oss << ", \"partition_num\":" << info.partition_num;
+        if (info.partition_ptr != nullptr) {
+            oss << ", " + info.partition_ptr->to_str();
+        }
     }
     oss << ", \"namespace\":\"" << info.namespace_ << "\"}'";
     row.push_back(oss.str());
@@ -1954,7 +1970,7 @@ bool StateMachine::_handle_client_query_show_abnormal_regions(SmartSocket client
             row.push_back("unhealthy");
         }
         for (auto& peer_info : region_info.peer_status_infos()) {
-            row.push_back(peer_info.peer_id() + ":" + pb::PeerStatus_Name(peer_info.peer_status()));
+            row.push_back(peer_info.peer_id() + "@" + pb::PeerStatus_Name(peer_info.peer_status()));
         }
         if (max_size < row.size()) {
             max_size = row.size();
@@ -1974,6 +1990,61 @@ bool StateMachine::_handle_client_query_show_abnormal_regions(SmartSocket client
     for (int i = 1; i <= max_size - 4; i++) {
         names.push_back("peer" + std::to_string(i));
     }
+
+    std::vector<ResultField> fields;
+    for (auto& name : names) {
+        ResultField field;
+        field.name = name;
+        field.type = MYSQL_TYPE_STRING;
+        fields.push_back(field);
+    }
+    // Make mysql packet.
+    if (_make_common_resultset_packet(client, fields, rows) != 0) {
+        DB_FATAL_CLIENT(client, "Failed to make result packet.");
+        _wrapper->make_err_packet(client, ER_MAKE_RESULT_PACKET, "Failed to make result packet.");
+        client->state = STATE_ERROR;
+        return false;
+    }
+    client->state = STATE_READ_QUERY_RESULT;
+    return true;
+}
+bool StateMachine::_handle_client_query_show_cost(SmartSocket client) {
+    if (client == nullptr || client->query_ctx == nullptr) {
+        DB_FATAL("param invalid");
+        //client->state = STATE_ERROR;
+        return false;
+    }
+    
+    std::vector<std::string> split_vec;
+    boost::split(split_vec, client->query_ctx->sql,
+            boost::is_any_of(" \t\n\r"), boost::token_compress_on);
+    if (split_vec.size() != 3) {
+        client->state = STATE_ERROR;
+        return false;
+    }
+
+    std::vector<std::string> database_table;
+    SchemaFactory* factory = SchemaFactory::get_instance();
+    if (split_vec[2] == "switch") {
+        factory->get_cost_switch_open(database_table);
+    } else {
+        factory->table_with_statistics_info(database_table);
+    }
+    DB_WARNING("show cost");
+    std::vector< std::vector<std::string> > rows;
+    for (auto& d_t_name : database_table) {
+        DB_WARNING("%s", d_t_name.c_str());
+        std::vector<std::string> split_vec;
+        boost::split(split_vec, d_t_name,
+            boost::is_any_of("."), boost::token_compress_on);
+        if (split_vec.size() !=3 ) {
+            DB_FATAL("databae table name:%s", d_t_name.c_str());
+            continue;
+        }
+        rows.push_back(split_vec);
+    }
+
+    std::vector<std::string> names = { "name_space", "database_name", "table_name" };
 
     std::vector<ResultField> fields;
     for (auto& name : names) {

--- a/src/protocol/state_machine.cpp
+++ b/src/protocol/state_machine.cpp
@@ -26,6 +26,7 @@ DEFINE_int32(max_connections_per_user, 4000, "default user max connections");
 DEFINE_int32(query_quota_per_user, 3000, "default user query quota by 1 second");
 DEFINE_string(log_plat_name, "test", "plat name for print log, distinguish monitor");
 DECLARE_int64(print_time_us);
+DECLARE_string(meta_server_bns);
 
 void StateMachine::run_machine(SmartSocket client,
         EpollInfo* epoll_info,
@@ -1017,6 +1018,12 @@ bool StateMachine::_query_process(SmartSocket client) {
                         && boost::algorithm::istarts_with(
                                 client->query_ctx->sql, SQL_SHOW_VARIABLES)) {
                 ret = _handle_client_query_show_variables(client);
+            } else if (boost::istarts_with(client->query_ctx->sql, SQL_SHOW_META)) {
+                ret = _handle_client_query_template(client, "Meta", 
+                    MYSQL_TYPE_VARCHAR, FLAGS_meta_server_bns);
+            } else if (boost::istarts_with(client->query_ctx->sql, SQL_SHOW_NAMESPACE)) {
+                ret = _handle_client_query_template(client, "Namespace", MYSQL_TYPE_VARCHAR,
+                    client->user_info->namespace_);
             } else {
                 _wrapper->make_simple_ok_packet(client);
                 client->state = STATE_READ_QUERY_RESULT;

--- a/src/raft/log_entry_reader.cpp
+++ b/src/raft/log_entry_reader.cpp
@@ -62,6 +62,7 @@ int LogEntryReader::read_log_entry(int64_t region_id, int64_t start_log_index, i
     options.iterate_upper_bound = &upper_bound_slice;
     options.prefix_same_as_start = true;
     options.total_order_seek = false;
+    options.fill_cache = false;
     std::unique_ptr<rocksdb::Iterator> iter(_rocksdb->new_iterator(options, _log_cf));
     iter->Seek(log_data_key.data());
     for (; iter->Valid(); iter->Next()) {
@@ -91,7 +92,6 @@ int LogEntryReader::read_log_entry(int64_t region_id, int64_t start_log_index, i
             && store_req.op_type() != pb::OP_DELETE
             && store_req.op_type() != pb::OP_UPDATE
             && store_req.op_type() != pb::OP_PREPARE
-            && store_req.op_type() != pb::OP_PREPARE_V2
             && store_req.op_type() != pb::OP_ROLLBACK
             && store_req.op_type() != pb::OP_COMMIT) {
             //DB_WARNING("log entry is not txn, region_id: %ld head.type: %d", region_id, store_req.op_type());
@@ -129,6 +129,7 @@ int LogEntryReader::read_txn_last_log_entry(int64_t region_id, int64_t start_log
     options.iterate_upper_bound = &upper_bound_slice;
     options.prefix_same_as_start = true;
     options.total_order_seek = false;
+    options.fill_cache = false;
     std::map<int64_t, uint64_t> log_index_txn_map;
     std::unique_ptr<rocksdb::Iterator> iter(_rocksdb->new_iterator(options, _log_cf));
     iter->Seek(log_data_key.data());
@@ -159,7 +160,6 @@ int LogEntryReader::read_txn_last_log_entry(int64_t region_id, int64_t start_log
             && store_req.op_type() != pb::OP_DELETE
             && store_req.op_type() != pb::OP_UPDATE
             && store_req.op_type() != pb::OP_PREPARE
-            && store_req.op_type() != pb::OP_PREPARE_V2
             && store_req.op_type() != pb::OP_ROLLBACK
             && store_req.op_type() != pb::OP_COMMIT) {
             //DB_WARNING("log entry is not txn, region_id: %ld head.type: %d", region_id, store_req.op_type());

--- a/src/raft/my_raft_log.cpp
+++ b/src/raft/my_raft_log.cpp
@@ -23,12 +23,14 @@ static pthread_once_t g_register_once = PTHREAD_ONCE_INIT;
 
 struct MyRaftExtension {
     MyRaftLogStorage my_raft_log_storage;
+    MyRaftLogStorage my_bin_log_storage;
     MyRaftMetaStorage my_raft_meta_storage;
 };
 
 static void register_once_or_die() {
     static MyRaftExtension* s_ext = new MyRaftExtension;
     braft::log_storage_extension()->RegisterOrDie("myraftlog", &s_ext->my_raft_log_storage);
+    braft::log_storage_extension()->RegisterOrDie("mybinlog", &s_ext->my_bin_log_storage);
 #ifdef BAIDU_INTERNAL
     braft::stable_storage_extension()->RegisterOrDie("myraftmeta", &s_ext->my_raft_meta_storage);
 #else

--- a/src/reverse/reverse_common.cpp
+++ b/src/reverse/reverse_common.cpp
@@ -190,17 +190,13 @@ int Tokenizer::simple_seg_gbk(std::string word, uint32_t word_count, std::map<st
     while (fast_pos < word.size()) {
         if ((word[slow_pos] & 0x80) != 0) {
             slow_pos++;
-        } else {
-            if (isupper(word[slow_pos])) {
-                word[slow_pos] = ::tolower(word[slow_pos]);
-            }
         }
         slow_pos++;
         if ((word[fast_pos] & 0x80) != 0) {
             fast_pos++;
         } else {
-            if (isupper(word[slow_pos])) {
-                word[slow_pos] = ::tolower(word[slow_pos]);
+            if (isupper(word[fast_pos])) {
+                word[fast_pos] = ::tolower(word[fast_pos]);
             }
         }
         fast_pos++;

--- a/src/session/binlog_context.cpp
+++ b/src/session/binlog_context.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2020-present Baidu, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "binlog_context.h"
+#include "meta_server_interact.hpp"
+
+namespace baikaldb {
+
+MetaServerInteract TsoFetcher::tso_meta_inter;
+int64_t TsoFetcher::get_tso() {
+    pb::TsoRequest request;
+    request.set_op_type(pb::OP_GEN_TSO);
+    request.set_count(1);
+    pb::TsoResponse response;
+    int retry_time = 0;
+    int ret = 0;
+    for (;;) {
+        retry_time++;
+        ret = TsoFetcher::tso_meta_inter.send_request("tso_service", request, response);
+        if (ret < 0) {
+            if (response.errcode() == pb::RETRY_LATER && retry_time < 5) {
+                bthread_usleep(tso::update_timestamp_interval_ms * 1000LL);
+                continue;  
+            } else {
+                DB_FATAL("get tso failed, response:%s", response.ShortDebugString().c_str());
+                return ret;
+            }
+        }
+        break;
+    }
+    //DB_WARNING("response:%s", response.ShortDebugString().c_str());
+    auto&  tso = response.start_timestamp();
+    int64_t timestamp = (tso.physical() << tso::logical_bits) + tso.logical();
+
+    return timestamp;
+}
+
+int BinlogContext::get_binlog_regions(uint64_t log_id) {
+    if (_table_info == nullptr || _partition_record == nullptr) {
+        DB_WARNING("wrong state log_id:%lu", log_id);
+        return -1;
+    }
+    if (!_table_info->is_linked || _table_info->link_field.empty()) {
+        DB_WARNING("table %ld not link to binlog table log_id:%lu", _table_info->id, log_id);
+        return -1;      
+    }
+    FieldInfo& link_filed = _table_info->link_field[0];
+
+    auto field_desc = _partition_record->get_field_by_idx(link_filed.pb_idx);
+    ExprValue value = _partition_record->get_value(field_desc);
+    int ret = _factory->get_binlog_regions(_table_info->id, value, _binlog_region);
+    if (ret < 0) {
+        DB_WARNING("get binlog region failed table_id: %ld value: %s log_id:%lu",
+            _table_info->id, value.get_string().c_str(), log_id);
+        return -1;
+    }
+    return 0;
+}
+
+} // namespace baikaldb

--- a/src/store/region.cpp
+++ b/src/store/region.cpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <fstream>
 #include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
 #include "table_key.h"
 #include "runtime_state.h"
 #include "mem_row_descriptor.h"
@@ -51,7 +52,8 @@ namespace baikaldb {
 DEFINE_int32(election_timeout_ms, 1000, "raft election timeout(ms)");
 DEFINE_int32(skew, 5, "split skew, default : 45% - 55%");
 DEFINE_int32(reverse_level2_len, 5000, "reverse index level2 length, default : 5000");
-DEFINE_string(log_uri, "myraftlog://my_raft_log?id=", "raft log uri");
+DEFINE_string(raftlog_uri, "myraftlog://my_raft_log?id=", "raft log uri");
+DEFINE_string(binlog_uri, "mybinlog://my_bin_log?id=", "bin log uri");
 //不兼容配置，默认用写到rocksdb的信息; raft自带的local://./raft_data/stable/region_
 DEFINE_string(stable_uri, "myraftmeta://my_raft_meta?id=", "raft stable path");
 DEFINE_string(snapshot_uri, "local://./raft_data/snapshot", "raft snapshot path");
@@ -67,8 +69,13 @@ DEFINE_int64(snapshot_log_exec_time_s, 60, "save_snapshot when log entries apply
 //分裂判断标准，如果3600S没有收到请求，则认为分裂失败
 DEFINE_int64(split_duration_us, 3600 * 1000 * 1000LL, "split duration time : 3600s");
 DEFINE_int64(compact_delete_lines, 200000, "compact when _num_delete_lines > compact_delete_lines");
+DECLARE_string(db_path);
 DECLARE_int64(print_time_us);
+DECLARE_int64(store_heart_beat_interval_us);
+DECLARE_int64(min_split_lines);
+DECLARE_bool(use_approximate_size_to_split);
 //const size_t  Region::REGION_MIN_KEY_SIZE = sizeof(int64_t) * 2 + sizeof(uint8_t);
+DEFINE_int64(schema_update_timed_wait, 3 * 1000 * 1000LL, "schema update timed wait default 3S");
 const uint8_t Region::PRIMARY_INDEX_FLAG = 0x01;                                   
 const uint8_t Region::SECOND_INDEX_FLAG = 0x02;
 const int BATCH_COUNT = 1024;
@@ -99,6 +106,13 @@ int Region::init(bool new_region, int32_t snapshot_times) {
     ON_SCOPE_EXIT([this]() {
         _can_heartbeat = true;
     });
+    MutTableKey start;
+    MutTableKey end;
+    start.append_i64(_region_id);
+    end.append_i64(_region_id);
+    end.append_u64(UINT64_MAX);
+    _rocksdb_start = start.data();
+    _rocksdb_end = end.data();
 
     _backup.set_info(get_ptr(), _region_id);
     _data_cf = _rocksdb->get_data_handle();
@@ -134,12 +148,19 @@ int Region::init(bool new_region, int32_t snapshot_times) {
         _report_peer_info = true;
     }
     if (!_is_global_index) {
+        // 处理schema 更新不及时，导致初始化region失败。 重试 3S。
+        TimeCost tc;
         auto table_info = _factory->get_table_info(_region_info.table_id());
-        if (table_info.id == -1) {
-            DB_WARNING("tableinfo get fail, table_id:%ld, region_id: %ld", 
-                        _region_info.table_id(), _region_id);
-            return -1;
+        while (table_info.id == -1) {
+            if (tc.get_time() > FLAGS_schema_update_timed_wait) {
+                DB_WARNING("tableinfo get fail, table_id:%ld, region_id: %ld", 
+                            _region_info.table_id(), _region_id);
+                return -1;
+            }
+            bthread_usleep(50 * 1000);
+            table_info = _factory->get_table_info(_region_info.table_id());
         }
+        
         for (int64_t index_id : table_info.indices) {
             IndexInfo info = _factory->get_index_info(index_id);
             if (info.id == -1) {
@@ -228,8 +249,13 @@ int Region::init(bool new_region, int32_t snapshot_times) {
     options.initial_conf = braft::Configuration(peers);
     options.snapshot_interval_s = 0;
     //options.snapshot_interval_s = FLAGS_snapshot_interval_s; // 禁止raft自动触发snapshot
-    options.log_uri = FLAGS_log_uri + 
-                       boost::lexical_cast<std::string>(_region_id);  
+    if (!_is_binlog_region) {
+        options.log_uri = FLAGS_raftlog_uri + 
+                        boost::lexical_cast<std::string>(_region_id);  
+    } else {
+        options.log_uri = FLAGS_binlog_uri + 
+                        boost::lexical_cast<std::string>(_region_id);  
+    }
 #if BAIDU_INTERNAL
     options.stable_uri = FLAGS_stable_uri + 
                            boost::lexical_cast<std::string>(_region_id);
@@ -258,16 +284,24 @@ int Region::init(bool new_region, int32_t snapshot_times) {
     }
     _time_cost.reset();
     while (snapshot_times > 0) {
+        // init的region会马上选主，等一会为leader
+        bthread_usleep(1 * 1000 * 1000LL);
         _region_control.sync_do_snapshot();
         --snapshot_times;
     }
     copy_region(&_resource->region_info);
     _resource->ddl_param_ptr = &_ddl_param;
     //compaction时候删掉多余的数据
-    SplitCompactionFilter::get_instance()->set_range_key(
-            _region_id,
-            _resource->region_info.start_key(),
-            _resource->region_info.end_key());
+    if (_is_binlog_region) {
+        //binlog region把start key和end key设置为空，防止filter把数据删掉
+        SplitCompactionFilter::get_instance()->set_range_key(
+                _region_id, "", "");
+    } else {
+        SplitCompactionFilter::get_instance()->set_range_key(
+                _region_id,
+                _resource->region_info.start_key(),
+                _resource->region_info.end_key());
+    }
     DB_WARNING("region_id: %ld init success, region_info:%s, time_cost:%ld", 
                 _region_id, _resource->region_info.ShortDebugString().c_str(), 
                 time_cost.get_time());
@@ -362,20 +396,6 @@ bool Region::validate_version(const pb::StoreReq* request, pb::StoreRes* respons
                 }
             }
         }
-        // 不执行rollback，分裂的新region会进行日志重放恢复事务状态
-        pb::OpType op_type = request->op_type();
-        if (op_type == pb::OP_PREPARE || op_type == pb::OP_PREPARE_V2) {
-            const pb::TransactionInfo& txn_info = request->txn_infos(0);
-            uint64_t txn_id = txn_info.txn_id();
-            auto txn = _txn_pool.get_txn(txn_id);
-            // 兼容老版本
-            if (txn != nullptr && !txn->primary_region_id_seted()) {
-                _txn_pool.on_leader_stop_rollback(txn_id);
-                response->set_last_seq_id(0);
-                DB_WARNING("when prepare, old version, txn rollback. region_id: %ld, txn_id: %lu",
-                _region_info.region_id(), txn_id);
-            }
-        }
         return false;
     }
     return true;
@@ -383,7 +403,7 @@ bool Region::validate_version(const pb::StoreReq* request, pb::StoreRes* respons
 
 int Region::execute_cached_cmd(const pb::StoreReq& request, pb::StoreRes& response, 
         uint64_t txn_id, SmartTransaction& txn, int64_t applied_index, int64_t term, uint64_t log_id) {
-    if (request.op_type() == pb::OP_ROLLBACK || request.txn_infos_size() == 0) {
+    if (request.txn_infos_size() == 0) {
         return 0;
     }
     const pb::TransactionInfo& txn_info = request.txn_infos(0);
@@ -547,6 +567,20 @@ void Region::exec_txn_query_primary_region(google::protobuf::RpcController* cont
                 txn_res->set_txn_state(pb::TXN_BEGINED);
                 return;
             }
+            if (txn_info.has_open_binlog() && txn_info.open_binlog()) {
+                int64_t commit_ts = get_commit_ts(txn_id, txn_info.start_ts());
+                if (commit_ts == -1) {
+                    commit_ts = Store::get_instance()->get_last_commit_ts();    
+                    if (commit_ts < 0) {
+                        response->set_errcode(pb::INPUT_PARAM_ERROR);
+                        response->set_errmsg("get tso failed");
+                        return;
+                    }
+                    DB_WARNING("txn_id:%lu region_id:%ld not found commit_ts in store, need get tso from meta ts:%ld",
+                        txn_id, _region_id, commit_ts);
+                }
+                txn_res->set_commit_ts(commit_ts);
+            }
             // secondary执行COMMIT
             response->set_errcode(pb::SUCCESS);
             txn_res->set_txn_state(pb::TXN_COMMITTED);
@@ -573,24 +607,21 @@ void Region::exec_in_txn_query(google::protobuf::RpcController* controller,
     pb::OpType op_type = request->op_type();
     const pb::TransactionInfo& txn_info = request->txn_infos(0);
     uint64_t txn_id = txn_info.txn_id();
-    int64_t primary_region_id = txn_info.has_primary_region_id() ? txn_info.primary_region_id() : -1;
     int seq_id = txn_info.seq_id();
     SmartTransaction txn = _txn_pool.get_txn(txn_id);
     // seq_id within a transaction should be continuous regardless of failure or success
     int last_seq = (txn == nullptr)? 0 : txn->seq_id();
 
     if (txn == nullptr) {
-        if (primary_region_id == _region_id) {
-            ret = _meta_writer->read_transcation_rollbacked_tag(_region_id, txn_id);
-            if (ret == 0) {
-                //查询meta存在说明已经ROLLBACK，baikaldb直接返回成功
-                DB_FATAL("TransactionError: txn has been rollbacked, remote_side:%s, "
-                    "region_id: %ld, txn_id: %lu, log_id:%lu op_type: %s",
-                remote_side, _region_id, txn_id, log_id, pb::OpType_Name(op_type).c_str());
-                response->set_errcode(pb::SUCCESS);
-                response->set_affected_rows(0);
-                return;
-            }
+        ret = _meta_writer->read_transcation_rollbacked_tag(_region_id, txn_id);
+        if (ret == 0) {
+            //查询meta存在说明已经ROLLBACK，baikaldb直接返回TXN_IS_ROLLBACK错误码
+            DB_FATAL("TransactionError: txn has been rollbacked due to timeout, remote_side:%s, "
+                "region_id: %ld, txn_id: %lu, log_id:%lu op_type: %s",
+            remote_side, _region_id, txn_id, log_id, pb::OpType_Name(op_type).c_str());
+            response->set_errcode(pb::TXN_IS_ROLLBACK);
+            response->set_affected_rows(0);
+            return;
         }
         // 事务幂等处理
         // 拦截事务结束后由于core，切主，超时等原因导致的事务重发
@@ -603,33 +634,37 @@ void Region::exec_in_txn_query(google::protobuf::RpcController* controller,
             response->set_errcode(pb::SUCCESS);
             return;
         }
-        //事务流程中，如果ROLLBACK COMMIT指令遇到txn为 nullptr，说明事务已经完成，此处控制ROLLBACK COMMIT重发
-        // 可能第一条语句就执行失败，导致没有创建事务，baikaldb会发送ROLLBACK
-        // 处理raft false negitive可能会导致ROLLBACK COMMIT重发
-        if (op_type == pb::OP_ROLLBACK || op_type == pb::OP_COMMIT) {
-            DB_FATAL("TransactionNote: no txn handler when commit/rollback, "
-                    "region_id: %ld, txn_id: %lu, log_id:%lu op_type: %s, remote_side:%s", 
-                _region_id, txn_id, log_id, pb::OpType_Name(op_type).c_str(), remote_side);
-            response->set_affected_rows(0);
-            response->set_errcode(pb::SUCCESS);
-            return;
-        }
-    } else if (last_seq >= seq_id) {
+    } else if (txn_info.start_seq_id() != 1 && last_seq >= seq_id) {
         // 事务幂等处理，多线程等原因，并不完美
         // 拦截事务过程中由于超时导致的事务重发
         // leader切换会重放最后一条DML
         DB_WARNING("TransactionWarning: txn has exec before, remote_side:%s "
-                "region_id: %ld, txn_id: %lu, op_type: %s, last_seq:%d, seq_id:%d log_id:%lu", 
+                "region_id: %ld, txn_id: %lu, op_type: %s, last_seq:%d, seq_id:%d log_id:%lu",
             remote_side, _region_id, txn_id, pb::OpType_Name(op_type).c_str(), last_seq, seq_id, log_id);
         response->set_affected_rows(txn->dml_num_affected_rows);
         response->set_errcode(txn->err_code);
         return;
     }
+    
+    if (txn != nullptr) {
+        if(txn_info.has_from_store() && txn_info.from_store() && !txn->is_finished() && txn->in_process()
+            && (op_type == pb::OP_ROLLBACK || op_type == pb::OP_COMMIT)) {
+            DB_WARNING("TransactionNote: txn in process when commit/rollback, remote_side:%s "
+                    "region_id: %ld, txn_id: %lu, op_type: %s log_id:%lu",
+                    remote_side, _region_id, txn_id, pb::OpType_Name(op_type).c_str(), log_id);
+            response->set_affected_rows(0);
+            response->set_errcode(pb::IN_PROCESS);
+            return;
+        }
+        txn->set_in_process(true);
+    }
     // read-only事务不提交raft log，直接prepare/commit/rollback
-    if (op_type == pb::OP_ROLLBACK || op_type == pb::OP_COMMIT || op_type == pb::OP_PREPARE) {
+    if (txn_info.start_seq_id() != 1 && !txn_info.has_from_store() &&
+        (op_type == pb::OP_ROLLBACK || op_type == pb::OP_COMMIT || op_type == pb::OP_PREPARE)) {
         if (txn != nullptr && !txn->has_write()) {
-            bool optimize_1pc = request->txn_infos(0).optimize_1pc();
-            _txn_pool.read_only_txn_process(txn, op_type, optimize_1pc);
+            bool optimize_1pc = txn_info.optimize_1pc();
+            _txn_pool.read_only_txn_process(_region_id, txn, op_type, optimize_1pc);
+            txn->set_in_process(false);
             response->set_affected_rows(0);
             response->set_errcode(pb::SUCCESS);
             DB_WARNING("TransactionNote: no write DML when commit/rollback, remote_side:%s "
@@ -639,14 +674,14 @@ void Region::exec_in_txn_query(google::protobuf::RpcController* controller,
         }
     }
     //if (txn_info.start_seq_id() > last_seq + 1) {
-    if (last_seq == 0 && txn_info.start_seq_id() > last_seq + 1) {
-        char errmsg[100];
-        snprintf(errmsg, sizeof(errmsg), "region_id: %ld, txn_id: %lu, txn_last_seq: %d, request_start_seq: %d remote_side: %s", 
+    if (last_seq == 0 && txn_info.start_seq_id() > last_seq + 1 && op_type != pb::OP_ROLLBACK) {
+        DB_WARNING("TransactionNote: TXN_FOLLOW_UP region_id: %ld, txn_id: %lu, txn_last_seq: %d, request_start_seq: %d remote_side: %s",
             _region_id, txn_id, last_seq, txn_info.start_seq_id(), remote_side);
-        //DB_WARNING("%s", errmsg);
+        if (txn != nullptr) {
+            txn->set_in_process(false);
+        }
         response->set_errcode(pb::TXN_FOLLOW_UP);
         response->set_last_seq_id(last_seq);
-        response->set_errmsg(errmsg);
         return;
     }
     // for tail splitting new region replay txn
@@ -657,9 +692,12 @@ void Region::exec_in_txn_query(google::protobuf::RpcController* controller,
         set_region_with_update_range(region_info_mem);
     }
     bool apply_success = true;
-    ScopeGuard auto_rollback_current_request([&txn, apply_success]() {
+    ScopeGuard auto_rollback_current_request([this, &txn, txn_id, &apply_success]() {
         if (txn != nullptr && !apply_success) {
             txn->rollback_current_request();
+            DB_WARNING("region_id:%ld txn_id: %lu need rollback cur seq_id:%d", _region_id, txn->txn_id(), txn->seq_id());
+            txn->set_in_process(false);
+            remove_readonly_txn(txn.get());
         }
     });
     
@@ -694,9 +732,8 @@ void Region::exec_in_txn_query(google::protobuf::RpcController* controller,
         break;
         case pb::OP_INSERT:
         case pb::OP_DELETE:
-        case pb::OP_UPDATE: 
-        case pb::OP_PREPARE_V2: 
-        case pb::OP_PREPARE: 
+        case pb::OP_UPDATE:
+        case pb::OP_PREPARE:
         case pb::OP_ROLLBACK:
         case pb::OP_COMMIT: {
             if (_split_param.split_slow_down) {
@@ -1043,7 +1080,7 @@ void Region::query(google::protobuf::RpcController* controller,
             response->set_affected_rows(_num_table_lines.load());
             response->clear_txn_infos();
             std::unordered_map<uint64_t, pb::TransactionInfo> prepared_txn;
-            _txn_pool.get_prepared_txn_info(prepared_txn, true);
+            _txn_pool.get_prepared_txn_info(prepared_txn);
             for (auto &pair : prepared_txn) {
                 auto txn_info = response->add_txn_infos();
                 txn_info->CopyFrom(pair.second);
@@ -1084,7 +1121,6 @@ void Region::query(google::protobuf::RpcController* controller,
         case pb::OP_INSERT:
         case pb::OP_DELETE:
         case pb::OP_UPDATE:
-        case pb::OP_PREPARE_V2:
         case pb::OP_PREPARE:
         case pb::OP_COMMIT:
         case pb::OP_ROLLBACK:
@@ -1168,7 +1204,7 @@ void Region::dml(const pb::StoreReq& request, pb::StoreRes& response,
         optimize_1pc = request.txn_infos(0).optimize_1pc();
         seq_id = request.txn_infos(0).seq_id();
     }
-    if ((request.op_type() == pb::OP_PREPARE || request.op_type() == pb::OP_PREPARE_V2) && optimize_1pc) {
+    if ((request.op_type() == pb::OP_PREPARE) && optimize_1pc) {
         dml_1pc(request, request.op_type(), request.plan(), request.tuples(), 
             response, applied_index, term);
     } else {
@@ -1188,18 +1224,18 @@ void Region::dml_2pc(const pb::StoreReq& request,
         int32_t seq_id, bool need_txn_limit) {
 
     TimeCost cost;
-    if (op_type == pb::OP_INSERT ||
+    if (applied_index == 0 && (op_type == pb::OP_INSERT ||
         op_type == pb::OP_UPDATE ||
-        op_type == pb::OP_DELETE) {
+        op_type == pb::OP_DELETE)) {
         Concurrency::get_instance()->service_lock_concurrency.increase_wait();
     }
-    ON_SCOPE_EXIT([op_type]() {
-        if (op_type == pb::OP_INSERT ||
+    ON_SCOPE_EXIT(([op_type, applied_index]() {
+        if (applied_index == 0 && (op_type == pb::OP_INSERT ||
             op_type == pb::OP_UPDATE ||
-            op_type == pb::OP_DELETE) {
+            op_type == pb::OP_DELETE)) {
             Concurrency::get_instance()->service_lock_concurrency.decrease_broadcast();
         }
-    });
+    }));
     int64_t wait_cost = cost.get_time();
     //DB_WARNING("num_prepared:%d region_id: %ld", num_prepared(), _region_id);
     std::set<int> need_rollback_seq;
@@ -1232,11 +1268,6 @@ void Region::dml_2pc(const pb::StoreReq& request,
         // rollback already executed cmds
         for (auto it = need_rollback_seq.rbegin(); it != need_rollback_seq.rend(); ++it) {
             int seq = *it;
-         /*   if (txn->cache_plan_map().count(seq) == 0) {
-                DB_WARNING("cache does not contain seq: %d region_id:%ld txn_id: %lu, seq_id: %d, req_seq: %d", 
-                    seq, _region_id, txn_id, txn->seq_id(), seq_id);
-                continue;
-            }*/
             txn->rollback_to_point(seq);
             DB_WARNING("rollback seq_id: %d region_id: %ld, txn_id: %lu, seq_id: %d, req_seq: %d", 
                 seq, _region_id, txn_id, txn->seq_id(), seq_id);
@@ -1252,8 +1283,7 @@ void Region::dml_2pc(const pb::StoreReq& request,
         // 而导致当前region为follow_up, 每次都需要从baikaldb拉取cached命令
         txn->set_seq_id(seq_id);
         // set checkpoint for current DML operator
-        if (op_type != pb::OP_PREPARE && op_type != pb::OP_PREPARE_V2 
-                && op_type != pb::OP_COMMIT && op_type != pb::OP_ROLLBACK) {
+        if (op_type != pb::OP_PREPARE && op_type != pb::OP_COMMIT && op_type != pb::OP_ROLLBACK) {
             txn->set_save_point();
         }
         // 提前保存txn->num_increase_rows，以便事务提交/回滚时更新num_table_lines
@@ -1381,11 +1411,9 @@ void Region::dml_2pc(const pb::StoreReq& request,
 
     txn = _txn_pool.get_txn(txn_id);
     if (txn != nullptr) {
+        txn->set_seq_id(seq_id);
         txn->set_region_info(&_region_info);
         // DB_WARNING("seq_id: %d, %d, op:%d", seq_id, plan_map.count(seq_id), op_type);
-        if (op_type == pb::OP_INSERT || op_type == pb::OP_UPDATE || op_type == pb::OP_DELETE) {
-            txn->set_has_write(true);
-        }
         // commit/rollback命令不加缓存
         if (op_type != pb::OP_COMMIT && op_type != pb::OP_ROLLBACK) {
             pb::CachePlan plan_item;
@@ -1434,7 +1462,7 @@ void Region::dml_2pc(const pb::StoreReq& request,
     //这一步跟commit指令不原子，如果在这中间core会出错(todo)
     if (op_type == pb::OP_COMMIT || op_type == pb::OP_ROLLBACK) {
         auto ret = _meta_writer->write_meta_after_commit(_region_id, _num_table_lines,
-                        applied_index, txn_id, need_write_rollback);
+                        applied_index, _data_index, txn_id, need_write_rollback);
         //DB_WARNING("write meta info wheen commit or rollback,"
         //            " region_id: %ld, applied_index: %ld, num_table_line: %ld, txn_id: %lu"
         //            "op_type: %s", 
@@ -1444,6 +1472,10 @@ void Region::dml_2pc(const pb::StoreReq& request,
             DB_FATAL("write meta info fail, region_id: %ld, txn_id: %lu, log_index: %ld", 
                         _region_id, txn_id, applied_index);
         }
+        if (txn_info.has_open_binlog() && txn_info.open_binlog() && op_type == pb::OP_COMMIT
+            && txn_info.primary_region_id() == _region_id) {
+            put_commit_ts(txn_id, txn_info.commit_ts());
+        }
     }
     if (op_type == pb::OP_INSERT || op_type == pb::OP_DELETE || op_type == pb::OP_UPDATE) {
        update_average_cost(cost.get_time()); 
@@ -1451,10 +1483,10 @@ void Region::dml_2pc(const pb::StoreReq& request,
     int64_t dml_cost = cost.get_time();
     Store::get_instance()->dml_time_cost << dml_cost;
     if (dml_cost > FLAGS_print_time_us ||
+        //op_type == pb::OP_BEGIN ||
         op_type == pb::OP_COMMIT ||
         op_type == pb::OP_ROLLBACK ||
-        op_type == pb::OP_PREPARE || 
-        op_type == pb::OP_PREPARE_V2) {
+        op_type == pb::OP_PREPARE) {
         DB_NOTICE("dml type: %s, time_cost:%ld, region_id: %ld, txn_id: %lu:%d:%lu, num_table_lines:%ld, "
                   "affected_rows:%d, applied_index:%ld, term:%d, txn_num_rows:%ld,"
                   " average_cost: %ld, log_id:%lu, wait_cost:%ld", 
@@ -1533,8 +1565,7 @@ void Region::dml_1pc(const pb::StoreReq& request, pb::OpType op_type,
     }));
     // for out-txn dml query, create new txn.
     // for single-region 2pc query, simply fetch the txn created before.
-    bool is_new_txn = !((request.op_type() == pb::OP_PREPARE || request.op_type() == pb::OP_PREPARE_V2) 
-            && request.txn_infos(0).optimize_1pc());
+    bool is_new_txn = !((request.op_type() == pb::OP_PREPARE) && request.txn_infos(0).optimize_1pc());
     if (is_new_txn) {
         state.create_txn_if_null();
     }
@@ -1640,7 +1671,8 @@ void Region::dml_1pc(const pb::StoreReq& request, pb::OpType op_type,
     tmp_num_table_lines += txn_num_increase_rows;
     //老的insert update delete接口
     if (state.txn_id == 0) {
-        _meta_writer->write_meta_index_and_num_table_lines(_region_id, applied_index, tmp_num_table_lines, txn);
+        _meta_writer->write_meta_index_and_num_table_lines(_region_id, applied_index, 
+                _data_index, tmp_num_table_lines, txn);
         //DB_WARNING("write meta info when dml_1pc,"
         //            " region_id: %ld, num_table_line: %ld, applied_index: %ld", 
         //            _region_id, tmp_num_table_lines, applied_index);
@@ -1695,7 +1727,7 @@ void Region::dml_1pc(const pb::StoreReq& request, pb::OpType op_type,
     }
     if (state.txn_id != 0) {
         auto ret = _meta_writer->write_meta_after_commit(_region_id, _num_table_lines,
-            applied_index, state.txn_id, need_write_rollback);
+            applied_index, _data_index, state.txn_id, need_write_rollback);
         //DB_WARNING("write meta info wheen commit"
         //            " region_id: %ld, applied_index: %ld, num_table_line: %ld, txn_id: %lu", 
         //            _region_id, applied_index, _num_table_lines.load(), state.txn_id); 
@@ -1715,8 +1747,7 @@ void Region::dml_1pc(const pb::StoreReq& request, pb::OpType op_type,
     if (dml_cost > FLAGS_print_time_us ||
         op_type == pb::OP_COMMIT ||
         op_type == pb::OP_ROLLBACK ||
-        op_type == pb::OP_PREPARE || 
-        op_type == pb::OP_PREPARE_V2) {
+        op_type == pb::OP_PREPARE) {
         DB_NOTICE("dml type: %s, time_cost:%ld, region_id: %ld, txn_id: %lu, num_table_lines:%ld, "
                   "affected_rows:%d, applied_index:%ld, term:%d, txn_num_rows:%ld,"
                   " average_cost: %ld, log_id:%lu, wait_cost:%ld", 
@@ -1800,7 +1831,7 @@ void Region::select(const pb::StoreReq& request,
         BAIDU_SCOPED_LOCK(_ptr_mutex);
         state.set_resource(_resource);
     }
-    ret = state.init(request, plan, tuples, &_txn_pool, false);
+    ret = state.init(request, plan, tuples, &_txn_pool, false, _is_binlog_region);
     if (ret < 0) {
         response.set_errcode(pb::EXEC_FAIL);
         response.set_errmsg("RuntimeState init fail");
@@ -1836,9 +1867,6 @@ void Region::select(const pb::StoreReq& request,
         // rollback already executed cmds
         for (auto it = need_rollback_seq.rbegin(); it != need_rollback_seq.rend(); ++it) {
             int seq = *it;
-            //if (txn->cache_plan_map().count(seq) == 0) {
-            //    continue;
-            //}
             txn->rollback_to_point(seq);
             DB_WARNING("rollback seq_id: %d region_id: %ld, txn_id: %lu, seq_id: %d", 
                 seq, _region_id, txn->txn_id(), txn->seq_id());
@@ -2184,8 +2212,25 @@ void Region::on_apply(braft::Iterator& iter) {
 
         pb::StoreRes res;
         switch (op_type) {
+            //binlog op
+            case pb::OP_PREWRITE_BINLOG:
+            case pb::OP_COMMIT_BINLOG:
+            case pb::OP_ROLLBACK_BINLOG:
+            case pb::OP_FAKE_BINLOG: {
+                if (!_is_binlog_region) {
+                    DB_FATAL("region_id: %ld, is not binlog region can't process binlog op");
+                    break;
+                }
+                _data_index = _applied_index;
+                _meta_writer->update_apply_index(_region_id, _applied_index, _data_index);
+                apply_binlog(request, done);
+                break;
+            }
+
             //kv操作,存储计算分离时使用
             case pb::OP_KV_BATCH: {
+                // 在on_apply里赋值，有些函数可能不在状态机里调用
+                _data_index = _applied_index;
                 uint64_t txn_id = request.txn_infos_size() > 0 ? request.txn_infos(0).txn_id():0;
                 if (txn_id == 0) {
                     apply_kv_out_txn(request, done, _applied_index, term);
@@ -2196,13 +2241,14 @@ void Region::on_apply(braft::Iterator& iter) {
             }
             //分裂时new region处理old region发来的raftlog
             case pb::OP_KV_BATCH_SPLIT: {
+                _data_index = _applied_index;
                 apply_kv_split(request, done, _applied_index, term);
                 break;
             }
-            case pb::OP_PREPARE_V2:
             case pb::OP_PREPARE:
             case pb::OP_COMMIT:
             case pb::OP_ROLLBACK: {
+                _data_index = _applied_index;
                 apply_txn_request(request, done, _applied_index, term);
                 break;
             }
@@ -2212,6 +2258,7 @@ void Region::on_apply(braft::Iterator& iter) {
             case pb::OP_DELETE:
             case pb::OP_UPDATE: 
             case pb::OP_TRUNCATE_TABLE: {
+                _data_index = _applied_index;
                 uint64_t txn_id = request.txn_infos_size() > 0 ? request.txn_infos(0).txn_id():0;
                 //事务流程中DML处理
                 if (txn_id != 0 && (op_type == pb::OP_INSERT || op_type == pb::OP_DELETE || op_type == pb::OP_UPDATE)) {
@@ -2246,7 +2293,7 @@ void Region::on_apply(braft::Iterator& iter) {
             }
             //split的各类请求传进的来的done类型各不相同，不走下边的if(done)逻辑，直接处理完成，然后continue
             case pb::OP_NONE: {
-                _meta_writer->update_apply_index(_region_id, _applied_index);
+                _meta_writer->update_apply_index(_region_id, _applied_index, _data_index);
                 if (done) {
                     ((DMLClosure*)done)->response->set_errcode(pb::SUCCESS);
                 }
@@ -2267,26 +2314,29 @@ void Region::on_apply(braft::Iterator& iter) {
                 break;
             }
             case pb::OP_ADJUSTKEY_AND_ADD_VERSION: {
+                _data_index = _applied_index;
                 adjustkey_and_add_version(request, done, _applied_index, term);
                 DB_NOTICE("op_type: %s, region_id :%ld, applied_index:%ld, term:%d",
                     pb::OpType_Name(request.op_type()).c_str(), _region_id, _applied_index, term);
                 break;
             }
             case pb::OP_VALIDATE_AND_ADD_VERSION: {
+                _data_index = _applied_index;
                 validate_and_add_version(request, done, _applied_index, term);
                 DB_NOTICE("op_type: %s, region_id: %ld, applied_index:%ld, term:%d", 
                     pb::OpType_Name(request.op_type()).c_str(), _region_id, _applied_index, term);
                 break;
             }
             case pb::OP_ADD_VERSION_FOR_SPLIT_REGION: {
+                _data_index = _applied_index;
                 add_version_for_split_region(request, done, _applied_index, term); 
                 DB_NOTICE("op_type: %s, region_id: %ld, applied_index:%ld, term:%d", 
                     pb::OpType_Name(request.op_type()).c_str(), _region_id, _applied_index, term);
                 break;
             }
             default:
-                _meta_writer->update_apply_index(_region_id, _applied_index);
-                DB_WARNING("unsupport request type, op_type:%d, region_id: %ld", 
+                _meta_writer->update_apply_index(_region_id, _applied_index, _data_index);
+                DB_FATAL("unsupport request type, op_type:%d, region_id: %ld", 
                         request.op_type(), _region_id);
                 if (done) {
                     ((DMLClosure*)done)->response->set_errcode(pb::UNSUPPORT_REQ_TYPE); 
@@ -2369,7 +2419,7 @@ void Region::apply_kv_out_txn(const pb::StoreReq& request, braft::Closure* done,
     
     int64_t num_increase_rows = request.num_increase_rows();
     int64_t num_table_lines = _num_table_lines + num_increase_rows;
-    _meta_writer->write_meta_index_and_num_table_lines(_region_id, index, num_table_lines, txn);
+    _meta_writer->write_meta_index_and_num_table_lines(_region_id, index, _data_index, num_table_lines, txn);
     
     auto res = txn->commit();
     if (res.ok()) {
@@ -2501,7 +2551,7 @@ void Region::apply_kv_split(const pb::StoreReq& request, braft::Closure* done,
     }
     
     int64_t num_table_lines = _num_table_lines + num_write_lines;
-    _meta_writer->write_meta_index_and_num_table_lines(_region_id, index, num_table_lines, txn);
+    _meta_writer->write_meta_index_and_num_table_lines(_region_id, index, _data_index, num_table_lines, txn);
     
     auto res = txn->commit();
     if (res.ok()) {
@@ -2550,9 +2600,12 @@ void Region::apply_txn_request(const pb::StoreReq& request, braft::Closure* done
     // seq_id within a transaction should be continuous regardless of failure or success
     int last_seq = (txn == nullptr)? 0 : txn->seq_id();
     bool apply_success = true;
-    ScopeGuard auto_rollback_current_request([&txn, apply_success]() {
+    ScopeGuard auto_rollback_current_request([&txn, &apply_success]() {
         if (txn != nullptr && !apply_success) {
             txn->rollback_current_request();
+        }
+        if (txn != nullptr) {
+            txn->set_in_process(false);
         }
     });
     int ret = 0;
@@ -2577,12 +2630,12 @@ void Region::apply_txn_request(const pb::StoreReq& request, braft::Closure* done
         return;
     }
     bool write_begin_index = false;
-    if (term != 0 && txn != nullptr && txn->write_begin_index()) {
+    if (index != 0 && txn != nullptr && txn->write_begin_index()) {
         // 需要记录首条事务指令
         write_begin_index = true;
     }
     if (write_begin_index) {
-        auto ret = _meta_writer->write_meta_begin_index(_region_id, index, txn_id);
+        auto ret = _meta_writer->write_meta_begin_index(_region_id, index, _data_index, txn_id);
         //DB_WARNING("write meta info when prepare, region_id: %ld, applied_index: %ld, txn_id: %ld", 
         //            _region_id, index, txn_id);
         if (ret < 0) {
@@ -2651,14 +2704,14 @@ void Region::apply_txn_request(const pb::StoreReq& request, braft::Closure* done
 void Region::start_split(braft::Closure* done, int64_t applied_index, int64_t term) {
     static bvar::Adder<int> bvar_split; 
     static bvar::Window<bvar::Adder<int>> split_count("split_count_minite", &bvar_split, 60);
-    _meta_writer->update_apply_index(_region_id, applied_index);
+    _meta_writer->update_apply_index(_region_id, applied_index, _data_index);
     //只有leader需要处理split请求，记录当前的log_index, term和迭代器
     if (done) {
         bvar_split << 1;
         _split_param.split_start_index = applied_index + 1;
         _split_param.split_term = term;
         _split_param.snapshot = _rocksdb->get_db()->GetSnapshot();
-        _txn_pool.get_prepared_txn_info(_split_param.prepared_txn, true);
+        _txn_pool.get_prepared_txn_info(_split_param.prepared_txn);
 
         ((SplitClosure*)done)->ret = 0;
         if (_split_param.snapshot == nullptr) {
@@ -2672,7 +2725,7 @@ void Region::start_split(braft::Closure* done, int64_t applied_index, int64_t te
 }
 
 void Region::start_split_for_tail(braft::Closure* done, int64_t applied_index, int64_t term) {    
-    _meta_writer->update_apply_index(_region_id, applied_index);
+    _meta_writer->update_apply_index(_region_id, applied_index, _data_index);
     if (done) {
         _split_param.split_end_index = applied_index;
         _split_param.split_term = term;
@@ -2686,8 +2739,9 @@ void Region::start_split_for_tail(braft::Closure* done, int64_t applied_index, i
         rocksdb::ReadOptions read_options;
         read_options.total_order_seek = true;
         read_options.prefix_same_as_start = false;
+        read_options.fill_cache = false;
         std::unique_ptr<rocksdb::Iterator> iter(_rocksdb->new_iterator(read_options, _data_cf));
-        _txn_pool.get_prepared_txn_info(_split_param.prepared_txn, true);
+        _txn_pool.get_prepared_txn_info(_split_param.prepared_txn);
 
         MutTableKey key;
         //不够精确，但暂且可用。不允许主键是FFFFF
@@ -2780,7 +2834,7 @@ void Region::adjustkey_and_add_version(const pb::StoreReq& request,
     rocksdb::WriteBatch batch;
     batch.Put(_meta_writer->get_handle(), 
               _meta_writer->applied_index_key(_region_id), 
-              _meta_writer->encode_applied_index(applied_index));
+              _meta_writer->encode_applied_index(applied_index, _data_index));
     ON_SCOPE_EXIT(([this, &batch]() {
         _meta_writer->write_batch(&batch, _region_id);
         DB_WARNING("write metainfo when adjustkey and add version, region_id: %ld", 
@@ -2809,6 +2863,7 @@ void Region::adjustkey_and_add_version(const pb::StoreReq& request,
                str_to_hex(request.end_key()).c_str(), 
                applied_index, term);
     set_region_with_update_range(region_info_mem);   
+    _last_split_time_cost.reset();
 }
 
 void Region::validate_and_add_version(const pb::StoreReq& request, 
@@ -2818,7 +2873,7 @@ void Region::validate_and_add_version(const pb::StoreReq& request,
     rocksdb::WriteBatch batch;
     batch.Put(_meta_writer->get_handle(), 
                 _meta_writer->applied_index_key(_region_id), 
-                _meta_writer->encode_applied_index(applied_index));
+                _meta_writer->encode_applied_index(applied_index, _data_index));
     ON_SCOPE_EXIT(([this, &batch]() {
             _meta_writer->write_batch(&batch, _region_id);
             DB_WARNING("write metainfo when add version, region_id: %ld", _region_id); 
@@ -2853,13 +2908,20 @@ void Region::validate_and_add_version(const pb::StoreReq& request,
                 _num_table_lines.load(), request.reduce_num_lines(),
                 applied_index, term);
     set_region_with_update_range(region_info_mem);
+    _last_split_time_cost.reset();
+    _approx_info.last_version_region_size = _approx_info.region_size;
+    _approx_info.last_version_table_lines = _approx_info.table_lines;
+
     // 分裂后的老region需要删除范围
     _reverse_remove_range = true;
     _num_table_lines -= request.reduce_num_lines();
     batch.Put(_meta_writer->get_handle(), _meta_writer->num_table_lines_key(_region_id), _meta_writer->encode_num_table_lines(_num_table_lines));
+    std::vector<pb::TransactionInfo> txn_infos;
+    txn_infos.reserve(request.txn_infos_size());
     for (auto& txn_info : request.txn_infos()) {
-        _txn_pool.update_txn_num_rows_after_split(txn_info);
+        txn_infos.push_back(txn_info);
     }
+    _txn_pool.update_txn_num_rows_after_split(txn_infos);
     // 分裂后主动执行compact
     DB_WARNING("region_id: %ld, new_region_id: %ld, split do compact in queue", 
             _region_id, _split_param.new_region_id);
@@ -2868,7 +2930,8 @@ void Region::validate_and_add_version(const pb::StoreReq& request,
 
 void Region::add_version_for_split_region(const pb::StoreReq& request, braft::Closure* done, int64_t applied_index, int64_t term) {
     rocksdb::WriteBatch batch;
-    batch.Put(_meta_writer->get_handle(), _meta_writer->applied_index_key(_region_id), _meta_writer->encode_applied_index(applied_index));
+    batch.Put(_meta_writer->get_handle(), _meta_writer->applied_index_key(_region_id), 
+            _meta_writer->encode_applied_index(applied_index, _data_index));
     pb::RegionInfo region_info_mem;
     copy_region(&region_info_mem);
     region_info_mem.set_version(1);
@@ -2899,10 +2962,11 @@ void Region::add_version_for_split_region(const pb::StoreReq& request, braft::Cl
             }
             return;
         }
+        _last_split_time_cost.reset();
         // 分裂后的新region需要删除范围
         _reverse_remove_range = true;
         std::unordered_map<uint64_t, pb::TransactionInfo> prepared_txn;
-        _txn_pool.get_prepared_txn_info(prepared_txn, true);
+        _txn_pool.get_prepared_txn_info(prepared_txn);
         if (done) {
             ((DMLClosure*)done)->response->set_errcode(pb::SUCCESS);
             ((DMLClosure*)done)->response->set_errmsg("success");
@@ -2962,7 +3026,8 @@ void Region::recovery_when_leader_start(std::map<uint64_t, SmartTransaction> rep
                     _region_id, log_entry_pair.first, pb::OpType_Name(store_req.op_type()).c_str());
             continue;
         }
-        DB_WARNING("replay log entry op_type:%s", pb::OpType_Name(store_req.op_type()).c_str());
+        DB_WARNING("replay log entry region_id: %ld, txn_id:%lu op_type:%s",
+            _region_id, log_entry_pair.first, pb::OpType_Name(store_req.op_type()).c_str());
         auto txn = replay_txns[log_entry_pair.first];
         butil::IOBuf data;
         data.append(log_entry_pair.second);
@@ -3002,15 +3067,15 @@ void Region::on_leader_start(int64_t term) {
 void Region::on_leader_stop() {
     DB_WARNING("leader stop at term, region_id: %ld", _region_id);
     _is_leader.store(false);
-    //指令逐条复制之后不必回滚
-    //_txn_pool.on_leader_stop_rollback();
+    //只读事务清理
+    _txn_pool.on_leader_stop_rollback();
 }
 
 void Region::on_leader_stop(const butil::Status& status) {   
     DB_WARNING("leader stop, region_id: %ld, error_code:%d, error_des:%s",
                 _region_id, status.error_code(), status.error_cstr());
     _is_leader.store(false);
-    //_txn_pool.on_leader_stop_rollback();
+    _txn_pool.on_leader_stop_rollback();
 }
 
 void Region::on_error(const ::braft::Error& e) {
@@ -3049,8 +3114,8 @@ void Region::on_configuration_committed(const::braft::Configuration& conf, int64
 void Region::on_snapshot_save(braft::SnapshotWriter* writer, braft::Closure* done) {
     TimeCost time_cost;
     brpc::ClosureGuard done_guard(done);
-    if (writer->add_file(SNAPSHOT_DATA_FILE) != 0
-            || writer->add_file(SNAPSHOT_META_FILE) != 0) {
+    if (writer->add_file(SNAPSHOT_META_FILE) != 0 
+            || writer->add_file(SNAPSHOT_DATA_FILE) != 0) {
         done->status().set_error(EINVAL, "Fail to add snapshot");
         DB_WARNING("Error while adding extra_fs to writer, region_id: %ld", _region_id);
         return;
@@ -3110,7 +3175,7 @@ void Region::on_snapshot_load_for_restart(braft::SnapshotReader* reader,
     std::unordered_map<uint64_t, int64_t> prepared_log_indexs;
     int64_t start_log_index = INT64_MAX;
     std::set<uint64_t> txn_ids;
-    _applied_index = _meta_writer->read_applied_index(_region_id);
+    _meta_writer->read_applied_index(_region_id, &_applied_index, &_data_index);
     _num_table_lines = _meta_writer->read_num_table_lines(_region_id);
     //没有commited事务的log_index
     _meta_writer->parse_txn_log_indexs(_region_id, prepared_log_indexs);
@@ -3141,7 +3206,7 @@ void Region::on_snapshot_load_for_restart(braft::SnapshotReader* reader,
             }
             //手工erase掉meta信息，applied_index + 1, 系统挂在commit事务和write meta信息之间，事务已经提交，不需要重放
             ret = _meta_writer->write_meta_after_commit(_region_id, num_table_lines, applied_index,
-                    txn_id, is_rollback);
+                    _data_index, txn_id, is_rollback);
             DB_WARNING("write meta info wheen on snapshot load for restart"
                         " region_id: %ld, applied_index: %ld, txn_id: %lu", 
                         _region_id, applied_index, txn_id); 
@@ -3166,8 +3231,10 @@ void Region::on_snapshot_load_for_restart(braft::SnapshotReader* reader,
     }
     DB_WARNING("success load snapshot, snapshot file not exist, "
                 "region_id: %ld, prepared_log_size: %ld,"
+                "applied_index:%ld data_index:%ld"
                 " prepared_log_entrys_size: %ld, time_cost: %ld",
                 _region_id, prepared_log_indexs.size(), 
+                _applied_index, _data_index,
                 prepared_log_entrys.size(), time_cost.get_time());
 }
 
@@ -3187,6 +3254,9 @@ int Region::on_snapshot_load(braft::SnapshotReader* reader) {
     if (_restart && !Store::get_instance()->doing_snapshot_when_stop(_region_id)) {
         DB_WARNING("region_id: %ld, restart no snapshot sst");
         on_snapshot_load_for_restart(reader, prepared_log_entrys);
+        if (_is_binlog_region) {
+            binlog_reset_on_snapshot_load_restart();
+        }
     } else if (!boost::filesystem::exists(snapshot_meta_file)) {
         DB_FATAL(" region_id: %ld, no meta_sst file");
         return -1;
@@ -3204,18 +3274,38 @@ int Region::on_snapshot_load(braft::SnapshotReader* reader) {
         _txn_pool.clear();
         //清空数据
         if (_region_info.version() != 0) {
+            int64_t old_data_index = _data_index;
             DB_WARNING("region_id: %ld, clear_data on_snapshot_load", _region_id);
-            ret = clear_data();
-            if (ret != 0) {
-                DB_FATAL("clear data fail when on snapshot load, region_id: %ld", _region_id);
+            _meta_writer->clear_meta_info(_region_id);
+            int ret_meta = RegionControl::ingest_meta_sst(meta_sst_file, _region_id);
+            if (ret_meta < 0) {
+                DB_FATAL("ingest sst fail, region_id: %ld", _region_id);
                 return -1;
+            }
+            _meta_writer->read_applied_index(_region_id, &_applied_index, &_data_index);
+            boost::filesystem::path snapshot_first_data_file = meta_sst_file + "0";
+            //如果新的_data_index和old_data_index一样，则不需要清理数据，而且leader也不会发送数据
+            //如果存在data_sst并且是重启过程，则清理后走重启故障恢复
+            if (_data_index > old_data_index || 
+                (_restart && boost::filesystem::exists(snapshot_first_data_file))) {
+                //删除preapred 但没有committed的事务
+                _txn_pool.clear();
+                RegionControl::remove_data(_region_id);
+            } else {
+                DB_WARNING("region_id: %ld, no need clear_data, data_index:%ld, old_data_index:%ld",
+                        _region_id, _data_index, old_data_index);
             }
         } else {
             DB_WARNING("region_id: %ld is new, no need clear_data. region_info: %s",
                         _region_id, _region_info.ShortDebugString().c_str());
+            int ret_meta = RegionControl::ingest_meta_sst(meta_sst_file, _region_id);
+            if (ret_meta < 0) {
+                DB_FATAL("ingest sst fail, region_id: %ld", _region_id);
+                return -1;
+            }
         }
         // ingest sst
-        ret = ingest_sst(data_sst_file, meta_sst_file);
+        ret = ingest_snapshot_sst(reader->get_path());
         if (ret != 0) {
             DB_FATAL("ingest sst fail when on snapshot load, region_id: %ld", _region_id);
             return -1;
@@ -3226,11 +3316,12 @@ int Region::on_snapshot_load(braft::SnapshotReader* reader) {
             DB_FATAL("clear txn infos from rocksdb fail when on snapshot load, region_id: %ld", _region_id);
             return -1;
         }
+        binlog_reset_on_snapshot_load();
         DB_WARNING("success load snapshot, ingest sst file, region_id: %ld", _region_id);
     }
     // 读出来applied_index, 重放事务指令会把applied index覆盖, 因此必须在回放指令之前把applied index提前读出来
     //恢复内存中applied_index 和number_table_line
-    _applied_index = _meta_writer->read_applied_index(_region_id);
+    _meta_writer->read_applied_index(_region_id, &_applied_index, &_data_index);
     _num_table_lines = _meta_writer->read_num_table_lines(_region_id);
     pb::RegionInfo region_info;
     int ret = _meta_writer->read_region_info(_region_id, region_info);
@@ -3305,30 +3396,24 @@ int Region::on_snapshot_load(braft::SnapshotReader* reader) {
             DB_FATAL("parse prepared exec plan fail from log entry, region_id: %ld", _region_id);
             return -1; 
         }
-        /*
-        if (store_req.op_type() != pb::OP_PREPARE && store_req.op_type() != pb::OP_PREPARE_V2) {
-            DB_FATAL("op_type is not prepared when parse log entry, region_id: %ld, op_type: %s, log_index: %ld", 
-                    _region_id, pb::OpType_Name(store_req.op_type()).c_str(), log_index);
-            return -1;
-        }
-        */
         apply_txn_request(store_req, NULL, log_index, 0);
         const pb::TransactionInfo& txn_info = store_req.txn_infos(0);
         DB_WARNING("recovered not committed transaction, region_id: %ld,"
-            " log_index: %ld op_type: %s txn_id: %lu seq_id: %d",
+            " log_index: %ld op_type: %s txn_id: %lu seq_id: %d primary_region_id:%ld",
             _region_id, log_index, pb::OpType_Name(store_req.op_type()).c_str(),
-            txn_info.txn_id(), txn_info.seq_id());
+            txn_info.txn_id(), txn_info.seq_id(), txn_info.primary_region_id());
     }
     //如果有回放请求，apply_index会被覆盖，所以需要重新写入
     if (prepared_log_entrys.size() != 0) {
-        _meta_writer->update_apply_index(_region_id, _applied_index);
+        _meta_writer->update_apply_index(_region_id, _applied_index, _data_index);
         DB_WARNING("update apply index when on_snapshot_load, region_id: %ld, apply_index: %ld",
                     _region_id, _applied_index);
     }
+    _last_split_time_cost.reset();
 
     DB_WARNING("snapshot load success, region_id: %ld, num_table_lines: %ld,"
-                " applied_index: %ld, region_info: %s, cost:%ld _restart:%d",
-                _region_id, _num_table_lines.load(), _applied_index, 
+                " applied_index:%ld, data_index:%ld, region_info: %s, cost:%ld _restart:%d",
+                _region_id, _num_table_lines.load(), _applied_index, _data_index,
                 region_info.ShortDebugString().c_str(), time_cost.get_time(), _restart);
     if (!_restart) {
         auto run_snapshot = [this] () {
@@ -3339,6 +3424,8 @@ int Region::on_snapshot_load(braft::SnapshotReader* reader) {
             // 延迟做snapshot，等到snapshot_load结束，懒得搞条件变量了
             bthread_usleep(5 * 1000 * 1000LL);
             _region_control.sync_do_snapshot();
+            bthread_usleep_fast_shutdown(FLAGS_store_heart_beat_interval_us * 10, _shutdown);
+            _report_peer_info = true;
         };
         Bthread bth;
         bth.run(run_snapshot);
@@ -3347,14 +3434,53 @@ int Region::on_snapshot_load(braft::SnapshotReader* reader) {
     return 0;
 }
 
+int Region::ingest_snapshot_sst(const std::string& dir) {
+    typedef boost::filesystem::directory_iterator dir_iter;
+    dir_iter iter(dir);
+    dir_iter end;
+    int cnt = 0;
+    for (; iter != end; ++iter) {
+        std::string child_path = iter->path().c_str();
+        std::vector<std::string> split_vec;
+        boost::split(split_vec, child_path, boost::is_any_of("/"));
+        std::string out_path = split_vec.back();
+        if (boost::istarts_with(out_path, SNAPSHOT_DATA_FILE)) {
+            std::string link_path = dir + "/link." + out_path;
+            // 建一个硬链接，通过ingest采用move方式，可以不用修改异常恢复流程
+            // 失败了说明之前创建过，可忽略
+            link(child_path.c_str(), link_path.c_str());
+            DB_WARNING("region_id: %ld, ingest file:%s", _region_id, link_path.c_str());
+            wait_rocksdb_normal();
+            int ret_data = RegionControl::ingest_data_sst(link_path, _region_id, true);
+            if (ret_data < 0) {
+                DB_FATAL("ingest sst fail, region_id: %ld", _region_id);
+                return -1;
+            }
+
+            cnt++;
+        }
+    }
+    if (cnt == 0) {
+        DB_WARNING("region_id: %ld is empty when on snapshot load", _region_id);
+    } else {
+        // rocksdb ingest 有bug : https://github.com/facebook/rocksdb/issues/5913
+        // 确认是否真的没数据
+        if (!ingest_has_sst_data()) {
+            DB_FATAL("ingest sst fail due hit bug:there is no data after ingest data_sst, region_id: %ld", _region_id);
+            return -1;
+        }
+    }
+    return 0;
+}
+
 int Region::ingest_sst(const std::string& data_sst_file, const std::string& meta_sst_file) {
     if (boost::filesystem::exists(boost::filesystem::path(data_sst_file))) {
-        int ret_data = RegionControl::ingest_data_sst(data_sst_file, _region_id);
+        int ret_data = RegionControl::ingest_data_sst(data_sst_file, _region_id, false);
         if (ret_data < 0) {
             DB_FATAL("ingest sst fail, region_id: %ld", _region_id);
             return -1;
         }
-
+ 
         // rocksdb ingest 有bug : https://github.com/facebook/rocksdb/issues/5913
         // 确认是否真的没数据
         if (!ingest_has_sst_data()) {
@@ -3429,9 +3555,10 @@ std::string Region::dump_hex() {
     //encode pk fields
     //TableKey key;
     //key.append_i64(_region_id);
-    rocksdb::ReadOptions read_option;
+    rocksdb::ReadOptions read_options;
+    read_options.fill_cache = false;
     //read_option.prefix_same_as_start = true;
-    std::unique_ptr<rocksdb::Iterator> iter(_rocksdb->new_iterator(read_option, RocksWrapper::DATA_CF));
+    std::unique_ptr<rocksdb::Iterator> iter(_rocksdb->new_iterator(read_options, RocksWrapper::DATA_CF));
 
     std::string dump_str("{");
     for (iter->SeekToFirst();
@@ -3471,6 +3598,7 @@ bool Region::has_sst_data(int64_t* seek_table_lines) {
     rocksdb::ReadOptions read_options;
     read_options.prefix_same_as_start = true;
     read_options.total_order_seek = false;
+    read_options.fill_cache = false;
     // TODO iterate_upper_bound边界判断，其他地方也需要改写
     read_options.iterate_upper_bound = &upper_bound_slice;
     std::unique_ptr<rocksdb::Iterator> iter(_rocksdb->new_iterator(read_options, _data_cf));
@@ -3494,6 +3622,7 @@ bool Region::ingest_has_sst_data() {
     rocksdb::ReadOptions read_options;
     read_options.prefix_same_as_start = false;
     read_options.total_order_seek = true;
+    read_options.fill_cache = false;
     // TODO iterate_upper_bound边界判断，其他地方也需要改写
     read_options.iterate_upper_bound = &upper_bound_slice;
     std::unique_ptr<rocksdb::Iterator> iter(_rocksdb->new_iterator(read_options, _data_cf));
@@ -3754,6 +3883,7 @@ void Region::start_process_split(const pb::RegionSplitResponse& split_response,
     region_info->set_parent(_region_id);
     region_info->set_timestamp(time(NULL));
     region_info->set_can_add_peer(false);
+    region_info->set_partition_num(1);
     _new_region_info = *region_info; 
     //如果此参数设置为true，则认为此region是分裂出来的region
     //需要判断分裂多久之后有没有成功，没有成功则认为是失败，需要自己删除自己
@@ -3832,6 +3962,7 @@ void Region::get_split_key_for_tail_split() {
     ScopeProcStatus split_status(this);
     TimeCost time_cost;
     if (!is_leader()) {
+        start_thread_to_remove_region(_split_param.new_region_id, _split_param.instance);
         DB_FATAL("leader transfer when split, split fail, region_id: %ld", _region_id);
         return;
     }
@@ -3841,7 +3972,8 @@ void Region::get_split_key_for_tail_split() {
     int64_t disable_write_wait = get_split_wait_time();
     int ret = _real_writing_cond.timed_wait(disable_write_wait);
     if (ret != 0) {
-        DB_FATAL("_real_writing_cond wait timeout, region_id: %ld", _region_id);
+        start_thread_to_remove_region(_split_param.new_region_id, _split_param.instance);
+        DB_FATAL("_real_writing_cond wait timeout, region_id: %ld new_region_id:%ld ", _region_id, _split_param.new_region_id);
         return;
     }
     DB_WARNING("start not allow write, region_id: %ld, time_cost:%ld", 
@@ -3941,6 +4073,8 @@ void Region::write_local_rocksdb_for_split() {
     for (int64_t index_id : indices) {
         auto read_and_write = [this, &pk_info, &write_sst_lines, 
                                 index_id, new_region] () {
+            std::unique_ptr<SstFileWriter> writer(new SstFileWriter(
+                        _rocksdb->get_options(_rocksdb->get_data_handle())));
             MutTableKey table_prefix;
             table_prefix.append_i64(_region_id).append_i64(index_id);
             rocksdb::WriteOptions write_options;
@@ -3954,6 +4088,7 @@ void Region::write_local_rocksdb_for_split() {
             rocksdb::ReadOptions read_options;
             read_options.prefix_same_as_start = true;
             read_options.total_order_seek = false;
+            read_options.fill_cache = false;
             read_options.snapshot = _split_param.snapshot;
            
             IndexInfo index_info = _factory->get_index_info(index_id);
@@ -3963,6 +4098,23 @@ void Region::write_local_rocksdb_for_split() {
             }
             std::string end_key = get_end_key();
             int64_t count = 0;
+            std::ostringstream os;
+            // 使用FLAGS_db_path，保证ingest能move成功
+            os << FLAGS_db_path << "/" << "region_split_ingest_sst." << _region_id << "." 
+                << _split_param.new_region_id << "." << index_id;
+            std::string path = os.str();
+
+            ScopeGuard auto_fail_guard([path, this]() {
+                _split_param.err_code = -1;
+                start_thread_to_remove_region(_split_param.new_region_id, _split_param.instance);
+                butil::DeleteFile(butil::FilePath(path), false);
+            });
+
+            auto s = writer->open(path);
+            if (!s.ok()) {
+                DB_FATAL("open sst file path: %s failed, err: %s, region_id: %ld", path.c_str(), s.ToString().c_str(), _region_id);
+                return;
+            }
             for (iter->Seek(table_prefix.data()); iter->Valid(); iter->Next()) {
                 ++count;
                 if (count % 1000 == 0) {
@@ -3972,8 +4124,6 @@ void Region::write_local_rocksdb_for_split() {
                 if (count % 1000 == 0 && (!is_leader() || _shutdown)) {
                     DB_WARNING("index %ld, old region_id: %ld write to new region_id: %ld failed, not leader",
                                 index_id, _region_id, _split_param.new_region_id);
-                    _split_param.err_code = -1;
-                    start_thread_to_remove_region(_split_param.new_region_id, _split_param.instance);
                     return;
                 }
                 //int ret1 = 0; 
@@ -4004,23 +4154,34 @@ void Region::write_local_rocksdb_for_split() {
                 }
                 MutTableKey key(iter->key());
                 key.replace_i64(_split_param.new_region_id, 0);
-                auto s = _rocksdb->put(write_options, _data_cf, key.data(), iter->value());
+                s = writer->put(key.data(), iter->value());
                 if (!s.ok()) {
                     DB_FATAL("index %ld, old region_id: %ld write to new region_id: %ld failed, status: %s", 
                     index_id, _region_id, _split_param.new_region_id, s.ToString().c_str());
-                    _split_param.err_code = -1;
-                    start_thread_to_remove_region(_split_param.new_region_id, _split_param.instance);
                     return;
                 }
                 num_write_lines++;
             }
+            s = writer->finish();
+            if (!s.ok()) {
+                DB_FATAL("finish sst file path: %s failed, err: %s, region_id: %ld, index %ld", 
+                        path.c_str(), s.ToString().c_str(), _region_id, index_id);
+                return;
+            }
+            uint64_t file_size = writer->file_size();
+            int ret_data = RegionControl::ingest_data_sst(path, _region_id, true);
+            if (ret_data < 0) {
+                DB_FATAL("ingest sst fail, path:%s, region_id: %ld", path.c_str(), _region_id);
+                return;
+            }
+            auto_fail_guard.release();
             write_sst_lines += num_write_lines;
             if (index_info.type == pb::I_PRIMARY || _is_global_index) {
                 _split_param.reduce_num_lines = num_write_lines;
             }
-            DB_WARNING("scan index:%ld, cost=%ld, lines=%ld, skip:%ld, region_id: %ld "
+            DB_WARNING("scan index:%ld, cost=%ld, file_size=%lu, lines=%ld, skip:%ld, region_id: %ld "
                     "level lines=[%ld,%ld,%ld]", 
-                    index_id, cost.get_time(), num_write_lines, skip_write_lines, _region_id,
+                    index_id, cost.get_time(), file_size, num_write_lines, skip_write_lines, _region_id,
                     level1_lines, level2_lines, level3_lines);
 
         };
@@ -4050,6 +4211,7 @@ void Region::write_local_rocksdb_for_split() {
                 rocksdb::ReadOptions read_options;
                 read_options.prefix_same_as_start = true;
                 read_options.total_order_seek = false;
+                read_options.fill_cache = false;
                 read_options.snapshot = _split_param.snapshot;
 
                 std::unique_ptr<rocksdb::Iterator> iter(_rocksdb->new_iterator(read_options, _data_cf));
@@ -4200,62 +4362,41 @@ int Region::replay_txn_for_recovery(
         auto& begin_plan = txn_info.cache_plans(0);
         auto& prepare_plan = txn_info.cache_plans(plan_size - 1);
         if (!txn_info.has_primary_region_id()) {
-            if (prepare_plan.op_type() != pb::OP_PREPARE && prepare_plan.op_type() != pb::OP_PREPARE_V2) {
-                DB_FATAL("TransactionError: invalid command type, region_id: %ld, txn_id: %lu, op_type: %d", 
+            DB_FATAL("TransactionError: invalid txn state, region_id: %ld, txn_id: %lu, op_type: %d", 
                     _region_id, txn_id, prepare_plan.op_type());
-                return -1;
-            }
+            return -1;
         }
         for (auto& plan : txn_info.cache_plans()) {
             // construct prepare request to send to new_plan
             pb::StoreReq request;
             pb::StoreRes response;
-            if (txn_info.has_primary_region_id()) {
-                if (plan.op_type() == pb::OP_BEGIN) {
-                    continue;
-                }
-                request.set_op_type(plan.op_type());
-                for (auto& tuple : plan.tuples()) {
-                    request.add_tuples()->CopyFrom(tuple);
-                }
-                request.set_region_id(region_id);
-                request.set_region_version(0);
-                request.mutable_plan()->CopyFrom(plan.plan());
-                if (start_key.size() > 0) {
-                    // send new start_key to new_region, only once
-                    // tail split need send start_key at this place
-                    request.set_start_key(start_key);
-                    start_key.clear();
-                }
-                pb::TransactionInfo* txn = request.add_txn_infos();
-                txn->set_txn_id(txn_id);
-                txn->set_seq_id(plan.seq_id());
-                txn->set_optimize_1pc(false);
-                txn->set_start_seq_id(1);
-                for (auto seq_id : txn_info.need_rollback_seq()) {
-                    txn->add_need_rollback_seq(seq_id);
-                }
-                txn->set_primary_region_id(txn_info.primary_region_id());
-                pb::CachePlan* pb_cache_plan = txn->add_cache_plans();
-                pb_cache_plan->CopyFrom(begin_plan);
-            } else {
-                request.set_op_type(prepare_plan.op_type());
-                for (auto& tuple : prepare_plan.tuples()) {
-                    request.add_tuples()->CopyFrom(tuple);
-                }
-                request.set_region_id(region_id);
-                request.set_region_version(0);
-                request.mutable_plan()->CopyFrom(prepare_plan.plan());
-                if (start_key.size() > 0) {
-                    // send new start_key to new_region, only once
-                    request.set_start_key(start_key);
-                    start_key.clear();
-                }
-                pb::TransactionInfo* txn = request.add_txn_infos();
-                txn->CopyFrom(txn_info);
-                // 最后一个即当前发送的req
-                txn->mutable_cache_plans()->RemoveLast();
+            if (plan.op_type() == pb::OP_BEGIN) {
+                continue;
             }
+            request.set_op_type(plan.op_type());
+            for (auto& tuple : plan.tuples()) {
+                request.add_tuples()->CopyFrom(tuple);
+            }
+            request.set_region_id(region_id);
+            request.set_region_version(0);
+            request.mutable_plan()->CopyFrom(plan.plan());
+            if (start_key.size() > 0) {
+                // send new start_key to new_region, only once
+                // tail split need send start_key at this place
+                request.set_start_key(start_key);
+                start_key.clear();
+            }
+            pb::TransactionInfo* txn = request.add_txn_infos();
+            txn->set_txn_id(txn_id);
+            txn->set_seq_id(plan.seq_id());
+            txn->set_optimize_1pc(false);
+            txn->set_start_seq_id(1);
+            for (auto seq_id : txn_info.need_rollback_seq()) {
+                txn->add_need_rollback_seq(seq_id);
+            }
+            txn->set_primary_region_id(txn_info.primary_region_id());
+            pb::CachePlan* pb_cache_plan = txn->add_cache_plans();
+            pb_cache_plan->CopyFrom(begin_plan);
             int ret = RpcSender::send_query_method(request, instance, region_id);
             if (ret < 0) {
                 DB_FATAL("TransactionError: new region request fail, region_id: %ld, new_region_id:%ld, instance:%s, txn_id: %lu",
@@ -4708,10 +4849,11 @@ int Region::get_log_entry_for_split(const int64_t split_start_index,
     int64_t start_index = split_start_index;
     MutTableKey log_data_key;
     log_data_key.append_i64(_region_id).append_u8(MyRaftLogStorage::LOG_DATA_IDENTIFY).append_i64(split_start_index);
-    rocksdb::ReadOptions opt;
-    opt.prefix_same_as_start = true;
-    opt.total_order_seek = false;
-    std::unique_ptr<rocksdb::Iterator> iter(_rocksdb->new_iterator(opt, RocksWrapper::RAFT_LOG_CF));
+    rocksdb::ReadOptions read_options;
+    read_options.prefix_same_as_start = true;
+    read_options.total_order_seek = false;
+    read_options.fill_cache = false;
+    std::unique_ptr<rocksdb::Iterator> iter(_rocksdb->new_iterator(read_options, RocksWrapper::RAFT_LOG_CF));
     iter->Seek(log_data_key.data());
     // 小batch发送
     for (int i = 0; iter->Valid() && i < 10000; iter->Next(), i++) {
@@ -4744,7 +4886,6 @@ int Region::get_log_entry_for_split(const int64_t split_start_index,
                 && store_req.op_type() != pb::OP_DELETE
                 && store_req.op_type() != pb::OP_UPDATE
                 && store_req.op_type() != pb::OP_PREPARE
-                && store_req.op_type() != pb::OP_PREPARE_V2
                 && store_req.op_type() != pb::OP_ROLLBACK
                 && store_req.op_type() != pb::OP_COMMIT
                 && store_req.op_type() != pb::OP_NONE
@@ -4779,6 +4920,7 @@ int Region::get_split_key(std::string& split_key) {
     rocksdb::ReadOptions read_options;
     read_options.total_order_seek = false;
     read_options.prefix_same_as_start = true;
+    read_options.fill_cache = false;
     std::unique_ptr<rocksdb::Iterator> iter(_rocksdb->new_iterator(read_options, _data_cf));
     MutTableKey key;
 
@@ -5085,6 +5227,7 @@ void Region::write_local_rocksdb_for_ddl() {
     rocksdb::ReadOptions read_options;
     read_options.prefix_same_as_start = true; 
     read_options.total_order_seek = false;
+    read_options.fill_cache = false;
     std::unique_ptr<rocksdb::Iterator> iter(_rocksdb->new_iterator(read_options, _data_cf));
     MutTableKey table_prefix;
     table_prefix.append_i64(_region_id).append_i64(pk_index_id);
@@ -5131,6 +5274,9 @@ void Region::write_local_rocksdb_for_ddl() {
             }
         }
         all_num++;
+        if (all_num % 10000 == 0) {
+            wait_rocksdb_normal();
+        }
         SmartTransaction txn(new Transaction(0, smart_transaction.get(), _use_ttl)); 
         txn->set_write_ttl_timestamp_us(ttl_timestamp_us);
         txn->set_region_info(&_region_info);
@@ -5457,6 +5603,32 @@ bool Region::is_wait_ddl() {
     }
     return _ddl_param.is_waiting;
 }
+
+bool Region::can_use_approximate_split() {
+    if (FLAGS_use_approximate_size_to_split && 
+            get_num_table_lines() > FLAGS_min_split_lines &&
+            get_last_split_time_cost() > 60 * 60 * 1000 * 1000LL &&
+            _approx_info.region_size > 512 * 1024 * 1024) {
+        if (_approx_info.last_version_region_size > 0 && 
+                _approx_info.last_version_table_lines > 0 && 
+                _approx_info.region_size > 0 &&
+                _approx_info.table_lines > 0) {
+            double avg_size = 1.0 * _approx_info.region_size / _approx_info.table_lines;
+            double last_avg_size = 1.0 * _approx_info.last_version_region_size / _approx_info.last_version_table_lines;
+            // avg_size差不多时才能做
+            // 严格点判断，减少分裂后不做compaction导致的再次分裂问题
+            if (avg_size / last_avg_size < 1.2) {
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            return true;
+        }
+    } else {
+        return false;
+    }
+}
 // 后续要用compaction filter 来维护，现阶段主要有num_table_lines维护问题
 void Region::ttl_remove_expired_data() {
     if (!_use_ttl) {
@@ -5510,11 +5682,13 @@ void Region::ttl_remove_expired_data() {
         rocksdb::ReadOptions read_options;
         read_options.prefix_same_as_start = true;
         read_options.total_order_seek = false;
+        read_options.fill_cache = false;
 
         std::string end_key = get_end_key();
         IndexInfo index_info = _factory->get_index_info(index_id);
         std::unique_ptr<rocksdb::Iterator> iter(_rocksdb->new_iterator(read_options, _data_cf));
         rocksdb::ReadOptions read_opt;
+        read_opt.fill_cache = false;
         rocksdb::TransactionOptions txn_opt;
         txn_opt.lock_timeout = 100;
         int64_t count = 0;

--- a/src/store/region_binlog.cpp
+++ b/src/store/region_binlog.cpp
@@ -1,0 +1,1020 @@
+// Copyright (c) 2018-present Baidu, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "region.h"
+#include <algorithm>
+#include <fstream>
+#include <boost/filesystem.hpp>
+#include "table_key.h"
+#include "runtime_state.h"
+#include "mem_row_descriptor.h"
+#include "exec_node.h"
+#include "table_record.h"
+#include "my_raft_log_storage.h"
+#include "log_entry_reader.h"
+#include "raft_log_compaction_filter.h"
+#include "split_compaction_filter.h"
+#include "rpc_sender.h"
+#include "concurrency.h"
+#include "store.h"
+#include "closure.h"
+
+namespace baikaldb {
+DECLARE_int32(retry_interval_us);
+DEFINE_int64(binlog_timeout_us, 10 * 1000 * 1000LL, "binlog timeout us : 10s");
+
+//该函数联调时测试 TODO by YUZHENGQUAN
+int Region::get_primary_region_info(int64_t primary_region_id, pb::RegionInfo& region_info) {
+    MetaServerInteract&   meta_server_interact = Store::get_instance()->get_meta_server_interact();
+    pb::QueryRequest query_request;
+    pb::QueryResponse query_response;
+    query_request.set_op_type(pb::QUERY_REGION);
+    query_request.set_region_id(primary_region_id);
+    if (meta_server_interact.send_request("query", query_request, query_response) != 0) {
+        DB_FATAL("send query request to meta server fail primary_region_id: %ld "
+                "region_id:%ld res: %s", primary_region_id, _region_id, query_response.ShortDebugString().c_str());
+        return -1;
+    }
+
+    if (query_response.errcode() != pb::SUCCESS) {
+        DB_FATAL("send query request to meta server fail primary_region_id: %ld "
+                "region_id:%ld res: %s", primary_region_id, _region_id, query_response.ShortDebugString().c_str());
+        return -1;
+    }
+
+    region_info = query_response.region_infos(0);
+    return 0;
+}
+
+void Region::binlog_query_primary_region(const int64_t& start_ts, const int64_t& txn_id, pb::RegionInfo& region_info, int64_t rollback_ts) {
+    pb::StoreReq request;
+    pb::StoreRes response;
+    request.set_op_type(pb::OP_TXN_QUERY_PRIMARY_REGION);
+    request.set_region_id(region_info.region_id());
+    request.set_region_version(region_info.version());
+    pb::TransactionInfo* pb_txn = request.add_txn_infos();
+    pb_txn->set_txn_id(txn_id);
+    pb_txn->set_seq_id(0);
+    pb_txn->set_start_ts(start_ts);
+    pb_txn->set_open_binlog(true);
+    //pb_txn->set_seq_id(txn->seq_id());
+    pb_txn->set_txn_state(pb::TXN_PREPARED);
+
+    int retry_times = 1;
+    bool success = false;
+    int64_t commit_ts = 0;
+    do {
+        RpcSender::send_query_method(request, response, region_info.leader(), region_info.region_id());
+        switch (response.errcode()) {
+            case pb::SUCCESS: {
+                pb::StoreReq binlog_request;
+                auto txn_info = response.txn_infos(0);
+                if (txn_info.txn_state() == pb::TXN_ROLLBACKED) {
+                    binlog_request.set_op_type(pb::OP_ROLLBACK_BINLOG);
+                    commit_ts = rollback_ts;
+                } else if (txn_info.txn_state() == pb::TXN_COMMITTED) {
+                    binlog_request.set_op_type(pb::OP_COMMIT_BINLOG);
+                    commit_ts = txn_info.commit_ts();
+                } else {
+                    // primary没有查到rollback_tag，认为是commit，但是secondary不是PREPARE状态
+                    DB_FATAL("primary committed, secondary need catchup log, region_id:%ld,"
+                        "primary_region_id: %ld txn_id: %lu",
+                        _region_id, region_info.region_id(), txn_id);
+                    success = true;
+                    return;
+                }
+                if (commit_ts <= start_ts) {
+                    DB_FATAL("commit_ts: %ld, start_ts: %ld, txn_id: %ld", commit_ts, start_ts, txn_id);
+                    return;
+                }
+                binlog_request.set_region_id(_region_id);
+                binlog_request.set_region_version(get_version());
+                //查询时对端region需要设置commit_ts TODO by YUZHENGQUAN
+                auto binlog_desc = binlog_request.mutable_binlog_desc();
+                binlog_desc->set_binlog_ts(commit_ts);
+                binlog_desc->set_txn_id(txn_info.txn_id());
+                binlog_desc->set_start_ts(start_ts);
+
+                butil::IOBuf data;
+                butil::IOBufAsZeroCopyOutputStream wrapper(&data);
+                if (!binlog_request.SerializeToZeroCopyStream(&wrapper)) {
+                    DB_FATAL("region_id: %ld serialize failed", _region_id);
+                    return;
+                }
+
+                BinlogClosure* c = new BinlogClosure;
+                c->cost.reset();
+                braft::Task task;
+                task.data = &data;
+                task.done = c;
+                _node.apply(task);
+                success = true;
+                DB_WARNING("send txn query success request:%s response: %s",
+                    request.ShortDebugString().c_str(), response.ShortDebugString().c_str());
+                break;
+            }
+            case pb::NOT_LEADER: {
+                if (response.leader() != "0.0.0.0:0") {
+                    region_info.set_leader(response.leader());
+                }
+                DB_WARNING("send txn query NOT_LEADER , request:%s response: %s",
+                    request.ShortDebugString().c_str(),
+                    response.ShortDebugString().c_str());
+                bthread_usleep(retry_times * FLAGS_retry_interval_us);
+                break;
+            }
+            case pb::VERSION_OLD: {
+                for (auto r : response.regions()) {
+                    if (r.region_id() == region_info.region_id()) {
+                        region_info.CopyFrom(r);
+                        request.set_region_version(region_info.version());
+                    }
+                }
+                DB_WARNING("send txn query VERSION_OLD , request:%s response: %s",
+                    request.ShortDebugString().c_str(),
+                    response.ShortDebugString().c_str());
+                bthread_usleep(retry_times * FLAGS_retry_interval_us);
+                break;
+            }
+            default: {
+                DB_WARNING("send txn query failed , request:%s response: %s",
+                    request.ShortDebugString().c_str(),
+                    response.ShortDebugString().c_str());
+                bthread_usleep(retry_times * FLAGS_retry_interval_us);
+                break;
+            }
+        }
+        retry_times++;
+    } while (!success && retry_times <= 5);
+}
+
+// 没有commit或rollback的prewrite binlog超时检查
+void Region::binlog_timeout_check(int64_t rollback_ts) {
+    int64_t start_ts = 0;
+    int64_t txn_id   = 0;
+    int64_t primary_region_id = 0;
+
+    {
+        _binlog_cond.increase_wait(1);
+        ON_SCOPE_EXIT([this]() {
+            //出作用域自动释放，避免阻塞binlog写
+            _binlog_cond.decrease_signal();
+        });
+
+        if (_binlog_param.ts_binlog_map.size() == 0) {
+            return;
+        }
+
+        auto iter = _binlog_param.ts_binlog_map.begin();
+        if (iter->second.time.get_time() > FLAGS_binlog_timeout_us) {
+            //告警
+            DB_WARNING("region_id: %ld, start_ts: %ld, txn_id:%ld, primary_region_id: %ld timeout", _region_id, iter->first, txn_id, iter->second.primary_region_id);
+            if (is_leader()) {
+                start_ts = iter->first;
+                txn_id = iter->second.txn_id;
+                primary_region_id = iter->second.primary_region_id;
+            } else {
+                return;
+            }
+        } else {
+            return;
+        }
+    }
+
+    //  反查primary region，确认prewrite binlog是否已经commit 或 rollback
+    pb::RegionInfo region_info;
+    int ret = get_primary_region_info(primary_region_id, region_info);
+    if (ret < 0) {
+        return;
+    }
+
+    binlog_query_primary_region(start_ts, txn_id, region_info, rollback_ts);
+
+}
+
+void Region::binlog_fake(int64_t ts, BthreadCond& cond) {
+
+    pb::StoreReq request;
+
+    request.set_op_type(pb::OP_FAKE_BINLOG);
+    request.set_region_id(_region_id);
+    request.set_region_version(get_version());
+    //测试需要将ts设为time TODO
+    request.mutable_binlog_desc()->set_binlog_ts(ts);
+
+    butil::IOBuf data;
+    butil::IOBufAsZeroCopyOutputStream wrapper(&data);
+    if (!request.SerializeToZeroCopyStream(&wrapper)) {
+        DB_FATAL("region_id: %ld serialize failed", _region_id);
+        return;
+    }
+
+    DB_WARNING("region_id: %ld, FAKE BINLOG", _region_id);
+
+    BinlogClosure* c = new BinlogClosure(&cond);
+    cond.increase_wait();
+    c->cost.reset();
+    braft::Task task;
+    task.data = &data;
+    task.done = c;
+    _node.apply(task);
+    return;
+}
+
+void Region::binlog_fill_exprvalue(const pb::BinlogDesc& binlog_desc, pb::OpType op_type, std::map<std::string, ExprValue>& field_value_map) {
+    if (binlog_desc.has_binlog_ts()) {
+        ExprValue ts;
+        ts.type = pb::INT64;
+        ts._u.int64_val = binlog_desc.binlog_ts();
+        field_value_map["ts"] = ts;
+    }
+
+    if (binlog_desc.has_txn_id()) {
+        ExprValue txn_id;
+        txn_id.type = pb::INT64;
+        txn_id._u.int64_val = binlog_desc.txn_id();
+        field_value_map["txn_id"] = txn_id;
+    }
+
+    if (binlog_desc.has_start_ts()) {
+        ExprValue start_ts;
+        start_ts.type = pb::INT64;
+        start_ts._u.int64_val = binlog_desc.start_ts();
+        field_value_map["start_ts"] = start_ts;
+    }  
+
+    if (binlog_desc.has_primary_region_id()) {
+        ExprValue primary_region_id;
+        primary_region_id.type = pb::INT64;
+        primary_region_id._u.int64_val = binlog_desc.primary_region_id();
+        field_value_map["primary_region_id"] = primary_region_id;
+    }
+
+    if (binlog_desc.has_partion_key()) {
+        ExprValue partion_key;
+        partion_key.type = pb::INT64;
+        partion_key._u.int64_val = binlog_desc.partion_key();
+        field_value_map["partion_key"] = partion_key;
+    }   
+
+    {
+        ExprValue binlog_region_id;
+        binlog_region_id.type = pb::INT64;
+        binlog_region_id._u.int64_val = _region_id;
+        field_value_map["binlog_region_id"] = binlog_region_id;
+    } 
+
+    ExprValue binlog_type;
+    binlog_type.type = pb::INT64;
+    switch (op_type)  {
+        case pb::OP_PREWRITE_BINLOG: {
+            binlog_type._u.int64_val = static_cast<int64_t>(PREWRITE_BINLOG);
+            break;
+        }
+        case pb::OP_COMMIT_BINLOG: {
+            binlog_type._u.int64_val = static_cast<int64_t>(COMMIT_BINLOG);
+            break;
+        }
+        case pb::OP_ROLLBACK_BINLOG: {
+            binlog_type._u.int64_val = static_cast<int64_t>(ROLLBACK_BINLOG);
+            break;
+        }
+        default: {
+            binlog_type._u.int64_val = static_cast<int64_t>(FAKE_BINLOG);
+            break;
+        }
+    }
+
+    field_value_map["binlog_type"] = binlog_type;
+}
+
+int64_t Region::binlog_get_int64_val(const std::string& name, const std::map<std::string, ExprValue>& field_value_map) {
+    auto iter = field_value_map.find(name);
+    if (iter == field_value_map.end()) {
+        return -1;
+    }
+
+    return iter->second.get_numberic<int64_t>();
+}
+
+std::string Region::binlog_get_str_val(const std::string& name, const std::map<std::string, ExprValue>& field_value_map) {
+    auto iter = field_value_map.find(name);
+    if (iter == field_value_map.end()) {
+        return "";
+    }
+
+    return iter->second.get_string();
+}
+
+void Region::binlog_get_scan_fields(std::map<int32_t, FieldInfo*>& field_ids, std::vector<int32_t>& field_slot) {
+    SmartTable  table_ptr = _factory->get_table_info_ptr(get_table_id());
+    SmartIndex  pri_info  = _factory->get_index_info_ptr(get_table_id());
+
+    field_slot.resize(table_ptr->fields.back().id + 1);
+
+    std::set<int32_t> pri_field_ids;
+    for (auto& field_info : pri_info->fields) {
+        pri_field_ids.insert(field_info.id);
+    }
+
+    for (auto& field : table_ptr->fields) {
+        field_slot[field.id] = field.id;
+        if (pri_field_ids.count(field.id) == 0) {
+            field_ids[field.id] = &field;
+        }
+    }
+}
+
+void Region::binlog_get_field_values(std::map<std::string, ExprValue>& field_value_map, SmartRecord record) {
+    SmartTable  table_ptr = _factory->get_table_info_ptr(get_table_id());
+
+    for (auto& field : table_ptr->fields) {
+        auto f = record->get_field_by_tag(field.id);
+        field_value_map[field.short_name] = record->get_value(f);
+    }
+}
+
+void Region::binlog_reset_on_snapshot_load_restart() {
+    _binlog_cond.increase_wait(1);
+    ON_SCOPE_EXIT([this]() {
+        _binlog_cond.decrease_signal();
+    });
+
+    //重新读取check point
+    _binlog_param.check_point_ts = _meta_writer->read_binlog_check_point(_region_id);
+    _binlog_param.oldest_ts      = _meta_writer->read_binlog_oldest_ts(_region_id);
+    _binlog_param.max_ts_in_map  = _binlog_param.check_point_ts;
+    _binlog_param.min_ts_in_map  = _binlog_param.check_point_ts;
+    _binlog_param.ts_binlog_map.clear();
+    DB_WARNING("region_id: %ld, check_point_ts: %ld, oldest_ts: %ld", _region_id, 
+        _binlog_param.check_point_ts, _binlog_param.oldest_ts);
+}
+
+//add peer时不拉取binlog快照，需要重置oldest binlog ts和check point
+void Region::binlog_reset_on_snapshot_load() {
+    _binlog_cond.increase_wait(1);
+    ON_SCOPE_EXIT([this]() {
+        _binlog_cond.decrease_signal();
+    });
+
+    //重置等待FAKE BINLOG时更新，第一次FAKE BINLOG之前的都会舍弃
+    _binlog_param.check_point_ts = -1;
+    _binlog_param.oldest_ts      = -1;
+    _binlog_param.max_ts_in_map  = -1;
+    _binlog_param.min_ts_in_map  = -1;
+    _binlog_param.ts_binlog_map.clear();
+    DB_WARNING("region_id: %ld, snapshot load", _region_id);
+}
+
+void Region::binlog_scan() {
+
+    _binlog_cond.increase_wait(1);
+    ON_SCOPE_EXIT([this]() {
+        _binlog_cond.decrease_signal();
+    });
+    TimeCost cost;
+    int64_t begin_ts = 0;
+    if (_binlog_param.max_ts_in_map == -1 || _binlog_param.min_ts_in_map == -1) {
+        //重启或者刚拉取快照
+        return;
+    } 
+
+    //接续 max ts 扫描
+    begin_ts = _binlog_param.max_ts_in_map;
+
+    SmartRecord left_record  = _factory->new_record(get_table_id());
+    SmartRecord right_record = _factory->new_record(get_table_id());
+    SmartIndex  pri_info     = _factory->get_index_info_ptr(get_table_id());
+    if (left_record == nullptr || right_record == nullptr || pri_info == nullptr) {
+        return;
+    }
+
+    ExprValue value;
+    value.type = pb::INT64;
+    value._u.int64_val = begin_ts;
+    left_record->set_value(left_record->get_field_by_tag(1), value);
+    right_record->decode("");
+
+    IndexRange range(left_record.get(), right_record.get(), pri_info.get(), pri_info.get(),
+                        &_region_info, 1, 0, false, false, false);
+
+    std::map<int32_t, FieldInfo*> field_ids;
+    std::vector<int32_t> field_slot;
+
+    binlog_get_scan_fields(field_ids, field_slot);
+
+    TableIterator* table_iter = Iterator::scan_primary(nullptr, range, field_ids, field_slot, false, true);
+    if (table_iter == nullptr) {
+        DB_WARNING("open TableIterator fail, table_id:%ld", get_table_id());
+        return;
+    }
+
+    ON_SCOPE_EXIT(([this, table_iter]() {
+        delete table_iter;
+    }));
+
+    SmartRecord record = _factory->new_record(get_table_id());
+    while (1) {
+        record->clear();
+        if (!table_iter->valid()) {
+            break;
+        }
+
+        int ret = table_iter->get_next(record);
+        if (ret < 0) {
+            break;
+        }
+
+        std::map<std::string, ExprValue> field_value_map;
+        binlog_get_field_values(field_value_map, record);
+
+        //binlog 元信息更新map
+        binlog_update_map_when_scan(field_value_map);
+    }
+
+    // 一轮扫描结束后，处理内存map，更新check point
+    binlog_update_check_point();
+    DB_WARNING("region_id: %ld, binlog_scan map size: %d, min ts: %ld, max ts: %ld, check point ts: %ld, cost: %ld", 
+        _region_id, _binlog_param.ts_binlog_map.size(), _binlog_param.min_ts_in_map, _binlog_param.max_ts_in_map, 
+        _binlog_param.check_point_ts, cost.get_time());
+}
+
+//scan时更新map，因为不会和写入并发，扫描ts严格递增
+void Region::binlog_update_map_when_scan(const std::map<std::string, ExprValue>& field_value_map) {
+    BinlogDesc binlog_desc;
+    int64_t ts = binlog_get_int64_val("ts", field_value_map);
+    BinlogType binlog_type = static_cast<BinlogType>(binlog_get_int64_val("binlog_type", field_value_map));
+    int64_t txn_id = binlog_get_int64_val("txn_id", field_value_map);
+    int64_t start_ts = binlog_get_int64_val("start_ts", field_value_map);
+
+    //扫描时小于max ts直接跳过
+    if (ts <= _binlog_param.max_ts_in_map) {
+        DB_WARNING("region_id: %ld scan_ts: %ld <= max_ts: %ld, txn_id: %ld", _region_id, ts, _binlog_param.max_ts_in_map, txn_id);
+        return;
+    }
+
+    if (binlog_type == FAKE_BINLOG) {
+        binlog_desc.binlog_type = binlog_type;
+        _binlog_param.ts_binlog_map[ts] = binlog_desc;
+        // DB_WARNING("region_id: %ld, ts: %ld, type: %s, txn_id: %ld", _region_id, ts, binlog_type_name(binlog_type), txn_id);
+    } else if (binlog_type == PREWRITE_BINLOG) {
+        binlog_desc.binlog_type = binlog_type;
+        binlog_desc.txn_id = txn_id;
+        binlog_desc.primary_region_id = binlog_get_int64_val("primary_region_id", field_value_map);
+        _binlog_param.ts_binlog_map[ts] = binlog_desc;
+        // DB_WARNING("region_id: %ld, start_ts: %ld, type: %s, txn_id: %ld", _region_id, ts, binlog_type_name(binlog_type), txn_id);
+    } else if (binlog_type == COMMIT_BINLOG || binlog_type == ROLLBACK_BINLOG) {
+        if (start_ts < _binlog_param.min_ts_in_map) {
+            DB_WARNING("region_id: %ld, type: %s, start_ts: %ld < min ts: %ld, ts: %ld, txn_id: %ld", _region_id, binlog_type_name(binlog_type), start_ts, 
+                _binlog_param.min_ts_in_map, ts, txn_id);
+            return;
+        }
+
+        auto iter = _binlog_param.ts_binlog_map.find(start_ts);
+        if (iter == _binlog_param.ts_binlog_map.end()) {
+            DB_FATAL("region_id: %ld, type: %s, start_ts: %ld can not find in map, ts: %ld, txn_id: %ld", 
+                _region_id, binlog_type_name(binlog_type), start_ts, ts, txn_id);
+            return;
+        } else {
+            _binlog_param.ts_binlog_map.erase(start_ts);
+            DB_WARNING("region_id: %ld, type: %s, start_ts: %ld erase, commit_ts: %ld, txn_id: %ld", 
+                _region_id, binlog_type_name(binlog_type), start_ts, ts, txn_id);
+        }
+
+    }
+
+    _binlog_param.max_ts_in_map = ts;
+    if (_binlog_param.ts_binlog_map.size() > 0) {
+        _binlog_param.min_ts_in_map = _binlog_param.ts_binlog_map.begin()->first;
+    } else {
+        _binlog_param.min_ts_in_map = ts;
+    }
+
+    // DB_WARNING("region_id: %ld, type: %s, map size: %d, min ts: %ld, max ts: %ld, txn_id: %ld", _region_id, binlog_type_name(binlog_type), _binlog_param.ts_binlog_map.size(), 
+    //                 _binlog_param.min_ts_in_map, _binlog_param.max_ts_in_map, txn_id);
+    return;
+}
+
+//on_apply中只有相关start_ts/commit_ts/rollback_ts和map区间有重合时才可以更新map
+int Region::binlog_update_map_when_apply(const std::map<std::string, ExprValue>& field_value_map) {
+    int ret = 0;
+    BinlogDesc binlog_desc;
+    int64_t ts = binlog_get_int64_val("ts", field_value_map);
+    int64_t type = binlog_get_int64_val("binlog_type", field_value_map);
+    int64_t txn_id = binlog_get_int64_val("txn_id", field_value_map);
+    int64_t start_ts = binlog_get_int64_val("start_ts", field_value_map);
+    
+    if (_binlog_param.max_ts_in_map == -1 || _binlog_param.min_ts_in_map == -1) {
+        //on_apply之前会调用on_snapshot_load, 如果重启max_ts_in_map不会为-1，如果新拉取快照则需要在FAKE BINLOG时重置check point和oldest ts
+        if (type == FAKE_BINLOG) {
+            binlog_desc.binlog_type = static_cast<BinlogType>(type);
+            _binlog_param.ts_binlog_map[ts] = binlog_desc;
+            ret = _meta_writer->write_binlog_check_point(_region_id, ts);
+            if (ret < 0) {
+                return -1;
+            }
+            ret = _meta_writer->write_binlog_oldest_ts(_region_id, ts);
+            if (ret < 0) {
+                return -1;
+            }
+            _binlog_param.check_point_ts = ts;
+            _binlog_param.oldest_ts      = ts;
+            _binlog_param.max_ts_in_map  = ts;
+            _binlog_param.min_ts_in_map  = ts;
+            DB_WARNING("region_id: %ld, ts: %ld, FAKE BINLOG reset check point and oldest ts", _region_id, ts);
+        } else {
+            DB_WARNING("region_id :%ld, ts: %ld, binlog_type: %d, discard", _region_id, ts, type);
+        }
+        return 0;
+    }
+
+    if (ts > _binlog_param.max_ts_in_map) {
+        // DB_WARNING("region_id: %ld, type:%d, ts: %ld > max ts: %ld, don't update map", _region_id, type, ts, _binlog_param.max_ts_in_map);
+        return 0;
+    } else {
+        if (type == FAKE_BINLOG) {
+            binlog_desc.binlog_type = static_cast<BinlogType>(type);
+            _binlog_param.ts_binlog_map[ts] = binlog_desc;
+            // DB_WARNING("region_id: %ld, ts: %ld, FAKE BINLOG", _region_id, ts);
+        } else if (type == PREWRITE_BINLOG) {
+            binlog_desc.binlog_type = static_cast<BinlogType>(type);
+            binlog_desc.txn_id = txn_id;
+            binlog_desc.primary_region_id = binlog_get_int64_val("primary_region_id", field_value_map);
+            _binlog_param.ts_binlog_map[ts] = binlog_desc;
+            DB_WARNING("region_id: %ld, ts: %ld, PREWRITE BINLOG", _region_id, ts);
+        } else if (type == COMMIT_BINLOG || type == ROLLBACK_BINLOG) {
+            if (start_ts < _binlog_param.min_ts_in_map) {
+                DB_FATAL("region_id: %ld, type: %d, start_ts: %ld < min ts: %ld", _region_id, type, start_ts, _binlog_param.min_ts_in_map);
+                return 0;
+            }
+
+            auto iter = _binlog_param.ts_binlog_map.find(start_ts);
+            if (iter == _binlog_param.ts_binlog_map.end()) {
+                DB_FATAL("region_id: %ld, type: %d, start_ts: %ld can not find in map", _region_id, type, start_ts);
+                return 0;
+            } else {
+                _binlog_param.ts_binlog_map.erase(start_ts);
+                DB_WARNING("region_id: %ld, start_ts: %ld erase", _region_id, start_ts);
+            }
+        }
+
+        if (_binlog_param.ts_binlog_map.size() > 0) {
+            _binlog_param.min_ts_in_map = _binlog_param.ts_binlog_map.begin()->first;
+        } else {
+            _binlog_param.min_ts_in_map = _binlog_param.max_ts_in_map;
+        }
+
+    }
+    return 0;
+}
+
+//扫描一轮或者新写入binlog之后，更新map，更新扫描进度点
+int Region::binlog_update_check_point() {
+    if (_binlog_param.max_ts_in_map == -1 || _binlog_param.min_ts_in_map == -1) {
+        return 0;
+    }
+
+    int ret = 0;
+    int64_t check_point_ts = 0;
+    if (_binlog_param.ts_binlog_map.empty()) {
+        check_point_ts = _binlog_param.min_ts_in_map;
+    } else {
+        auto iter = _binlog_param.ts_binlog_map.begin();
+        while (iter != _binlog_param.ts_binlog_map.end()) {
+            check_point_ts = iter->first;
+            BinlogType type = iter->second.binlog_type;
+
+            if (type == PREWRITE_BINLOG) {
+                break;
+            }
+
+            auto delete_iter = iter++;
+            _binlog_param.ts_binlog_map.erase(delete_iter->first);
+        }
+
+        //更新min_ts_in_map
+        if (!_binlog_param.ts_binlog_map.empty()) {
+            _binlog_param.min_ts_in_map = _binlog_param.ts_binlog_map.begin()->first;
+        } else {
+            _binlog_param.min_ts_in_map = _binlog_param.max_ts_in_map;
+        }
+    }
+
+    //write check point
+    if (_binlog_param.check_point_ts > check_point_ts) {
+        // check point 变小说明写入ts小于check point，告警
+        DB_FATAL("region_id: %ld, new check point ts: %ld, < old check point ts: %ld", 
+                    _region_id, check_point_ts, _binlog_param.check_point_ts);
+    } else if (_binlog_param.check_point_ts == check_point_ts) {
+        return 0;
+    }
+
+    ret = _meta_writer->write_binlog_check_point(_region_id, check_point_ts);
+    if (ret != 0) {
+        return -1;
+    }
+
+    DB_WARNING("region_id: %ld, check point ts %ld => %ld", _region_id, _binlog_param.check_point_ts, check_point_ts);
+    _binlog_param.check_point_ts = check_point_ts;
+    return 0;
+}
+
+int Region::write_binlog_record(SmartRecord record) {
+
+    IndexInfo pk_index = _factory->get_index_info(get_table_id());
+
+    MutTableKey key;
+    // DB_WARNING("region_id: %ld, pk_id: %ld", _region_id, pk_index.id);
+    key.append_i64(_region_id).append_i64(pk_index.id);
+    if (0 != key.append_index(pk_index, record.get(), -1, true)) {
+        DB_FATAL("Fail to append_index, reg=%ld, tab=%ld", _region_id, pk_index.id);
+        return -1;
+    }
+
+    std::string value;
+    int ret = record->encode(value);
+    if (ret != 0) {
+        DB_FATAL("encode record failed: reg=%ld, tab=%ld", _region_id, pk_index.id);
+        return -1;
+    }
+
+    rocksdb::WriteOptions write_options;
+    auto s = _rocksdb->put(write_options, _data_cf, key.data(), value);
+    if (!s.ok()) {
+        DB_FATAL("write binlog failed, region_id: %lld, status: %s", _region_id, s.ToString().c_str());
+        return -1;
+    }
+    
+    return 0;
+}
+
+//ts(primary key),   no null 
+//txn_id,            default 0
+//binlog_type,       no null
+//partion_key,       default 0
+//start_ts,          default -1
+//primary_region_id, default -1
+int Region::write_binlog_value(std::map<std::string, ExprValue> field_value_map) {
+    SmartTable  table_ptr = _factory->get_table_info_ptr(get_table_id());
+    SmartRecord record    = _factory->new_record(get_table_id());
+
+    for (auto& field : table_ptr->fields) {
+        auto iter = field_value_map.find(field.short_name);
+        if (iter == field_value_map.end()) {
+            //default
+            if (field.default_expr_value.is_null()) {
+                continue;
+            }
+            ExprValue default_value = field.default_expr_value;
+            if (field.default_value == "(current_timestamp())") {
+                default_value = ExprValue::Now();
+                default_value.cast_to(field.type);
+            }
+            if (0 != record->set_value(record->get_field_by_tag(field.id), default_value)) {
+                DB_WARNING("fill insert value failed");
+                return -1;
+            }
+        } else {
+            if (0 != record->set_value(record->get_field_by_tag(field.id), iter->second)) {
+                DB_WARNING("fill insert value failed");
+                return -1;
+            }
+        }
+    }
+
+    int ret = write_binlog_record(record);
+    if (ret != 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+void Region::apply_binlog(const pb::StoreReq& request, braft::Closure* done) {
+    _binlog_cond.increase_wait(1);
+    ON_SCOPE_EXIT([this]() {
+        _binlog_cond.decrease_signal();
+    });
+    
+    pb::OpType op_type = request.op_type();
+
+    std::map<std::string, ExprValue> field_value_map;
+
+    switch (op_type) {
+        case pb::OP_PREWRITE_BINLOG: 
+        case pb::OP_COMMIT_BINLOG: 
+        case pb::OP_ROLLBACK_BINLOG: 
+        case pb::OP_FAKE_BINLOG: {
+            binlog_fill_exprvalue(request.binlog_desc(), op_type, field_value_map);
+            break;
+        }
+        default: {
+            DB_FATAL("unsupport request type, op_type:%d, region_id: %ld", 
+                    request.op_type(), _region_id);
+            if (done != nullptr && ((BinlogClosure*)done)->response != nullptr) {
+                ((BinlogClosure*)done)->response->set_errcode(pb::UNSUPPORT_REQ_TYPE); 
+                ((BinlogClosure*)done)->response->set_errmsg("unsupport request type");
+            }
+            DB_NOTICE("op_type: %s, region_id: %ld, applied_index:%ld", 
+                pb::OpType_Name(request.op_type()).c_str(), _region_id, _applied_index);
+            break;
+        }
+    }
+
+    if (field_value_map.size() > 0) {
+        if (0 != write_binlog_value(field_value_map)) {
+            if (done != nullptr && ((BinlogClosure*)done)->response != nullptr) {
+                ((BinlogClosure*)done)->response->set_errcode(pb::PUT_VALUE_FAIL); 
+                ((BinlogClosure*)done)->response->set_errmsg("write rocksdb fail");
+            }
+            DB_FATAL("write binlog failed, region_id: %ld", _region_id);
+        }
+
+        binlog_update_map_when_apply(field_value_map);
+    }
+
+    if (done != nullptr && ((BinlogClosure*)done)->response != nullptr) {
+        ((BinlogClosure*)done)->response->set_errcode(pb::SUCCESS); 
+        ((BinlogClosure*)done)->response->set_errmsg("apply binlog success");
+    }
+
+}
+
+void Region::read_binlog(const pb::StoreReq* request,
+                   pb::StoreRes* response) {
+    int64_t binlog_cnt = request->binlog_desc().read_binlog_cnt();
+    int64_t begin_ts = request->binlog_desc().binlog_ts();
+    DB_DEBUG("read_binlog request %s", request->ShortDebugString().c_str());
+    int64_t check_point_ts = 0;
+    int64_t oldest_ts = 0;
+    {
+        // 获取check point时应加锁，避免被修改
+        _binlog_cond.increase_wait(1);
+        ON_SCOPE_EXIT([this]() {
+            _binlog_cond.decrease_signal();
+        });
+
+        check_point_ts = _meta_writer->read_binlog_check_point(_region_id);
+        if (check_point_ts < 0) {
+            DB_FATAL("region_id: %ld, get check point failed", _region_id);
+            response->set_errcode(pb::GET_VALUE_FAIL); 
+            response->set_errmsg("get binlog check point ts");
+            return;
+        }
+
+        oldest_ts = _meta_writer->read_binlog_oldest_ts(_region_id);
+        if (oldest_ts < 0) {
+            DB_FATAL("region_id: %ld, get oldest ts failed", _region_id);
+            response->set_errcode(pb::GET_VALUE_FAIL); 
+            response->set_errmsg("get binlog oldest ts failed");
+            return;
+        }
+    }
+
+    if (begin_ts == 0) {
+        begin_ts = oldest_ts;
+        DB_WARNING("region_id: %ld, begin_ts is 0, chg to: %ld", _region_id, oldest_ts);
+    }
+
+    if (begin_ts < oldest_ts) {
+        DB_WARNING("region_id: %ld, begin ts : %ld < oldest ts : %ld", _region_id, begin_ts, oldest_ts);
+        response->set_errcode(pb::LESS_THAN_OLDEST_TS); 
+        response->set_errmsg("begin ts gt oldest ts");
+        return;
+    }
+
+    SmartRecord left_record  = _factory->new_record(get_table_id());
+    SmartRecord right_record = _factory->new_record(get_table_id());
+    SmartIndex  pri_info     = _factory->get_index_info_ptr(get_table_id());
+    if (left_record == nullptr || right_record == nullptr || pri_info == nullptr) {
+        response->set_errcode(pb::GET_VALUE_FAIL); 
+        response->set_errmsg("get index info failed");
+        return;
+    }
+
+    // ExprValue left_value;
+    // left_value.type = pb::INT64;
+    // left_value._u.int64_val = begin_ts;
+    // left_record->set_value(left_record->get_field_by_tag(1), left_value);
+    // ExprValue right_value;
+    // right_value.type = pb::INT64;
+    // right_value._u.int64_val = check_point_ts;
+    // right_record->set_value(right_record->get_field_by_tag(1), right_value);
+
+    // IndexRange range(left_record.get(), right_record.get(), pri_info.get(), pri_info.get(),
+    //                 &_region_info, 1, 1, false, false, false);
+
+
+    ExprValue value;
+    value.type = pb::INT64;
+    value._u.int64_val = begin_ts;
+    left_record->set_value(left_record->get_field_by_tag(1), value);
+    right_record->decode("");
+
+    IndexRange range(left_record.get(), right_record.get(), pri_info.get(), pri_info.get(),
+                        &_region_info, 1, 0, false, false, false);
+
+    std::map<int32_t, FieldInfo*> field_ids;
+    std::vector<int32_t> field_slot;
+
+    binlog_get_scan_fields(field_ids, field_slot);
+
+    TableIterator* table_iter = Iterator::scan_primary(nullptr, range, field_ids, field_slot, false, true);
+    if (table_iter == nullptr) {
+        DB_WARNING("open TableIterator fail, table_id:%ld", get_table_id());
+        return;
+    }
+
+    ON_SCOPE_EXIT(([this, table_iter]() {
+        delete table_iter;
+    }));
+
+    int64_t max_fake_binlog = 0;
+    int64_t return_nr = 0;
+    std::map<std::string, ExprValue> field_value_map;
+    SmartRecord record = _factory->new_record(get_table_id());
+    while (1) {
+        record->clear();
+        if (!table_iter->valid()) {
+            DB_WARNING("region_id: %ld not valid", _region_id);
+            break;
+        }
+
+        int ret = table_iter->get_next(record);
+        if (ret < 0) {
+            DB_WARNING("region_id: %ld get_next failed", _region_id);
+            break;
+        }
+        std::map<std::string, ExprValue> field_value_map;
+        binlog_get_field_values(field_value_map, record);
+        int64_t ts = binlog_get_int64_val("ts", field_value_map); // type 为 COMMIT 时，ts 为 commit_ts
+        BinlogType binlog_type = static_cast<BinlogType>(binlog_get_int64_val("binlog_type", field_value_map));
+        int64_t start_ts = binlog_get_int64_val("start_ts", field_value_map);
+        if (ts < begin_ts || ts > check_point_ts) {
+            DB_WARNING("region_id: %ld, ts: %ld, begin_ts: %ld, check_point_ts: %ld", _region_id, ts, begin_ts, check_point_ts);
+            break;
+        }
+
+        if (binlog_type == FAKE_BINLOG) {
+            if (ts > max_fake_binlog) {
+                max_fake_binlog = ts;
+            }
+        }
+
+        if (binlog_type != COMMIT_BINLOG || ts == begin_ts) {
+            continue;
+        }
+
+        if (start_ts < oldest_ts) {
+            DB_WARNING("region_id: %ld, start ts : %ld < oldest ts : %ld", _region_id, start_ts, oldest_ts);
+            //特殊错误码 TODO
+            response->set_errcode(pb::LESS_THAN_OLDEST_TS); 
+            response->set_errmsg("start ts gt oldest ts");
+            return;
+        }
+        
+        if ((--binlog_cnt) < 0) {
+            break;
+        }
+        DB_WARNING("region_id: %ld, get bin log start_ts: %ld, commit ts: %ld begin_ts: %ld", _region_id, start_ts, ts, begin_ts);
+        return_nr++;
+        char buf[sizeof(int64_t)];
+        memcpy(buf, (void*)&start_ts, sizeof(int64_t));
+        auto binlog_cf = _rocksdb->get_bin_log_handle();
+        std::string binlog_value;
+        rocksdb::Status status = _rocksdb->get(rocksdb::ReadOptions(), binlog_cf, 
+            rocksdb::Slice(buf, sizeof(int64_t)), &binlog_value);
+        if (!status.ok()) {
+            DB_FATAL("get ts:%ld from rocksdb binlog cf fail, region_id: %ld",
+                    start_ts, _region_id);
+            response->set_errcode(pb::GET_VALUE_FAIL); 
+            response->set_errmsg("read binlog failed");            
+            return;
+        }
+        (*response->add_binlogs()) = binlog_value;
+        response->add_commit_ts(ts);
+    }
+
+    if (return_nr == 0 && max_fake_binlog != 0) {
+        pb::StoreReq fake_binlog;
+        DB_WARNING("region_id: %ld, fake binlog ts: %ld", _region_id, max_fake_binlog);
+        fake_binlog.set_op_type(pb::OP_FAKE_BINLOG);
+        fake_binlog.set_region_id(_region_id);
+        fake_binlog.set_region_version(get_version());
+        fake_binlog.mutable_binlog_desc()->set_binlog_ts(max_fake_binlog);
+        fake_binlog.mutable_binlog()->set_type(pb::FAKE);
+        fake_binlog.mutable_binlog()->set_start_ts(max_fake_binlog);
+        fake_binlog.mutable_binlog()->set_commit_ts(max_fake_binlog);
+
+        std::string binlog_value;
+        if (!fake_binlog.SerializeToString(&binlog_value)) {
+            DB_FATAL("region_id: %ld serialize failed", _region_id);
+            response->set_errcode(pb::GET_VALUE_FAIL); 
+            response->set_errmsg("serialize fake binlog failed"); 
+            return;
+        }
+        (*response->add_binlogs()) = binlog_value;
+        response->add_commit_ts(max_fake_binlog);
+
+    }
+
+    response->set_errcode(pb::SUCCESS); 
+    response->set_errmsg("read binlog success");
+
+}
+
+void Region::query_binlog(google::protobuf::RpcController* controller,
+                   const pb::StoreReq* request,
+                   pb::StoreRes* response,
+                   google::protobuf::Closure* done) {
+    _multi_thread_cond.increase();
+    ON_SCOPE_EXIT([this]() {
+        _multi_thread_cond.decrease_signal();
+    });
+    _time_cost.reset();
+    brpc::ClosureGuard done_guard(done);
+    brpc::Controller* cntl = (brpc::Controller*)controller;
+    uint64_t log_id = 0;
+    if (cntl->has_log_id()) { 
+        log_id = cntl->log_id();
+    }
+
+    const auto& remote_side_tmp = butil::endpoint2str(cntl->remote_side());
+    const char* remote_side     = remote_side_tmp.c_str();
+    if ((!is_leader()) && (request->op_type() != pb::OP_READ_BINLOG || _shutdown || !_init_success)) {
+        response->set_errcode(pb::NOT_LEADER);
+        response->set_leader(butil::endpoint2str(_node.leader_id().addr).c_str());
+        response->set_errmsg("not leader");
+        DB_WARNING("not leader, leader:%s, region_id: %ld, log_id:%lu, remote_side:%s",
+                        butil::endpoint2str(_node.leader_id().addr).c_str(), 
+                        _region_id, log_id, remote_side);
+        return;
+    }
+
+    response->set_leader(butil::endpoint2str(_node.leader_id().addr).c_str()); // 每次都返回leader
+    if (validate_version(request, response) == false) {
+        DB_WARNING("region version too old, region_id: %ld, log_id:%lu,"
+                   " request_version:%ld, region_version:%ld optype:%s remote_side:%s",
+                    _region_id, log_id, request->region_version(), _region_info.version(),
+                    pb::OpType_Name(request->op_type()).c_str(), remote_side);
+        return;
+    }
+
+    // 启动时，或者follow落后太多，需要读leader
+    if (request->op_type() == pb::OP_READ_BINLOG && request->region_version() > _region_info.version()) {
+        response->set_errcode(pb::NOT_LEADER);
+        response->set_leader(butil::endpoint2str(_node.leader_id().addr).c_str());
+        response->set_errmsg("not leader");
+        DB_WARNING("not leader, leader:%s, region_id: %ld, version:%ld, log_id:%lu, remote_side:%s",
+                        butil::endpoint2str(_node.leader_id().addr).c_str(), 
+                        _region_id, _region_info.version(), log_id, remote_side);
+        return;
+    }
+
+    switch (request->op_type()) {
+        case pb::OP_READ_BINLOG: {
+            read_binlog(request, response);
+            break;
+        }
+        case pb::OP_PREWRITE_BINLOG:
+        case pb::OP_COMMIT_BINLOG:
+        case pb::OP_ROLLBACK_BINLOG:
+        case pb::OP_FAKE_BINLOG: {
+            butil::IOBuf data;
+            butil::IOBufAsZeroCopyOutputStream wrapper(&data);
+            if (!request->SerializeToZeroCopyStream(&wrapper)) {
+                cntl->SetFailed(brpc::EREQUEST, "Fail to serialize request");
+                return;
+            }
+
+            BinlogClosure* c = new BinlogClosure;
+            c->cost.reset();
+            c->response = response;
+            c->done = done_guard.release();
+            braft::Task task;
+            task.data = &data;
+            task.done = c;
+            _node.apply(task);
+            break;
+        }
+        default:
+            response->set_errcode(pb::UNSUPPORT_REQ_TYPE);
+            response->set_errmsg("unsupport request type");
+            DB_WARNING("not support op_type when binlog request, op_type:%s region_id: %ld, log_id:%lu",
+                        pb::OpType_Name(request->op_type()).c_str(), _region_id, log_id);
+    }
+    return;
+}
+
+} // namespace baikaldb

--- a/src/store/region_control.cpp
+++ b/src/store/region_control.cpp
@@ -154,12 +154,12 @@ int RegionControl::clear_all_infos_for_region(int64_t drop_region_id) {
     remove_log_entry(drop_region_id);
     return 0;
 }
-int RegionControl::ingest_data_sst(const std::string& data_sst_file, int64_t region_id) {
+int RegionControl::ingest_data_sst(const std::string& data_sst_file, int64_t region_id, bool move_files) {
     auto rocksdb = RocksWrapper::get_instance();
     rocksdb::IngestExternalFileOptions ifo;
     // snapshot恢复流程需要保留原始文件
     // TODO 修改恢复流程，可以减少一次文件copy
-    //ifo.move_files = true;
+    ifo.move_files = move_files;
     ifo.write_global_seqno = false;
     auto data_cf = rocksdb->get_data_handle();
     auto res = rocksdb->ingest_external_file(data_cf, {data_sst_file}, ifo);

--- a/src/tools/script/gen_done_file.sh
+++ b/src/tools/script/gen_done_file.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+#if [ $# -ne 1 ];then
+#    echo param1: stream_name
+#    exit 1
+#fi
+#mysql -h10.94.160.61 -uroot -pfast -P8121 -Dfengmai -e "select * from baikaldb_level" > out
+#mysql -hsmartbns.fcdb7113-bmi0000.xdb.all.serv -ubaikaldb_read -p3dJ_1xvrVG2y -P5616 -DFC_Fengmai
+WATT_PARAM_HOST="smartbns.fcdb7113-bmi0000.xdb.all.serv"
+WATT_PARAM_PORT="5616"
+WATT_PARAM_USER="baikaldb_read"
+WATT_PARAM_PASSWORD="3dJ_1xvrVG2y"
+WATT_PARAM_DB="FC_Fengmai"
+WATT_PARAM_TABLE="baikaldb_level"
+WATT_BASE_PATH="/home/work/afs_cluster/mnt"
+
+while getopts ":s:d:t:" opt
+do
+    case $opt in
+        s)
+        echo "stream:$OPTARG"
+        OPT_STREAM_NAME=$OPTARG
+        ;;
+        d)
+        echo "database:$OPTARG"
+        OPT_DATABASE=$OPTARG
+        ;;
+        t)
+        echo "table:$OPTARG"
+        OPT_TABLE=$OPTARG
+        ;;
+        ?)
+        echo "unkonwn param"
+        exit 1;;
+    esac
+done
+
+PROJECT_PATH=$(cd `dirname $0`; pwd)
+echo $PROJECT_PATH
+DATE=$(date +%Y%m%d%H%m%S)
+echo $DATE
+if [ X$OPT_STREAM_NAME != X ];then
+    IMPORT_DIR=${OPT_STREAM_NAME}"_"$DATE
+elif [ X$OPT_DATABASE != X ] && [ X$OPT_TABLE != X ];then
+    IMPORT_DIR=${OPT_DATABASE}"_"${OPT_TABLE}"_"$DATE
+else
+    echo "invalid param stream:$OPT_STREAM_NAME database:$OPT_DATABASE table:$OPT_TABLE"
+    exit 1
+fi
+
+WORK_DIR=$PROJECT_PATH/$IMPORT_DIR
+DATA_DIR=$PROJECT_PATH/data/$IMPORT_DIR
+echo $WORK_DIR
+if [ ! -d $WORK_DIR ];then
+    mkdir -p $WORK_DIR
+    mkdir -p $DATA_DIR
+else
+    echo "maybe done, date:"$DATE
+    exit 1
+fi
+
+function fail_quit() {
+    cd $PROJECT_PATH  
+    rm -r $WORK_DIR
+    exit 1
+}
+
+function get_column_single() {
+    local column_name=$1
+    local idx=$(head -1 $MYSQL_OUT_FILE | awk -F "\t" -v name="${column_name}" '{for(i=0;i<NF;i++){if($i==name){print i}}}')     
+    echo $(cat $MYSQL_OUT_FILE | sed -n '2,2p' | awk -F "\t" -v i="${idx}" '{print $i}')   
+}
+
+function get_column_multi() {
+    local column_name=$1
+    local idx=$(head -1 $MYSQL_OUT_FILE | awk -F "\t" -v name="${column_name}" '{for(i=0;i<NF;i++){if($i==name){print i}}}')     
+    echo $(cat $MYSQL_OUT_FILE | sed '1d' | awk -F "\t" -v i="${idx}" '{print $i}')   
+}
+
+function check_base() {
+    local shard_num=$1
+    local group_num=$2
+    local stream_path=$3
+    for ((i=0;i<$shard_num;i++))
+    {
+        if [ ! -d $stream_path/$i ];then
+            echo "$stream_path/$i is not dir"
+            return 1
+        fi
+        if [ ! -d $stream_path/$i/merge ];then
+            echo "$stream_path/$i/merge is not dir"
+            return 1
+        fi
+        local bid_count=$(ls $stream_path/$i | grep "bid.info.n" | grep -v "md5" | wc -l)
+        if [ $bid_count -ne $group_num ];then
+            echo "path:$stream_path/$i bid_count:$bid_count vs group_num:$group_num base invalid"
+            return 1
+        fi
+    }
+    return 0
+}
+
+#############################################################
+cd $WORK_DIR
+MYSQL_OUT_FILE="mysql_out_file"
+if [ X$OPT_STREAM_NAME != X ];then
+    mysql -h$WATT_PARAM_HOST -P$WATT_PARAM_PORT -u$WATT_PARAM_USER -p$WATT_PARAM_PASSWORD -D$WATT_PARAM_DB -e "select * from $WATT_PARAM_TABLE where stream in ('$OPT_STREAM_NAME')" > mysql_out_tmp
+    if [ $? -ne 0 ];then
+        echo "mysql exec failed"
+        fail_quit
+    fi
+elif [ X$OPT_DATABASE != X ] && [ X$OPT_TABLE != X ];then
+    mysql -h$WATT_PARAM_HOST -P$WATT_PARAM_PORT -u$WATT_PARAM_USER -p$WATT_PARAM_PASSWORD -D$WATT_PARAM_DB -e "select * from $WATT_PARAM_TABLE where baikaldb_dbname in ('$OPT_DATABASE') and baikaldb_tablename in ('$OPT_TABLE')" > mysql_out_tmp
+    if [ $? -ne 0 ];then
+        echo "mysql exec failed"
+        fail_quit
+    fi
+else
+    echo "invalid param stream:$OPT_STREAM_NAME database:$OPT_DATABASE table:$OPT_TABLE"
+    fail_quit
+fi
+cat mysql_out_tmp | grep -v baidu_dba > $MYSQL_OUT_FILE
+rm -f mysql_out_tmp
+if [ $(cat $MYSQL_OUT_FILE | wc -l) -le 1 ];then
+    echo "no data in mysql, stream:$OPT_STREAM_NAME"
+    fail_quit
+fi
+PRODUCT=$(get_column_single "product")
+STREAM=$(get_column_single "stream")
+PROFILE=$(get_column_single "profile")
+DATABASES=($(get_column_multi "baikaldb_dbname"))
+TABLES=($(get_column_multi "baikaldb_tablename"))
+LEVEL_VALUES=($(get_column_multi "level"))
+FIELD_JSON=($(get_column_multi "field_json"))
+SHARD_NUM=$(get_column_single "shard_num")
+GROUP_NUM=$(get_column_single "group_num")
+CHARSET=$(get_column_single "charset")
+if [ X$PRODUCT = X ] || [ X$STREAM = X ] || [ X$PROFILE = X ] || [ X$SHARD_NUM = X ] || [ X$GROUP_NUM = X ] || [ X$DATABASES = X ] || [ X$TABLES = X ] || [ X$LEVEL_VALUES = X ];then
+    echo product:$PRODUCT
+    echo stream:$STREAM
+    echo profile:$PROFILE
+    echo shard_num:$SHARD_NUM
+    echo group_num:$GROUP_NUM
+    echo datebases:$DATABASES
+    echo tables:$TABLES
+    echo level_values:$LEVEL_VALUES
+    fail_quit
+fi
+
+STREAM_PATH=$WATT_BASE_PATH/$PRODUCT-$STREAM-$PROFILE
+echo stream_path:$STREAM_PATH
+if [ ! -d $STREAM_PATH ];then
+    echo stream_path:$STREAM_PATH is not dir
+    fail_quit
+fi
+check_base $SHARD_NUM $GROUP_NUM $STREAM_PATH
+if [ $? -ne 0 ];then
+    echo "check base failed"
+    fail_quit
+fi
+
+for ((shard_dir=0;shard_dir<$SHARD_NUM; shard_dir++))
+{
+    ln -s $STREAM_PATH/$shard_dir/merge $DATA_DIR/$shard_dir
+}
+
+done_json="{\"path\": \"./$IMPORT_DIR\", \"charset\":\"$CHARSET\", \"update\": ["
+table_size=${#TABLES[@]}
+echo table_size:$table_size
+for ((table_idx=0;table_idx<${table_size};table_idx++))
+{
+    table_json="{\"filter_field\": \"level\",\"filter_value\": \"${LEVEL_VALUES[$table_idx]}\",\"fields\": ${FIELD_JSON[$table_idx]},\"db\": \"${DATABASES[$table_idx]}\", \"table\": \"${TABLES[$table_idx]}\"}"
+    echo table_idx:$table_idx table_json:$table_json
+    table_index=$[${table_size}-1]
+    if [ $table_idx -lt ${table_index} ];then
+        done_json=$done_json$table_json,
+    else
+        done_json=$done_json$table_json
+    fi
+}
+
+done_json=$done_json"]}"
+
+cd $PROJECT_PATH
+
+echo $done_json | python -mjson.tool > ./$IMPORT_DIR.done

--- a/src/tools/script/modify_index_status.sh
+++ b/src/tools/script/modify_index_status.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+#Created on 2020-09-18
+#测试场景：完成的meta_server流程
+
+echo -e "\n"
+echo -e "修改索引状态\n"
+echo -e "IHS_NORMAL : 普通索引\n"
+echo -e "IHS_DISABLE : 屏蔽索引\n"
+curl -d '{
+    "op_type":"OP_SET_INDEX_HINT_STATUS",
+    "table_info": {
+        "table_name": "TEST",
+        "database": "TEST",
+        "namespace_name": "TEST",
+        "indexs": [ {
+                "index_name" : "TEST",
+                "hint_status" : "IHS_DISABLE"
+            }
+        ]
+
+    }
+}' http://$1/MetaService/meta_manager
+echo -e "\n"

--- a/src/tools/script/show_processlist.sh
+++ b/src/tools/script/show_processlist.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+#you can add 'bns user password' to this array
+bns_user_password_array=(
+#             bns                                user        password
+    'group.opera-ps-baikaldb-000-bj.FENGCHAO.all baikal_user 59ACp2Bl#'
+    'group.opera-ps-baikaldb-000-ct.FENGCHAO.all baikal_user 59ACp2Bl#'
+    'group.opera-e0-baikaldb-000-yz.FENGCHAO.all root        root'
+)
+#print sql info to this file
+OUTPUTFILENAME="sql_proccesslist"
+TIME=60
+
+#############################################################################
+array_size=${#bns_user_password_array[@]}
+#echo "array_size:$array_size"
+for array in "${bns_user_password_array[@]}"
+{
+    array_line=($array)
+    #echo "array_line:${array_line[@]}"
+    #echo "bns:${array_line[0]};user:${array_line[1]};password:${array_line[2]}"
+    TMP_IPS=($(get_instance_by_service -a ${array_line[0]} | awk -F ' ' '{print $2}'))
+    if [ ${#TMP_IPS[@]} -eq 0 ];then
+        echo "get instance by service failed, bns_name:${array_line[0]}"
+        exit 1
+    fi
+    IPS=(${IPS[@]} ${TMP_IPS[@]})
+    PORTS=(${PORTS[@]} $(get_instance_by_service -a ${array_line[0]} | awk -F ' ' '{print $4}'))
+    STATUS=(${STATUS[@]} $(get_instance_by_service -a ${array_line[0]} | awk -F ' ' '{print $5}'))
+    HOSTNAMES=(${HOSTNAMES[@]} $(get_instance_by_service -a ${array_line[0]} | awk -F ' ' '{print $9}'))
+    ip_size=${#IPS[@]}
+    for ((i=0;i<ip_size;i++))
+    {
+        USERS=(${USERS[@]} ${array_line[1]})
+        PASSWORDS=(${PASSWORDS[@]} ${array_line[2]})
+    }
+}
+#echo "IPS:${IPS[@]}"
+#echo "PORTS:${PORTS[@]}"
+#echo "USERS:${USERS[@]}"
+#echo "PASSWORDS:${PASSWORDS[@]}"
+#echo "STATUS:${STATUS[@]}"
+#echo "HOSTNAMES:${HOSTNAMES[@]}"
+
+index=0
+ip_size=${#IPS[@]}
+#echo "ip_size:$ip_size"
+for ip in ${IPS[@]}
+do
+    echo "${HOSTNAMES[$index]} doing..."
+    echo "##########"${HOSTNAMES[$index]} "BEGIN ##########" >> $OUTPUTFILENAME
+    if [ ${STATUS[$index]} -ne 0 ];then
+        echo "${HOSTNAMES[$index]} is faulty"
+        continue
+    fi
+    mysql -h$ip -P${PORTS[$index]} -u${USERS[$index]} -p${PASSWORDS[$index]} -e "show processlist" > ${HOSTNAMES[$index]}.tmpfile1
+    if [ $? -ne 0 ];then
+        echo "mysql exec failed, ip:$ip, port:${PORTS[$index]}, user:${USERS[$index]}, password:${PASSWORDS[$index]}"
+        exit 1
+    fi
+    grep -v Sleep ${HOSTNAMES[$index]}.tmpfile1 > ${HOSTNAMES[$index]}.tmpfile2
+    while read line
+    do
+        sql=`echo $line | awk -F ' ' '{print $8}'`
+        if [ X$sql = X ];then
+            echo "line:$line has not sql info"
+            continue
+        elif [ "$sql" = "NULL" ];then
+            continue
+        fi
+
+        time_s=`echo $line | awk -F ' ' '{print $6}'`
+        if [ X$time_s = X ];then
+            echo "line:$line has not Time info"
+            continue
+        elif [ $time_s = "Time" ];then
+            echo $line >> $OUTPUTFILENAME
+        elif [ $time_s -ge $TIME ];then
+            echo $line >> $OUTPUTFILENAME
+        fi
+    done < ${HOSTNAMES[$index]}.tmpfile2
+    echo "##########"${HOSTNAMES[$index]} "END ##########" >> $OUTPUTFILENAME
+    rm -rf ${HOSTNAMES[$index]}.tmpfile*
+    let index++
+done
+echo "print sql info to $OUTPUTFILENAME"
+exit 0
+
+

--- a/src/tools/script/update_binlog.sh
+++ b/src/tools/script/update_binlog.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#Created on 2020-6-22
+
+echo -e "\n"
+curl -d '{
+    "op_type":"OP_UNLINK_BINLOG",
+    "table_info": {
+        "table_name": "tuuu",
+        "database": "Feed",
+        "namespace_name": "FENGCHAO"
+    },
+    "binlog_info": {
+        "table_name": "tt",
+        "database": "Feed",
+        "namespace_name": "FENGCHAO"
+    }
+}' http://$1/MetaService/meta_manager
+echo -e "\n"

--- a/src/tools/script/update_schema_conf.sh
+++ b/src/tools/script/update_schema_conf.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+#Created on 2017-11-22 
+#测试场景：完成的meta_server流程
+#bool need_merge
+#bool storage_compute_separate
+#bool select_index_by_cost
+#optional float filter_ratio 
+
+echo -e "\n"
+curl -d '{
+    "op_type":"OP_UPDATE_SCHEMA_CONF",
+    "table_info": {
+        "table_name": "t_sort",
+        "database": "TEST",
+        "namespace_name": "TEST",
+        "schema_conf":{
+            "select_index_by_cost": true
+        }
+    }
+}' http://$1/MetaService/meta_manager
+echo -e "\n"
+

--- a/test/test_common.cpp
+++ b/test/test_common.cpp
@@ -44,6 +44,10 @@ int main(int argc, char* argv[])
 
 namespace baikaldb {
 TEST(test_exmaple, case_all) {
+    int a = 10;
+    int& b = a;
+    int& c = b;
+    std::cout << &a << " " << &b << " " << &c << std::endl;
     boost::regex partion_key_pattern("[0-9.]+[eE][+-][0-9]+");
     boost::cmatch what;  
     auto aa = boost::regex_search("insert into user_acct (cop_userid, fc_userid) values (1123, 1.0E+7)", what, partion_key_pattern);


### PR DESCRIPTION
支持binlog，稍后给出使用文档和一个简单的binlog发sql的工具
addpeer前会检查rocksdb是否stalling，提前拒绝addpeer，减少禁写风险
增加dataindex，在install snapshot时会判断follower的数据是否已经是新的
单语句事务可能会导致raft卡住的bug修复
修复之前GetApproximateSizes不准的bug
代价相关会结合一些规则判断，增加索引选择正确率
暂时使用直方图+内部的distinct count做等值判断，cmskectch在大表情况下准确性较低
修复一些可能的内存泄露问题
修复一系列已知bug