### PR TITLE
make cstore vectorization when  table_seek

### DIFF
--- a/include/engine/table_iterator.h
+++ b/include/engine/table_iterator.h
@@ -13,7 +13,8 @@
 // limitations under the License.
 
 #pragma once
- 
+
+#include <bitset>
 #include "rocks_wrapper.h"
 #include "schema_factory.h"
 #include "mut_table_key.h"
@@ -25,6 +26,7 @@ class Transaction;
 class TableIterator;
 class IndexIterator;
 typedef std::shared_ptr<Transaction> SmartTransaction;
+typedef std::bitset<ROW_BATCH_CAPACITY> FiltBitSet;
 
 //前缀的=传 [key, key],双闭区间
 struct IndexRange {
@@ -85,8 +87,8 @@ public:
         delete _iter;
         _iter = nullptr;
         for (auto& iter : _column_iters) {
-            delete iter;
-            iter = nullptr;
+            delete iter.second;
+            iter.second = nullptr;
         }
     }
 
@@ -114,6 +116,14 @@ public:
         std::vector<int32_t>& field_slot,
         bool                check_region, 
         bool                forward);
+
+    bool is_cstore() {
+        return _is_cstore;
+    }
+    void ResetPrimaryKeys() {
+        _primary_keys.clear();
+        _primary_keys.reserve(ROW_BATCH_CAPACITY);
+    }
 
 protected:
     MutTableKey             _start;
@@ -151,8 +161,8 @@ protected:
     std::map<int32_t, FieldInfo*>    _fields;
     std::vector<int32_t> _field_slot;
 
-    std::vector<rocksdb::Iterator*>     _column_iters; // cstore, own it, should delete when destruct
-    std::vector<FieldInfo*>             _non_pk_fields; // cstore
+    std::vector<std::string>                _primary_keys;
+    std::map<int32_t, rocksdb::Iterator*>   _column_iters;
 
     int _prefix_len = sizeof(int64_t) * 2;
 
@@ -182,13 +192,9 @@ public:
     void set_mode(KVMode mode) {
         _mode = mode;
     }
-
+    int get_column(int32_t tuple_id, const FieldInfo& field, RowBatch* batch, FiltBitSet* filter = nullptr);
 private:
     int get_next_internal(SmartRecord* record, int32_t tuple_id, std::unique_ptr<MemRow>* mem_row);
-    // _iter is used to fit_bound and set pk field value,
-    // _column_iters is only used for set non-pk field value
-    int get_next_columns(const rocksdb::Slice& iter_key, SmartRecord* record, 
-            int32_t tuple_id, std::unique_ptr<MemRow>* mem_row);
     KVMode  _mode;
 };
 

--- a/include/engine/table_iterator.h
+++ b/include/engine/table_iterator.h
@@ -120,7 +120,7 @@ public:
     bool is_cstore() {
         return _is_cstore;
     }
