### PR TITLE
fix: read binlog delay 3s problems

### DIFF
--- a/src/store/region_binlog.cpp
+++ b/src/store/region_binlog.cpp
@@ -569,6 +569,7 @@ int Region::binlog_update_map_when_apply(const std::map<std::string, ExprValue>&
             }
         }
 
+        _binlog_param.max_ts_in_map = ts;
         if (_binlog_param.ts_binlog_map.size() > 0) {
             _binlog_param.min_ts_in_map = _binlog_param.ts_binlog_map.begin()->first;
         } else {
@@ -742,6 +743,7 @@ void Region::apply_binlog(const pb::StoreReq& request, braft::Closure* done) {
         }
 
         binlog_update_map_when_apply(field_value_map);
+        binlog_update_check_point();
     }
 
     if (done != nullptr && ((BinlogClosure*)done)->response != nullptr) {


### PR DESCRIPTION
- 问题描述：server端更新一条数据，收集端需要3s的延迟才能收到binlog
- 问题分析：https://github.com/baidu/BaikalDB/blob/master/src/store/region_binlog.cpp#L744
1. apply_binlog时，仅调用binlog_update_map_when_apply，未调用binlog_update_check_point
2. binlog_update_map_when_apply时未更新max_ts_in_map，及ts_binlog_map为空时的min_ts_in_map