### PR TITLE
add functions lz4 zstd  bvars  & bug fix

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -93,6 +93,7 @@ new_http_archive(
     name = "com_github_facebook_rocksdb",
     url = "https://github.com/facebook/rocksdb/archive/v6.8.1.tar.gz",
     strip_prefix = "rocksdb-6.8.1",
+    sha256 = "ca192a06ed3bcb9f09060add7e9d0daee1ae7a8705a3d5ecbe41867c5e2796a2",
     build_file = "third-party/com_github_facebook_rocksdb/BUILD",
 )
 
@@ -105,6 +106,7 @@ new_http_archive(
     name = "com_github_RoaringBitmap_CRoaring",
     url = "https://github.com/RoaringBitmap/CRoaring/archive/v0.2.66.tar.gz",
     strip_prefix = "CRoaring-0.2.66",
+    sha256 = "df98bd8f6ff09097ada529a004af758ff4d33faf6a06fadf8fad9a6533afc241",
     build_file = "third-party/com_github_RoaringBitmap_CRoaring/BUILD",
 )
 
@@ -145,6 +147,34 @@ bind(
     name = "snappy_config",
     actual = "//third-party/snappy_config:config"
 )
+
+# lz4
+new_http_archive(
+    name = "com_github_lz4_lz4",
+    urls = ["https://github.com/lz4/lz4/archive/v1.9.2.tar.gz"],
+    strip_prefix = "lz4-1.9.2",
+    build_file = "third-party/lz4.BUILD",
+    sha256 = "658ba6191fa44c92280d4aa2c271b0f4fbc0e34d249578dd05e50e76d0e5efcc",
+)
+bind(
+    name = "lz4",
+    actual = "@com_github_lz4_lz4//:lz4",
+)
+
+#zstd
+new_http_archive(
+    name = "com_github_facebook_zstd",
+    urls = ["https://github.com/facebook/zstd/archive/v1.4.4.tar.gz",],
+    strip_prefix = "zstd-1.4.4",
+    build_file = "third-party/zstd.BUILD",
+    sha256 = "a364f5162c7d1a455cc915e8e3cf5f4bd8b75d09bc0f53965b0c9ca1383c52c8",
+)
+
+bind(
+    name = "zstd",
+    actual = "@com_github_facebook_zstd//:zstd",
+)
+
 
 git_repository(
     name = "com_github_brpc_braft",

--- a/include/common/expr_value.h
+++ b/include/common/expr_value.h
@@ -742,6 +742,20 @@ struct ExprValue {
         ExprValue ret(pb::BITMAP);
         return ret;
     }
+    static ExprValue UTC_TIMESTAMP() {
+        // static int UTC_OFFSET = 8 * 60 * 60;
+        time_t current_time;
+        struct tm *timeinfo = localtime(&current_time);
+        long offset = timeinfo->tm_gmtoff;
+
+        ExprValue tmp(pb::TIMESTAMP);
+        tmp._u.uint32_val = time(NULL) - offset;
+        tmp.cast_to(pb::DATETIME);
+        timeval tv;
+        gettimeofday(&tv, NULL);
+        tmp._u.uint64_val |= tv.tv_usec;
+        return tmp;
+    }
 };
 }
 