-    void ResetPrimaryKeys() {
+    void reset_primary_keys() {
         _primary_keys.clear();
         _primary_keys.reserve(ROW_BATCH_CAPACITY);
     }
@@ -192,7 +192,7 @@ public:
     void set_mode(KVMode mode) {
         _mode = mode;
     }
-    int get_column(int32_t tuple_id, const FieldInfo& field, RowBatch* batch, FiltBitSet* filter = nullptr);
+    int get_column(int32_t tuple_id, const FieldInfo& field, const FiltBitSet* filter, RowBatch* batch);
 private:
     int get_next_internal(SmartRecord* record, int32_t tuple_id, std::unique_ptr<MemRow>* mem_row);
     KVMode  _mode;

--- a/include/exec/rocksdb_scan_node.h
+++ b/include/exec/rocksdb_scan_node.h
@@ -118,6 +118,8 @@ private:
 
 private:
     std::map<int32_t, FieldInfo*> _field_ids;
+    std::vector<int32_t> _filt_field_ids;
+    std::vector<int32_t> _trivial_field_ids;
     std::vector<int32_t> _field_slot;
     MemRowDescriptor* _mem_row_desc;
     SelectManagerNode* _related_manager_node = NULL;

--- a/include/runtime/row_batch.h
+++ b/include/runtime/row_batch.h
@@ -86,6 +86,12 @@ public:
     std::unique_ptr<MemRow>& get_row() {
         return _rows[_idx];
     }
+    std::unique_ptr<MemRow>& get_row(size_t i) {
+        return _rows[i];
+    }
+    const size_t& index() {
+        return _idx;
+    }
     void next() {
         _idx++;
     }

--- a/src/engine/table_iterator.cpp
+++ b/src/engine/table_iterator.cpp
@@ -496,7 +496,7 @@ int TableIterator::get_next_internal(SmartRecord* record, int32_t tuple_id, std:
     return 0;
 }
 
-int TableIterator::get_column(int32_t tuple_id, const FieldInfo& field, RowBatch* batch, FiltBitSet* filter) {
+int TableIterator::get_column(int32_t tuple_id, const FieldInfo& field, const FiltBitSet* filter, RowBatch* batch) {
 
     int32_t field_id = field.id;
     int32_t slot_id = _field_slot[field_id];
@@ -511,7 +511,7 @@ int TableIterator::get_column(int32_t tuple_id, const FieldInfo& field, RowBatch
 
     int filter_num = 0;
     for (size_t i = 0; i < batch->size(); ++i) {
-        if (filter && filter->test(i)) {
+        if (filter != nullptr && filter->test(i)) {
             filter_num++;
             continue;
         }

--- a/src/engine/table_iterator.cpp
+++ b/src/engine/table_iterator.cpp
@@ -78,7 +78,6 @@ int Iterator::open(const IndexRange& range, std::map<int32_t, FieldInfo*>& field
         _use_ttl = txn->use_ttl();
         _read_ttl_timestamp_us = txn->read_ttl_timestamp_us();
         _txn = txn->get_txn();
-        _is_cstore = txn->is_cstore();
     }
     bool like_prefix = range.like_prefix;
 
@@ -99,6 +98,7 @@ int Iterator::open(const IndexRange& range, std::map<int32_t, FieldInfo*>& field
         DB_WARNING("get schema factory failed");
         return -1;
     }
+    _is_cstore = _schema->get_table_engine(_pri_info->id) == pb::ROCKSDB_CSTORE;
 
     _start.append_i64(_region).append_i64(index_id);
     _end.append_i64(_region).append_i64(index_id);
@@ -339,6 +339,7 @@ int Iterator::open_columns(std::map<int32_t, FieldInfo*>& fields, SmartTransacti
         key.replace_i32(field_id, sizeof(int64_t) + sizeof(int32_t));
         rocksdb::Iterator* iter;
         if (_txn != nullptr) {
+            read_options.snapshot = txn->get_snapshot();
             iter = _txn->GetIterator(read_options, _data_cf);
         } else {
             iter = _db->new_iterator(read_options, RocksWrapper::DATA_CF);
@@ -358,8 +359,8 @@ int Iterator::open_columns(std::map<int32_t, FieldInfo*>& fields, SmartTransacti
             DB_DEBUG("region:%ld, field:%d, SeekForPrev cost:%ld, valid=%d",
                      _region, field_id, cost.get_time(), iter->Valid());
         }
-        _non_pk_fields.push_back(pair.second);
-        _column_iters.push_back(iter);
+        _column_iters[field_id] = iter;
+//        pair.second->can_null && pair.second->default_expr_value.is_null();
     }
     return 0;
 }
@@ -463,12 +464,8 @@ int TableIterator::get_next_internal(SmartRecord* record, int32_t tuple_id, std:
                 return -1;
             }
         } else {
-            // for cstore, column value may be null.
-            if (0 != get_next_columns(iter_key, record, tuple_id, mem_row)) {
-                DB_WARNING("get non-pk cloumn value failed table_id: %ld", _index_info->id);
-                _valid = false;
-                return -1;
-            }
+            _primary_keys.push_back(std::string(_iter->key().data() + _prefix_len,
+                                                _iter->key().size() - _prefix_len));
         }
     }
     if (KEY_ONLY == _mode || KEY_VAL == _mode) {
@@ -499,83 +496,77 @@ int TableIterator::get_next_internal(SmartRecord* record, int32_t tuple_id, std:
     return 0;
 }
 
-// for cstore only
-int TableIterator::get_next_columns(const rocksdb::Slice& iter_key, SmartRecord* record, 
-        int32_t tuple_id, std::unique_ptr<MemRow>* mem_row) {
-    TableKey primary_key(iter_key, true);
-    rocksdb::Slice pk = iter_key;
-    pk.remove_prefix(_prefix_len);
-    int64_t table_id = _pri_info->id;
+int TableIterator::get_column(int32_t tuple_id, const FieldInfo& field, RowBatch* batch, FiltBitSet* filter) {
 
-    for (size_t i = 0; i < _non_pk_fields.size(); i++) {
-        int32_t field_id = _non_pk_fields[i]->id;
-        int32_t slot_id = _field_slot[field_id];
-        if (slot_id == 0 && record == nullptr) {
-            return -1;
-        }
-        rocksdb::Iterator* iter = _column_iters[i];
-        rocksdb::Slice column_key = iter->key();
-        // total valid is depend on pk's _iter, column iter's valid is not necessary
-        if (!iter->Valid()) {
-            if (record != nullptr) {
-                (*record)->set_default_value(*_non_pk_fields[i]);
-            } else {
-                (*mem_row)->set_value(tuple_id, slot_id, _non_pk_fields[i]->default_expr_value);
-            }
-            DB_DEBUG("iter not valid, field_id=%d, pk=%s, default_value=%s",
-                     field_id, pk.ToString(true).c_str(),
-                     _non_pk_fields[i]->default_value.c_str());
+    int32_t field_id = field.id;
+    int32_t slot_id = _field_slot[field_id];
+    if (slot_id == 0) {
+        return -1;
+    }
+    rocksdb::Iterator* iter = _column_iters[field_id];
+    MutTableKey prefix_key;
+    prefix_key.append_i64(_region);
+    prefix_key.append_i32(_pri_info->id);
+    prefix_key.append_i32(field_id);
+
+    int filter_num = 0;
+    for (size_t i = 0; i < batch->size(); ++i) {
+        if (filter && filter->test(i)) {
+            filter_num++;
             continue;
         }
-        if (!_fits_prefix(column_key, field_id)) {
-            if (record != nullptr) {
-                (*record)->set_default_value(*_non_pk_fields[i]);
+        if (filter_num > 63) {
+            MutTableKey key;
+            key.append_index(prefix_key);
+            key.append_index(_primary_keys[i]);
+            if (_forward) {
+                iter->Seek(key.data());
             } else {
-                (*mem_row)->set_value(tuple_id, slot_id, _non_pk_fields[i]->default_expr_value);
+                iter->SeekForPrev(key.data());
             }
-            DB_DEBUG("not match prefix, field_id=%d, key=%s, default_value=%s",
-                     field_id, iter->key().ToString(true).c_str(),
-                     _non_pk_fields[i]->default_value.c_str());
-            continue;
         }
-        MutTableKey key(primary_key);
-        key.replace_i32(table_id, sizeof(int64_t));
-        key.replace_i32(field_id, sizeof(int64_t) + sizeof(int32_t));
-        column_key.remove_prefix(_prefix_len);
-        auto cmp = pk.compare(column_key);
-        // when column pure key is equal to pk's pure key, get column value to record.
-        if (cmp == 0) {
-            if (record != nullptr) {
-                if (0 != (*record)->decode_field(*_non_pk_fields[i], iter->value())) {
-                    DB_WARNING("decode value failed: %d", field_id);
-                    return -1;
+        std::unique_ptr<MemRow>& mem_row = batch->get_row(i);
+        rocksdb::Slice primary_key = _primary_keys[i];
+        int32_t cmp = 0;
+        while (true) {
+            if (!iter->Valid()) {
+                mem_row->set_value(tuple_id, slot_id, field.default_expr_value);
+                break;
+            }
+            rocksdb::Slice column_key = iter->key();
+            if (!column_key.starts_with(prefix_key.data())){
+                mem_row->set_value(tuple_id, slot_id, field.default_expr_value);
+                DB_DEBUG("not match prefix, field_id=%d, key=%s, default_value=%s",
+                         field_id, iter->key().ToString(true).c_str(), field.default_value.c_str());
+                break;
+            }
+            column_key.remove_prefix(_prefix_len);
+            cmp = primary_key.compare(column_key);
+            if (_forward) {
+                if (cmp == 0) {
+                    mem_row->decode_field(tuple_id, slot_id, field.type, iter->value());
+                    iter->Next();
+                    break;
+                } else if (cmp < 0) {
+                    mem_row->set_value(tuple_id, slot_id, field.default_expr_value);
+                    break;
+                } else {
+                    iter->Next();
                 }
             } else {
-                if (0 != (*mem_row)->decode_field(tuple_id, slot_id, _non_pk_fields[i]->type, iter->value())) {
-                    DB_WARNING("decode value failed: %d", field_id);
-                    return -1;
+                if (cmp == 0) {
+                    mem_row->decode_field(tuple_id, slot_id, field.type, iter->value());
+                    iter->Prev();
+                    break;
+                } else if (cmp > 0) {
+                    mem_row->set_value(tuple_id, slot_id, field.default_expr_value);
+                    break;
+                } else {
+                    iter->Prev();
                 }
             }
-        } else {
-            if (record != nullptr) {
-                (*record)->set_default_value(*_non_pk_fields[i]);
-            } else {
-                (*mem_row)->set_value(tuple_id, slot_id, _non_pk_fields[i]->default_expr_value);
-            }
-            DB_DEBUG("field_id=%d, pk=%s, key=%s, default_value=%s, cmp=%d", field_id,
-                            pk.ToString(true).c_str(),
-                            column_key.ToString(true).c_str(),
-                            _non_pk_fields[i]->default_value.c_str(),
-                            cmp);
         }
-        // as the pure key maybe not exists in column iter,
-        // only need to move iter when pk are greater or equal.
-        if (_forward && cmp >= 0) {
-            iter->Next();
-        }
-        if (!_forward && cmp <= 0)  {
-            iter->Prev();
-        }
+        filter_num = 0;
     }
     return 0;
 }

--- a/src/exec/rocksdb_scan_node.cpp
+++ b/src/exec/rocksdb_scan_node.cpp
@@ -191,19 +191,6 @@ int RocksdbScanNode::choose_index(RuntimeState* state) {
         _is_covering_index = true;
     }
 
-    // 索引条件下推，减少主表查询次数
-    index_condition_pushdown();
-    for (auto expr : _index_conjuncts) {
-        //pb::Expr pb;
-        //ExprNode::create_pb_expr(&pb, expr);
-        //DB_NOTICE("where:%s", pb.ShortDebugString().c_str());
-        ret = expr->open();
-        if (ret < 0) {
-            DB_WARNING_STATE(state, "Expr::open fail:%d", ret);
-            return ret;
-        }
-    }
-
     if (_multi_reverse_index.size() > 0) {
         for (auto id : _multi_reverse_index) {
             const pb::PossibleIndex& pos_index = _pb_node.derive_node().scan_node().indexes(id);
@@ -276,6 +263,20 @@ int RocksdbScanNode::choose_index(RuntimeState* state) {
             _use_get = true;
         }
     }
+
+    // 索引条件下推，减少主表查询次数
+    index_condition_pushdown();
+    for (auto expr : _index_conjuncts) {
+        //pb::Expr pb;
+        //ExprNode::create_pb_expr(&pb, expr);
+        //DB_NOTICE("where:%s", pb.ShortDebugString().c_str());
+        ret = expr->open();
+        if (ret < 0) {
+            DB_WARNING_STATE(state, "Expr::open fail:%d", ret);
+            return ret;
+        }
+    }
+
     //DB_WARNING_STATE(state, "start search");
     return 0;
 }
@@ -318,8 +319,12 @@ int RocksdbScanNode::predicate_pushdown(std::vector<ExprNode*>& input_exprs) {
 
 bool RocksdbScanNode::need_pushdown(ExprNode* expr) {
     pb::IndexType index_type = _index_info->type;
+    bool is_cstore_table_seek = false;
+    if ((!_use_get) && _table_info->engine == pb::ROCKSDB_CSTORE && _index_id == _table_id) {
+        is_cstore_table_seek = true;
+    }
     // get方式和主键无需下推
-    if (_use_get || index_type == pb::I_PRIMARY) {
+    if (_use_get || (index_type == pb::I_PRIMARY && !is_cstore_table_seek)) {
         return false;
     }
     // 该条件用于指定索引，在filternode里处理了
@@ -344,10 +349,12 @@ bool RocksdbScanNode::need_pushdown(ExprNode* expr) {
     if (expr->children(0)->node_type() != pb::SLOT_REF) {
         return false;
     }
-    SlotRef* slot_ref = static_cast<SlotRef*>(expr->children(0));
-    if (_index_slot_field_map.count(slot_ref->slot_id()) == 0) {
-        return false;
-    } 
+    if (!is_cstore_table_seek) {
+        SlotRef* slot_ref = static_cast<SlotRef*>(expr->children(0));
+        if (_index_slot_field_map.count(slot_ref->slot_id()) == 0) {
+            return false;
+        }
+    }
     // 倒排里用field_id识别
     //slot_ref->set_field_id(_index_slot_field_map[slot_ref->slot_id()]);
     switch (expr->node_type()) {
@@ -541,6 +548,20 @@ int RocksdbScanNode::open(RuntimeState* state) {
     }
     for (auto id : _index_ids) {
         state->add_scan_index(id);
+    }
+
+    if (!_use_get && _table_info->engine == pb::ROCKSDB_CSTORE && _index_id == _table_id) {
+        std::unordered_set<int32_t> filt_field_ids;
+        for (auto& expr : _index_conjuncts) {
+            expr->get_all_field_ids(filt_field_ids);
+        }
+        for (auto& iter : _field_ids) {
+            if (filt_field_ids.count(iter.first)) {
+                _filt_field_ids.push_back(iter.first);
+            } else {
+                _trivial_field_ids.push_back(iter.first);
+            }
+        }
     }
     return 0;
 }
@@ -744,19 +765,72 @@ int RocksdbScanNode::get_next_by_table_seek(RuntimeState* state, RowBatch* batch
                 continue;
             }
         }
-        ++_scan_rows;
-        std::unique_ptr<MemRow> row = _mem_row_desc->fetch_mem_row();
-        int ret = _table_iter->get_next(_tuple_id, row);
-        if (ret < 0) {
-            continue;
+        if (!_table_iter->is_cstore()) {
+            ++_scan_rows;
+            std::unique_ptr<MemRow> row = _mem_row_desc->fetch_mem_row();
+            int ret = _table_iter->get_next(_tuple_id, row);
+            if (ret < 0) {
+                continue;
+            }
+            if (!need_copy(row.get(), _index_conjuncts)) {
+                state->inc_num_filter_rows();
+                ++index_filter_cnt;
+                continue;
+            }
+            batch->move_row(std::move(row));
+            ++_num_rows_returned;
+        } else {
+            // scan primary
+            RowBatch row_batch;
+            std::shared_ptr<FiltBitSet> filter;
+            if (_index_conjuncts.size() > 0) {
+                filter.reset(new FiltBitSet());
+            }
+            _table_iter->ResetPrimaryKeys();
+            int32_t num = 0;
+            while (_table_iter->valid()) {
+                if (_limit != -1 && _num_rows_returned + num >= _limit) break;
+                if (row_batch.size() + num >= row_batch.capacity()) break;
+                std::unique_ptr<MemRow> row = _mem_row_desc->fetch_mem_row();
+                std::string key;
+                int ret = _table_iter->get_next(_tuple_id, row);
+                if (ret < 0) break;
+                row_batch.move_row(std::move(row));
+                ++num;
+            }
+            // scan filt column
+            for (auto& field_id : _filt_field_ids) {
+                FieldInfo* field_info = _field_ids[field_id];
+                int ret = _table_iter->get_column(_tuple_id, *field_info, &row_batch);
+            }
+            // filt
+            if (filter.get()) {
+                for (row_batch.reset(); !row_batch.is_traverse_over(); row_batch.next()) {
+                    std::unique_ptr<MemRow>& row = row_batch.get_row();
+                    if (!need_copy(row.get(), _index_conjuncts)) {
+                        filter->set(row_batch.index());
+                    }
+                }
+            }
+            // scan trivial column
+            for (auto& field_id : _trivial_field_ids) {
+                FieldInfo* field_info = _field_ids[field_id];
+                int ret = _table_iter->get_column(_tuple_id, *field_info, &row_batch, filter.get());
+            }
+
+            // move to row batch
+            for (row_batch.reset(); !row_batch.is_traverse_over(); row_batch.next()) {
+                ++_scan_rows;
+                std::unique_ptr<MemRow>& row = row_batch.get_row();
+                if (filter  && filter->test(row_batch.index())) {
+                    state->inc_num_filter_rows();
+                    ++index_filter_cnt;
+                    continue;
+                }
+                batch->move_row(std::move(row));
+                ++_num_rows_returned;
+            }
         }
-        if (!need_copy(row.get(), _index_conjuncts)) {
-            state->inc_num_filter_rows();
-            ++index_filter_cnt;
-            continue;
-        }
-        batch->move_row(std::move(row));
-        ++_num_rows_returned;
     }
 }
 


### PR DESCRIPTION
提升列存主键扫描速度
1. 列存扫表get_next_columns改为:get_column，一次扫描多列，改为一次扫描一列，提高cpu cache局部性
2. 先扫描带过滤条件的列，然后过滤，当查询条件过滤率高时，可以减少普通列扫描次数