--- a/include/common/expr_value.h
+++ b/include/common/expr_value.h
@@ -745,8 +745,9 @@ struct ExprValue {
     static ExprValue UTC_TIMESTAMP() {
         // static int UTC_OFFSET = 8 * 60 * 60;
         time_t current_time;
-        struct tm *timeinfo = localtime(&current_time);
-        long offset = timeinfo->tm_gmtoff;
+        struct tm timeinfo;
+        localtime_r(&current_time, &timeinfo);
+        long offset = timeinfo.tm_gmtoff;
 
         ExprValue tmp(pb::TIMESTAMP);
         tmp._u.uint32_val = time(NULL) - offset;

--- a/include/common/log.h
+++ b/include/common/log.h
@@ -172,6 +172,21 @@ inline void glog_info_writelog(const char* fmt, ...) {
     va_end(args);
     LOG(INFO) << buf;
 }
+const int MAX_LOG_LEN_LONG = 20480;
+inline void glog_info_writelog_long(const char* fmt, ...) {
+    char buf[MAX_LOG_LEN_LONG];
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+    LOG(INFO) << buf;
+}
+#define DB_NOTICE_LONG(_fmt_, args...) \
+    do {\
+        ::baikaldb::glog_info_writelog_long("[%s:%d][%s][%llu]" _fmt_, \
+                strrchr(__FILE__, '/') + 1, __LINE__, __FUNCTION__, bthread_self(), ##args);\
+    } while (0);
+
 inline void glog_warning_writelog(const char* fmt, ...) {
     char buf[MAX_LOG_LEN];
     va_list args;
@@ -318,8 +333,8 @@ inline int init_log(const char* bin_name) {
         auto my_logger2 = new SingleLogFileObject(old_logger2, google::GLOG_WARNING);
         google::base::SetLogger(google::GLOG_WARNING, my_logger2);
 
-        auto old_logger3 = google::base::GetLogger(google::ERROR);
-        auto my_logger3 = new SingleLogFileObject(old_logger3, google::ERROR);
+        auto old_logger3 = google::base::GetLogger(google::GLOG_ERROR);
+        auto my_logger3 = new SingleLogFileObject(old_logger3, google::GLOG_ERROR);
         google::base::SetLogger(google::GLOG_ERROR, my_logger3);
     }
     return 0;

--- a/include/common/schema_factory.h
+++ b/include/common/schema_factory.h
@@ -141,6 +141,7 @@ struct FieldInfo {
     bool                can_null = false;
     bool                auto_inc = false;
     bool                deleted = false;
+    bool                noskip = false;
 };
 
 struct DistInfo {

--- a/include/common/type_utils.h
+++ b/include/common/type_utils.h
@@ -71,7 +71,7 @@ struct ResultField {
     std::string     org_table;
     std::string     name;       // Name of column
     std::string     org_name;
-    uint16_t        charsetnr = 0;  // Character set.
+    uint16_t        charsetnr = 33;  // Character set default utf8.
     uint32_t        length = 0;     // Width of column (create length).
     uint8_t         type = 0;       // Type of field. See mysql_com.h for types.
     uint16_t        flags = 1;      // Div flags.

--- a/include/engine/transaction.h
+++ b/include/engine/transaction.h
@@ -532,5 +532,5 @@ private:
     static bvar::LatencyRecorder    rocksdb_get_time_cost;
 };
 
-typedef std::shared_ptr<Transaction> SmartTransaction;
+//typedef std::shared_ptr<Transaction> SmartTransaction;
 }

--- a/include/engine/transaction.h
+++ b/include/engine/transaction.h
@@ -532,5 +532,5 @@ private:
     static bvar::LatencyRecorder    rocksdb_get_time_cost;
 };
 
-//typedef std::shared_ptr<Transaction> SmartTransaction;
+typedef std::shared_ptr<Transaction> SmartTransaction;
 }

--- a/include/expr/internal_functions.h
+++ b/include/expr/internal_functions.h
@@ -66,6 +66,7 @@ ExprValue locate(const std::vector<ExprValue>& input);
 ExprValue unix_timestamp(const std::vector<ExprValue>& input);
 ExprValue from_unixtime(const std::vector<ExprValue>& input);
 ExprValue now(const std::vector<ExprValue>& input);
+ExprValue utc_timestamp(const std::vector<ExprValue>& input);
 ExprValue date_format(const std::vector<ExprValue>& input);
 ExprValue timediff(const std::vector<ExprValue>& input);
 ExprValue timestampdiff(const std::vector<ExprValue>& input);
@@ -85,6 +86,8 @@ ExprValue week(const std::vector<ExprValue>& input);
 ExprValue time_to_sec(const std::vector<ExprValue>& input);
 ExprValue sec_to_time(const std::vector<ExprValue>& input);
 ExprValue datediff(const std::vector<ExprValue>& input);
+ExprValue date_add(const std::vector<ExprValue>& input);
+ExprValue date_sub(const std::vector<ExprValue>& input);
 ExprValue weekday(const std::vector<ExprValue>& input);
 // hll functions
 ExprValue hll_add(const std::vector<ExprValue>& input);

--- a/include/protocol/state_machine.h
+++ b/include/protocol/state_machine.h
@@ -16,6 +16,7 @@
 
 #include <unordered_map>
 #include <map>
+#include <mutex>
 #include <bvar/bvar.h>
 #include "network_socket.h"
 #include "epoll_info.h"
@@ -174,6 +175,7 @@ private:
     bvar::PerSecond<bvar::Adder<int>> sql_error_second;
     std::unordered_map<std::string, std::unique_ptr<bvar::LatencyRecorder> > select_by_users;
     std::unordered_map<std::string, std::unique_ptr<bvar::LatencyRecorder> > dml_by_users;
+    std::mutex          _mutex;
 
     MysqlWrapper*   _wrapper = nullptr;
 

--- a/include/protocol/state_machine.h
+++ b/include/protocol/state_machine.h
@@ -111,7 +111,9 @@ public:
 
 private:
     StateMachine(): dml_time_cost("dml_time_cost"),
-                    select_time_cost("select_time_cost") {
+                    select_time_cost("select_time_cost"),
+                    sql_error("sql_error"),
+                    sql_error_second("sql_error_second", &sql_error){
         _wrapper = MysqlWrapper::get_instance();
     }
 
@@ -168,6 +170,10 @@ private:
 
     bvar::LatencyRecorder dml_time_cost;
     bvar::LatencyRecorder select_time_cost;
+    bvar::Adder<int> sql_error;
+    bvar::PerSecond<bvar::Adder<int>> sql_error_second;
+    std::unordered_map<std::string, std::unique_ptr<bvar::LatencyRecorder> > select_by_users;
+    std::unordered_map<std::string, std::unique_ptr<bvar::LatencyRecorder> > dml_by_users;
 
     MysqlWrapper*   _wrapper = nullptr;
 

--- a/include/reverse/reverse_arrow.h
+++ b/include/reverse/reverse_arrow.h
@@ -20,6 +20,9 @@
 #ifdef LZ4
 #undef LZ4
 #endif
+#ifdef ZSTD
+#undef ZSTD
+#endif
 #include <arrow/ipc/writer.h>
 #include <arrow/ipc/reader.h>
 #include <arrow/api.h>
@@ -114,7 +117,7 @@ public:
         } else {
             return _inner_node;
         }
-        
+
     }
 
     void add_node(const std::string& key, int8_t flag, double weight) {
@@ -147,7 +150,7 @@ public:
     std::string get_key(int64_t index) const {
         return std::string{_keys_ptr->GetView(index)};
     }
-    
+
     pb::ReverseNodeType get_flag(int64_t index) const {
         return pb::ReverseNodeType(_flags_ptr->Value(index));
     }

--- a/include/sqlparser/sql_lex.l
+++ b/include/sqlparser/sql_lex.l
@@ -200,7 +200,6 @@ USAGE { return USAGE; }
 USE { return USE; }
 USING { return USING; }
 UTC_DATE { return UTC_DATE; }
-UTC_TIMESTAMP { return UTC_TIMESTAMP; }
 UTC_TIME { return UTC_TIME; }
 VALUES { return VALUES; }
 LONG { return LONG; }
@@ -392,6 +391,7 @@ MAX { un_reserved_keyword(yylval, yyscanner, parser); return MAX; }
 MID { un_reserved_keyword(yylval, yyscanner, parser); return MID; }
 MIN { un_reserved_keyword(yylval, yyscanner, parser); return MIN; }
 NOW { un_reserved_keyword(yylval, yyscanner, parser); return NOW; }
+UTC_TIMESTAMP { un_reserved_keyword(yylval, yyscanner, parser); return UTC_TIMESTAMP; }
 POSITION { un_reserved_keyword(yylval, yyscanner, parser); return POSITION; }
 SESSION_USER { un_reserved_keyword(yylval, yyscanner, parser); return SESSION_USER; }
 STD { un_reserved_keyword(yylval, yyscanner, parser); return STD; }

--- a/include/sqlparser/sql_parse.y
+++ b/include/sqlparser/sql_parse.y
@@ -226,7 +226,6 @@ extern int sql_error(YYLTYPE* yylloc, yyscan_t yyscanner, SqlParser* parser, con
     USE
     USING
     UTC_DATE
-    UTC_TIMESTAMP
     UTC_TIME
     VALUES
     LONG
@@ -439,6 +438,7 @@ extern int sql_error(YYLTYPE* yylloc, yyscan_t yyscanner, SqlParser* parser, con
     MID
     MIN
     NOW
+    UTC_TIMESTAMP
     POSITION
     SESSION_USER
     STD
@@ -1997,6 +1997,11 @@ FunctionCallNonKeyword:
         fun->fn_name = $1;
         $$ = fun; 
     }
+    | UTC_TIMESTAMP '(' ')' {
+        FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = $1;
+        $$ = fun;
+    }
     | FunctionNameDateArithMultiForms '(' Expr ',' Expr ')' {
         FuncExpr* fun = new_node(FuncExpr);
         fun->fn_name = $1;
@@ -2493,6 +2498,7 @@ AllIdent:
     | MID
     | MIN
     | NOW
+    | UTC_TIMESTAMP
     | POSITION
     | SESSION_USER
     | STD

--- a/src/common/schema_factory.cpp
+++ b/src/common/schema_factory.cpp
@@ -442,6 +442,7 @@ int SchemaFactory::update_table_internal(SchemaMapping& background, const pb::Sc
         field_info.auto_inc = field.auto_increment();
         field_info.deleted = field.deleted();
         field_info.comment = field.comment();
+        field_info.noskip = boost::algorithm::icontains(field_info.comment, "noskip");
         field_info.default_value = field.default_value();
         field_info.on_update_value = field.on_update_value();
         if (field.has_default_value()) {

--- a/src/engine/rocks_wrapper.cpp
+++ b/src/engine/rocks_wrapper.cpp
@@ -50,6 +50,11 @@ DEFINE_int32(min_write_buffer_number_to_merge, 2, "min_write_buffer_number_to_me
 DEFINE_int32(rocks_binlog_max_files_size_gb, 100, "binlog max size default 100G");
 DEFINE_int32(rocks_binlog_ttl_days, 7, "binlog ttl default 7 days");
 
+DEFINE_int32(level0_file_num_compaction_trigger, 5, "Number of files to trigger level-0 compaction");
+DEFINE_int32(max_bytes_for_level_base, 1024 * 1024 * 1024, "total size of level 1.");
+DEFINE_int32(max_bytes_for_level_multiplier, 10, "max_bytes_for_level_multiplier.");
+DEFINE_bool(enable_bottommost_compression, false, "enable zstd for bottommost_compression");
+
 const std::string RocksWrapper::RAFT_LOG_CF = "raft_log";
 const std::string RocksWrapper::BIN_LOG_CF  = "bin_log";
 const std::string RocksWrapper::DATA_CF     = "data";
@@ -151,18 +156,28 @@ int32_t RocksWrapper::init(const std::string& path) {
     _data_cf_option.compaction_filter = SplitCompactionFilter::get_instance();
     _data_cf_option.table_factory.reset(rocksdb::NewBlockBasedTableFactory(table_options));
     _data_cf_option.compaction_style = rocksdb::kCompactionStyleLevel;
-    _data_cf_option.level0_file_num_compaction_trigger = 5;
+//    _data_cf_option.level0_file_num_compaction_trigger = 5;
     _data_cf_option.level0_slowdown_writes_trigger = 10;
     _data_cf_option.level0_stop_writes_trigger = FLAGS_stop_write_sst_cnt;
     _data_cf_option.hard_pending_compaction_bytes_limit = FLAGS_rocks_hard_pending_compaction_g * 1073741824ull;
     _data_cf_option.target_file_size_base = 128 * 1024 * 1024;
-    _data_cf_option.max_bytes_for_level_base = 1024 * 1024 * 1024;
     _data_cf_option.max_bytes_for_level_multiplier = FLAGS_rocks_level_multiplier;
     _data_cf_option.level_compaction_dynamic_level_bytes = FLAGS_rocks_data_dynamic_level_bytes;
 
     _data_cf_option.max_write_buffer_number = FLAGS_max_write_buffer_number;
     _data_cf_option.write_buffer_size = FLAGS_write_buffer_size;
     _data_cf_option.min_write_buffer_number_to_merge = FLAGS_min_write_buffer_number_to_merge;
+
+    _data_cf_option.level0_file_num_compaction_trigger = FLAGS_level0_file_num_compaction_trigger;
+    _data_cf_option.max_bytes_for_level_base = FLAGS_max_bytes_for_level_base;
+    _data_cf_option.max_bytes_for_level_multiplier = FLAGS_max_bytes_for_level_multiplier;
+
+    if (FLAGS_enable_bottommost_compression) {
+        _data_cf_option.bottommost_compression_opts.enabled = true;
+        _data_cf_option.bottommost_compression = rocksdb::kZSTD;
+        _data_cf_option.bottommost_compression_opts.max_dict_bytes = 1 << 14; // 16KB
+        _data_cf_option.bottommost_compression_opts.zstd_max_train_bytes = 1 << 18; // 256KB
+    }
 
     //todo
     //prefix: 0x01-0xFF,分别用来存储不同的meta信息

--- a/src/engine/rocks_wrapper.cpp
+++ b/src/engine/rocks_wrapper.cpp
@@ -52,7 +52,6 @@ DEFINE_int32(rocks_binlog_ttl_days, 7, "binlog ttl default 7 days");
 
 DEFINE_int32(level0_file_num_compaction_trigger, 5, "Number of files to trigger level-0 compaction");
 DEFINE_int32(max_bytes_for_level_base, 1024 * 1024 * 1024, "total size of level 1.");
-DEFINE_int32(max_bytes_for_level_multiplier, 10, "max_bytes_for_level_multiplier.");
 DEFINE_bool(enable_bottommost_compression, false, "enable zstd for bottommost_compression");
 
 const std::string RocksWrapper::RAFT_LOG_CF = "raft_log";
@@ -170,7 +169,6 @@ int32_t RocksWrapper::init(const std::string& path) {
 
     _data_cf_option.level0_file_num_compaction_trigger = FLAGS_level0_file_num_compaction_trigger;
     _data_cf_option.max_bytes_for_level_base = FLAGS_max_bytes_for_level_base;
-    _data_cf_option.max_bytes_for_level_multiplier = FLAGS_max_bytes_for_level_multiplier;
 
     if (FLAGS_enable_bottommost_compression) {
         _data_cf_option.bottommost_compression_opts.enabled = true;

--- a/src/exec/insert_node.cpp
+++ b/src/exec/insert_node.cpp
@@ -226,7 +226,12 @@ int InsertNode::insert_values_for_prepared_stmt(std::vector<SmartRecord>& insert
             expr->close();
         }
         for (auto& field : default_fields) {
-            if (0 != row->set_value(row->get_field_by_idx(field->pb_idx), field->default_expr_value)) {
+            ExprValue default_value = field->default_expr_value;
+            if (field->default_value == "(current_timestamp())") {
+                default_value = ExprValue::Now();
+                default_value.cast_to(field->type);
+            }
+            if (0 != row->set_value(row->get_field_by_idx(field->pb_idx), default_value)) {
                 DB_WARNING("fill insert value failed");
                 return -1;
             }

--- a/src/expr/agg_fn_call.cpp
+++ b/src/expr/agg_fn_call.cpp
@@ -246,7 +246,7 @@ int AggFnCall::initialize(const std::string& key, MemRow* dst) {
         case COUNT_STAR:
         case COUNT: {
             if (dst_val.is_null()) {
-                dst->set_value(_tuple_id, _intermediate_slot_id, ExprValue(_col_type));
+                dst->set_value(_tuple_id, _intermediate_slot_id, ExprValue(pb::INT64));
             }
             return 0;
         }

--- a/src/expr/fn_manager.cpp
+++ b/src/expr/fn_manager.cpp
@@ -152,6 +152,7 @@ void FunctionManager::register_operators() {
     register_object_ret("from_unixtime", from_unixtime, pb::TIMESTAMP);
     register_object_ret("now", now, pb::DATETIME);
     register_object_ret("sysdate", now, pb::DATETIME);
+    register_object_ret("utc_timestamp", utc_timestamp, pb::DATETIME);
     register_object_ret("date_format", date_format, pb::STRING);
     register_object_ret("timediff", timediff, pb::TIME);
     register_object_ret("timestampdiff", timestampdiff, pb::INT64);
@@ -172,6 +173,8 @@ void FunctionManager::register_operators() {
     register_object_ret("sec_to_time", sec_to_time, pb::TIME);
     register_object_ret("weekday", weekday, pb::UINT32);
     register_object_ret("datediff", datediff, pb::UINT32);
+    register_object_ret("date_add", date_add, pb::DATETIME);
+    register_object_ret("date_sub", date_sub, pb::DATETIME);
     // hll funcs
     register_object_ret("hll_add", hll_add, pb::HLL);
     register_object_ret("hll_merge", hll_merge, pb::HLL);

--- a/src/expr/internal_functions.cpp
+++ b/src/expr/internal_functions.cpp
@@ -698,6 +698,9 @@ ExprValue from_unixtime(const std::vector<ExprValue>& input) {
 ExprValue now(const std::vector<ExprValue>& input) {
     return ExprValue::Now();
 }
+ExprValue utc_timestamp(const std::vector<ExprValue>& input) {
+    return ExprValue::UTC_TIMESTAMP();
+}
 ExprValue date_format(const std::vector<ExprValue>& input) {
     if (input.size() != 2) {
         return ExprValue::Null();
@@ -1000,6 +1003,62 @@ ExprValue datediff(const std::vector<ExprValue>& input) {
     ExprValue tmp(pb::INT32);
     tmp._u.int32_val = (t1 - t2) / (3600 * 24);
     return tmp;
+}
+
+ExprValue date_add(const std::vector<ExprValue>& input) {
+    if (input.size() < 3) {
+            return ExprValue::Null();
+    }
+    for (auto& s : input) {
+        if (s.is_null()) {
+            return ExprValue::Null();
+        }
+    }
+    ExprValue arg1 = input[0];
+    ExprValue arg2 = input[1];
+    int32_t interval = arg2.cast_to(pb::INT32)._u.int32_val;
+    ExprValue ret = arg1.cast_to(pb::TIMESTAMP);
+    if (input[2].str_val == "second") {
+        ret._u.uint32_val += interval;
+    } else if (input[2].str_val == "minute") {
+        ret._u.uint32_val += interval * 60;
+    } else if (input[2].str_val == "hour") {
+        ret._u.uint32_val += interval * 3600;
+    } else if (input[2].str_val == "day") {
+        ret._u.uint32_val += interval * (24 * 3600);
+    } else {
+        // un-support
+        return ExprValue::Null();
+    }
+    return ret;
+}
+
+ExprValue date_sub(const std::vector<ExprValue>& input) {
+    if (input.size() < 3) {
+            return ExprValue::Null();
+    }
+    for (auto& s : input) {
+        if (s.is_null()) {
+            return ExprValue::Null();
+        }
+    }
+    ExprValue arg1 = input[0];
+    ExprValue arg2 = input[1];
+    int32_t interval = arg2.cast_to(pb::INT32)._u.int32_val;
+    ExprValue ret = arg1.cast_to(pb::TIMESTAMP);
+    if (input[2].str_val == "second") {
+        ret._u.uint32_val -= interval;
+    } else if (input[2].str_val == "minute") {
+        ret._u.uint32_val -= interval * 60;
+    } else if (input[2].str_val == "hour") {
+        ret._u.uint32_val -= interval * 3600;
+    } else if (input[2].str_val == "day") {
+        ret._u.uint32_val -= interval * (24 * 3600);
+    } else {
+        // un-support
+        return ExprValue::Null();
+    }
+    return ret;
 }
 
 ExprValue hll_add(const std::vector<ExprValue>& input) {

--- a/src/logical_plan/logical_planner.cpp
+++ b/src/logical_plan/logical_planner.cpp
@@ -1143,6 +1143,14 @@ int LogicalPlanner::create_values_expr(const parser::FuncExpr* func_item, pb::Ex
 int LogicalPlanner::create_scala_func_expr(const parser::FuncExpr* item, 
         pb::Expr& expr, parser::FuncType op, const CreateExprOptions& options) {
     if (op == parser::FT_COMMON) {
+        if (item->fn_name.to_lower() == "last_insert_id") {
+            pb::ExprNode* node = expr.add_nodes();
+            node->set_node_type(pb::INT_LITERAL);
+            node->set_col_type(pb::INT64);
+            node->set_num_children(0);
+            node->mutable_derive_node()->set_int_val(_ctx->client_conn->last_insert_id);
+            return 0;
+        }
         if (FunctionManager::instance()->get_object(item->fn_name.to_lower()) == nullptr) {
             DB_WARNING("un-supported scala op or func: %s", item->fn_name.c_str());
             return -1;

--- a/src/meta_server/table_manager.cpp
+++ b/src/meta_server/table_manager.cpp
@@ -1140,7 +1140,12 @@ void TableManager::modify_field(const pb::MetaManagerRequest& request,
         }
         for (auto& mem_field : *mem_schema_pb.mutable_fields()) {
             if (mem_field.field_name() == field_name) {
-                mem_field.set_mysql_type(field.mysql_type());
+                if (field.has_mysql_type()) {
+                    mem_field.set_mysql_type(field.mysql_type());
+                }
+                if (field.has_comment()) {
+                    mem_field.set_comment(field.comment());
+                }
             }
         }
     }

--- a/src/physical_plan/auto_inc.cpp
+++ b/src/physical_plan/auto_inc.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "auto_inc.h"
+#include <boost/algorithm/string.hpp>
 #include "exec_node.h"
 #include "query_context.h"
 #include "schema_factory.h"
@@ -52,6 +53,11 @@ int AutoInc::analyze(QueryContext* ctx) {
                 }
             }
     }
+    auto field_info = table_info_ptr->get_field_ptr(table_info_ptr->auto_inc_field_id);
+    // 通过字段注释可以标示:自增id不会随着插入id进行跳号,当插入的自增id来自于异构数据源时,用于避免自增id的双写冲突问题.
+    if (field_info !=nullptr && boost::algorithm::icontains(field_info->comment, "noskip")) {
+        max_id = 0;
+    }
     if (auto_id_count == 0 && max_id == 0) {
         return 0;
     }
@@ -71,6 +77,9 @@ int AutoInc::analyze(QueryContext* ctx) {
     }
     
     if (auto_id_count == 0) {
+        if (max_id > 0) {
+            ctx->client_conn->last_insert_id = max_id;
+        }
         return 0;
     }
     int64_t start_id = response.start_id();

--- a/src/physical_plan/auto_inc.cpp
+++ b/src/physical_plan/auto_inc.cpp
@@ -55,7 +55,7 @@ int AutoInc::analyze(QueryContext* ctx) {
     }
     auto field_info = table_info_ptr->get_field_ptr(table_info_ptr->auto_inc_field_id);
     // 通过字段注释可以标示:自增id不会随着插入id进行跳号,当插入的自增id来自于异构数据源时,用于避免自增id的双写冲突问题.
-    if (field_info !=nullptr && boost::algorithm::icontains(field_info->comment, "noskip")) {
+    if (field_info != nullptr && field_info->noskip) {
         max_id = 0;
     }
     if (auto_id_count == 0 && max_id == 0) {

--- a/src/protocol/network_server.cpp
+++ b/src/protocol/network_server.cpp
@@ -576,6 +576,7 @@ bool NetworkServer::start() {
         DB_FATAL("Network server is not initail.");
         return false;
     }
+    DB_WARNING("db server init success");
     if (0 != make_worker_process()) {
         DB_FATAL("Start event loop failed.");
         return false;

--- a/src/protocol/state_machine.cpp
+++ b/src/protocol/state_machine.cpp
@@ -367,7 +367,7 @@ void StateMachine::_print_query_time(SmartSocket client) {
                 || ctx->mysql_cmd == COM_STMT_EXECUTE) {
         if (op_type == pb::OP_SELECT) {
             select_time_cost << stat_info->total_time;
-            if (select_by_users.find(client->username) == dml_by_users.end()) {
+            if (select_by_users.find(client->username) == select_by_users.end()) {
                 select_by_users[client->username].reset(new bvar::LatencyRecorder("select_" + client->username));
             }
             (*select_by_users[client->username]) << stat_info->total_time;

--- a/src/protocol/state_machine.cpp
+++ b/src/protocol/state_machine.cpp
@@ -1132,7 +1132,7 @@ void StateMachine::_parse_comment(std::shared_ptr<QueryContext> ctx) {
         boost::algorithm::trim_right_if(ctx->sql, boost::is_any_of(" \t\n\r\x0B;"));
     }
     re2::RE2 ignore_reg("(\\/\\*.*?\\*\\/)", option);
-    if (RE2::GlobalReplace(&(ctx->sql), reg, " ")) {
+    if (RE2::GlobalReplace(&(ctx->sql), ignore_reg, " ")) {
         DB_WARNING("global replace sql.");
     }
 }

--- a/src/protocol/state_machine.cpp
+++ b/src/protocol/state_machine.cpp
@@ -367,8 +367,8 @@ void StateMachine::_print_query_time(SmartSocket client) {
                 || ctx->mysql_cmd == COM_STMT_EXECUTE) {
         if (op_type == pb::OP_SELECT) {
             select_time_cost << stat_info->total_time;
+            std::unique_lock<std::mutex> lock(_mutex);
             if (select_by_users.find(client->username) == select_by_users.end()) {
-                std::unique_lock<std::mutex> lock(_mutex);
                 select_by_users[client->username].reset(new bvar::LatencyRecorder("select_" + client->username));
             }
             (*select_by_users[client->username]) << stat_info->total_time;
@@ -376,8 +376,8 @@ void StateMachine::_print_query_time(SmartSocket client) {
                 op_type == pb::OP_UPDATE ||
                 op_type == pb::OP_DELETE) {
             dml_time_cost << stat_info->total_time;
+            std::unique_lock<std::mutex> lock(_mutex);
             if (dml_by_users.find(client->username) == dml_by_users.end()) {
-                std::unique_lock<std::mutex> lock(_mutex);
                 dml_by_users[client->username].reset(new bvar::LatencyRecorder("dml_" + client->username));
             }
             (*dml_by_users[client->username]) << stat_info->total_time;

--- a/src/protocol/state_machine.cpp
+++ b/src/protocol/state_machine.cpp
@@ -368,6 +368,7 @@ void StateMachine::_print_query_time(SmartSocket client) {
         if (op_type == pb::OP_SELECT) {
             select_time_cost << stat_info->total_time;
             if (select_by_users.find(client->username) == select_by_users.end()) {
+                std::unique_lock<std::mutex> lock(_mutex);
                 select_by_users[client->username].reset(new bvar::LatencyRecorder("select_" + client->username));
             }
             (*select_by_users[client->username]) << stat_info->total_time;
@@ -376,6 +377,7 @@ void StateMachine::_print_query_time(SmartSocket client) {
                 op_type == pb::OP_DELETE) {
             dml_time_cost << stat_info->total_time;
             if (dml_by_users.find(client->username) == dml_by_users.end()) {
+                std::unique_lock<std::mutex> lock(_mutex);
                 dml_by_users[client->username].reset(new bvar::LatencyRecorder("dml_" + client->username));
             }
             (*dml_by_users[client->username]) << stat_info->total_time;
@@ -458,7 +460,7 @@ void StateMachine::_print_query_time(SmartSocket client) {
                     stat_info->old_txn_id,
                     stat_info->old_seq_id,
                     ctx->get_runtime_state()->optimize_1pc(),
-		            out[0],
+                    out[0],
                     sql.length(),
                     sql.c_str(),
                     client->last_insert_id);

--- a/src/tools/script/add_auto_increment_id.sh
+++ b/src/tools/script/add_auto_increment_id.sh
@@ -128,3 +128,14 @@ curl -d '{
     }
 }' http://$1/MetaService/meta_manager
 echo -e "\n"
+
+#更新自增ID
+curl -d '{
+    "op_type": "OP_UPDATE_FOR_AUTO_INCREMENT",
+    "auto_increment": {
+        "table_id": 1,
+        "force": true,
+        "start_id": 100
+    }
+}' http://$1/MetaService/meta_manager
+echo -e "\n"

--- a/src/tools/script/update_field.sh
+++ b/src/tools/script/update_field.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+#Created on 2020-12-17 
+#测试场景：完成的modify field流程
+
+echo -e "\n"
+#comment字段用protobuf的bytes类型表示,请求时需要进行base64编码
+#可以在线编码https://www.base64encode.org/,"noskip" base64编码后为: "bm9za2lw"
+echo -e "修改列信息\n"
+curl -d '{
+    "op_type":"OP_MODIFY_FIELD",
+    "table_info": {
+        "table_name": "t",
+        "database": "TestDB",
+        "namespace_name": "TEST",
+        "fields": [ {
+                        "field_name" : "id",
+                        "comment" : "bm9za2lw" 
+                    }]
+    }
+}' http://$1/MetaService/meta_manager
+echo -e "\n"
+
+#查询table
+curl -d '{
+    "op_type" : "QUERY_SCHEMA"
+}' http://$1/MetaService/query
+echo -e "\n"
+

--- a/third-party/com_github_facebook_rocksdb/BUILD
+++ b/third-party/com_github_facebook_rocksdb/BUILD
@@ -266,6 +266,8 @@ cc_library(
         "SNAPPY",
         "HAVE_SSE42",
         "ZLIB",
+        "LZ4",
+        "ZSTD",
         "ROCKSDB_SCHED_GETCPU_PRESENT",
         "ROCKSDB_MALLOC_USABLE_SIZE",
     ],
@@ -298,6 +300,8 @@ cc_library(
         "//external:gtest",
         "//external:snappy",
         "//external:zlib",
+        "//external:lz4",
+        "//external:zstd",
     ],
     visibility = ["//visibility:public"],
 )

--- a/third-party/lz4.BUILD
+++ b/third-party/lz4.BUILD
@@ -1,0 +1,8 @@
+cc_library(
+    name = "lz4",
+    # We include the lz4.c as a header as lz4hc.c actually does #include "lz4.c".
+    hdrs = glob(["lib/*.h"]) + ["lib/lz4.c"],
+    srcs = glob(["lib/*.c"]),
+    visibility = ["//visibility:public"],
+    strip_include_prefix = "lib",
+)

--- a/third-party/zstd.BUILD
+++ b/third-party/zstd.BUILD
@@ -1,0 +1,112 @@
+licenses(["notice"])  # Apache v2 
+
+#@see: https://github.com/cschuet/zstd
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "zstd",
+    hdrs = glob(["lib/**/*.h"]),
+    srcs = glob(["lib/**/*.c"]),
+    copts = [
+        "-DZSTD_LEGACY_SUPPORT=5",
+        "-DXXH_NAMESPACE=ZSTD_",
+    ],
+    strip_include_prefix = "lib",
+    deps = [
+        ":zstd_header",
+        ":common",
+        ":compress",
+        ":decompress",
+        ":deprecated",
+        ":zdict",
+        ":legacy",
+    ],
+)
+
+cc_library(
+    name = "zdict",
+    hdrs = glob(["lib/dictBuilder/*.h"]),
+    srcs = glob(["lib/dictBuilder/*.c"]),
+    copts = [
+        "-DZSTD_LEGACY_SUPPORT=5",
+        "-DXXH_NAMESPACE=ZSTD_",
+    ],
+    strip_include_prefix = "lib/dictBuilder",
+    deps = [":common"],
+)
+
+cc_library(
+    name = "legacy",
+    hdrs = glob(["lib/legacy/*.h"]),
+    srcs = glob(["lib/legacy/*.c"]),
+    copts = [
+        "-DZSTD_LEGACY_SUPPORT=5",
+        "-DXXH_NAMESPACE=ZSTD_",
+    ],
+    strip_include_prefix = "lib/legacy",
+    deps = [":common"],
+)
+cc_library(
+    name = "decompress",
+    hdrs = glob(["lib/decompress/*.h"]),
+    srcs = glob(["lib/decompress/*.c"]),
+    strip_include_prefix = "lib/decompress",
+    copts = [
+        "-DXXH_NAMESPACE=ZSTD_",
+        "-DZSTD_LEGACY_SUPPORT=5",
+    ],
+    deps = [
+        ":common",
+        ":legacy",
+    ],
+)
+
+cc_library(
+    name = "deprecated",
+    hdrs = glob(["lib/deprecated/*.h"]),
+    srcs = glob(["lib/deprecated/*.c"]),
+    strip_include_prefix = "lib/deprecated",
+    copts = [
+        "-DXXH_NAMESPACE=ZSTD_",
+        "-DZSTD_LEGACY_SUPPORT=5",
+    ],
+    deps = [":common"],
+)
+
+cc_library(
+    name = "compress",
+    hdrs = glob(["lib/compress/*.h"]),
+    srcs = glob(["lib/compress/*.c"]),
+    copts = [
+        "-DZSTD_LEGACY_SUPPORT=5",
+        "-DXXH_NAMESPACE=ZSTD_",
+    ],
+    strip_include_prefix = "lib/compress",
+    deps = [":common"],
+)
+
+cc_library(
+    name = "common",
+    hdrs = glob(["lib/common/*.h"]),
+    srcs = glob(["lib/common/*.c"]),
+    strip_include_prefix = "lib/common",
+    copts = [
+        "-DZSTD_LEGACY_SUPPORT=5",
+        "-DXXH_NAMESPACE=ZSTD_",
+    ],
+    deps = [":zstd_header"],
+)
+
+cc_library(
+    name = "zstd_header",
+    hdrs = ["lib/zstd.h"],
+    strip_include_prefix = "lib",
+)
+cc_library(
+    name = "threading",
+    hdrs = ["lib/common/threading.h"],
+    srcs = ["lib/common/threading.c"],
+    linkopts = ["-pthread"],
+    copts = ["-DZSTD_MULTITHREAD"],
+    deps = [":debug"],
+)


### PR DESCRIPTION
**New Features:**
- add db qps bvars by users
- noskip for auto inc field
- add last_insert_id, sign and set set MAX_LOG_LEN to 20480 for _print_query_time log
- add gflags to reduce read amplification
- add lz4 zstd compression support for rocksdb
- add funcs: date_add, date_sub, utc_timestamp, last_insert_id
- set filed charset default utf8 adapts for dotnet mysql.client

**Bug Fixes:**
- prepare insert current time default value
- fix count(*) return NULL expected 0 when filter expr is always false
- ignore non-json format comment for sql string
- update last_insert_id when client set the value