### PR TITLE
support binlog meta table ttl; support operator _binary;  add func last_insert_id(expr); add flag for ignore case for schema info; optimize load balance

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -90,6 +90,7 @@ cc_library(
         "//external:croaring",
         "//external:tcmalloc_and_profiler",
         ":cc_baikaldb_internal_proto",
+        ":sqlparser",
     ],
     visibility = ["//visibility:public"],
 )

--- a/include/common/common.h
+++ b/include/common/common.h
@@ -947,6 +947,17 @@ extern std::string string_trim(std::string& str);
 extern const std::string& rand_peer(pb::RegionInfo& info);
 extern void other_peer_to_leader(pb::RegionInfo& info);
 
+DECLARE_bool(disambiguate_select_name);
+DECLARE_bool(schema_ignore_case);
+inline std::string try_to_lower(const std::string& str) {
+    if (FLAGS_schema_ignore_case) {
+        std::string tmp = str;
+        std::transform(tmp.begin(), tmp.end(), tmp.begin(), ::tolower);
+        return tmp;
+    }
+    return str;
+}
+
 inline uint64_t make_sign(const std::string& key) {
     uint64_t out[2];
     butil::MurmurHash3_x64_128(key.c_str(), key.size(), 1234, out);

--- a/include/common/log.h
+++ b/include/common/log.h
@@ -254,7 +254,7 @@ inline void glog_error_writelog(const char* fmt, ...) {
 #define SQL_TRACE(_fmt_, args...) \
     do {\
         if (!FLAGS_enable_self_trace) break; \
-        ::baikaldb::glog_info_writelog("[%s:%d][%s][%lu]" _fmt_, \
+        ::baikaldb::glog_info_writelog_long("[%s:%d][%s][%lu]" _fmt_, \
                 strrchr(__FILE__, '/') + 1, __LINE__, __FUNCTION__, bthread_self(), ##args);\
     } while (0);
 

--- a/include/common/schema_factory.h
+++ b/include/common/schema_factory.h
@@ -142,6 +142,7 @@ struct FieldInfo {
     bool                auto_inc = false;
     bool                deleted = false;
     bool                noskip = false;
+    uint32_t            flag   = 0;
 };
 
 struct DistInfo {

--- a/include/common/type_utils.h
+++ b/include/common/type_utils.h
@@ -17,6 +17,7 @@
 #include <stdint.h>
 #include <string>
 #include "proto/common.pb.h"
+#include "parser.h"
 
 namespace baikaldb {
 
@@ -292,6 +293,15 @@ inline int32_t get_num_size(pb::PrimitiveType type) {
     }
 }
 
+inline bool is_binary(uint32_t flag) {
+    switch (flag) {
+        case parser::MYSQL_FIELD_FLAG_BLOB:
+        case parser::MYSQL_FIELD_FLAG_BINARY:
+            return true;
+        default:
+            return false;
+    }
+}
 
 inline uint8_t to_mysql_type(pb::PrimitiveType type) {
     switch (type) {

--- a/include/engine/split_compaction_filter.h
+++ b/include/engine/split_compaction_filter.h
@@ -22,9 +22,12 @@
 #include "transaction.h"
 
 namespace baikaldb {
+DECLARE_int32(rocks_binlog_ttl_days);
 class SplitCompactionFilter : public rocksdb::CompactionFilter {
 typedef butil::FlatMap<int64_t, std::string*> KeyMap;
 typedef DoubleBuffer<KeyMap> DoubleBufKey;
+typedef std::unordered_set<int64_t> BinlogSet;
+typedef butil::DoublyBufferedData<BinlogSet> DoubleBufBinlog;
 public:
     static SplitCompactionFilter* get_instance() {
         static SplitCompactionFilter _instance;
@@ -52,6 +55,20 @@ public:
         int64_t region_id = table_key.extract_i64(0);
         std::string* end_key = get_end_key(region_id);
         if (end_key == nullptr || end_key->empty()) {
+            return false;
+        }
+        if (get_binlog_region(region_id) == 0) {
+            static int64_t ttl_ms = FLAGS_rocks_binlog_ttl_days * 24 * 60 * 60 * 1000;
+            rocksdb::Slice pure_key(key);
+            pure_key.remove_prefix(2 * sizeof(int64_t));
+            int64_t commit_tso = ttl_decode(pure_key);
+            int64_t expire_ts_ms = (commit_tso >> tso::logical_bits) + ttl_ms;
+            int64_t current_ts_ms = tso::clock_realtime_ms();
+//            DB_WARNING("binglog compaction filter, region_id: %ld, ttl_tso: %ld, commit_tso: %ld, expire_tso: %ld, current_tso: %ld",
+//                       region_id, ttl_ms, commit_tso, expire_ts_ms, current_ts_ms);
+            if (current_ts_ms > expire_ts_ms) {
+                return true;
+            }
             return false;
         }
         int64_t index_id = table_key.extract_i64(sizeof(int64_t));
@@ -107,6 +124,25 @@ public:
         return nullptr;
     }
 
+    void set_binlog_region(int64_t region_id) {
+        auto call = [this, region_id](BinlogSet& region_id_set) -> int {
+            region_id_set.insert(region_id);
+            return 1;
+        };
+        _binlog_region_id_set.Modify(call);
+    }
+
+    int get_binlog_region(int64_t region_id) const {
+        DoubleBufBinlog::ScopedPtr ptr;
+        if (_binlog_region_id_set.Read(&ptr) == 0) {
+            auto iter = ptr->find(region_id);
+            if (iter != ptr->end()) {
+                return 0;
+            }
+        }
+        return -1;
+    }
+
 private:
     SplitCompactionFilter() {
         _factory = SchemaFactory::get_instance();
@@ -116,6 +152,7 @@ private:
 
     // region_id => end_key
     mutable DoubleBufKey _range_key_map;
+    mutable DoubleBufBinlog _binlog_region_id_set;
     SchemaFactory* _factory;
 };
 }//namespace

--- a/include/engine/split_compaction_filter.h
+++ b/include/engine/split_compaction_filter.h
@@ -57,7 +57,7 @@ public:
         if (end_key == nullptr || end_key->empty()) {
             return false;
         }
-        if (get_binlog_region(region_id) == 0) {
+        if (is_binlog_region(region_id)) {
             static int64_t ttl_ms = FLAGS_rocks_binlog_ttl_days * 24 * 60 * 60 * 1000;
             rocksdb::Slice pure_key(key);
             pure_key.remove_prefix(2 * sizeof(int64_t));
@@ -132,15 +132,15 @@ public:
         _binlog_region_id_set.Modify(call);
     }
 
-    int get_binlog_region(int64_t region_id) const {
+    bool is_binlog_region(int64_t region_id) const {
         DoubleBufBinlog::ScopedPtr ptr;
         if (_binlog_region_id_set.Read(&ptr) == 0) {
             auto iter = ptr->find(region_id);
             if (iter != ptr->end()) {
-                return 0;
+                return true;
             }
         }
-        return -1;
+        return false;
     }
 
 private:

--- a/include/exec/exec_node.h
+++ b/include/exec/exec_node.h
@@ -21,6 +21,7 @@
 #include "proto/plan.pb.h"
 #include "proto/meta.interface.pb.h"
 #include "mem_row_descriptor.h"
+#include "runtime_state.h"
 
 namespace baikaldb { 
 

--- a/include/exec/update_manager_node.h
+++ b/include/exec/update_manager_node.h
@@ -53,7 +53,7 @@ public:
     void set_update_exprs(std::vector<ExprNode*>& update_exprs) {
         _update_exprs = update_exprs;
     }
-    void update_record(SmartRecord record);
+    void update_record(RuntimeState* state, SmartRecord record);
 
 private:
     int64_t _table_id = -1;

--- a/include/expr/expr_node.h
+++ b/include/expr/expr_node.h
@@ -34,6 +34,7 @@ public:
     virtual int init(const pb::ExprNode& node) {
         _node_type = node.node_type();
         _col_type = node.col_type();
+        _col_flag = node.col_flag();
         return 0;
     }
     virtual void children_swap() {}
@@ -185,6 +186,12 @@ public:
     void set_col_type(pb::PrimitiveType col_type) {
         _col_type = col_type;
     }
+    uint32_t col_flag() {
+        return _col_flag;
+    }
+    void set_col_flag(uint32_t col_flag) {
+        _col_flag = col_flag;
+    }
 
     void clear_filter_index() {
         _index_ids.clear();
@@ -244,6 +251,7 @@ protected:
     pb::ExprNodeType _node_type;
     pb::PrimitiveType _col_type = pb::INVALID_TYPE;
     std::vector<ExprNode*> _children;
+    uint32_t _col_flag;
     bool    _is_constant = true;
     bool    _has_null = false;
     bool    _replace_agg_to_slot = true;

--- a/include/expr/expr_node.h
+++ b/include/expr/expr_node.h
@@ -93,6 +93,14 @@ public:
     bool has_null() const {
         return _has_null;
     }
+    virtual bool has_last_insert_id() const {
+        for (auto c : _children) {
+            if (c->has_last_insert_id()) {
+                return true;
+            }
+        }
+        return false;
+    }
     bool is_row_expr() {
         return _node_type == pb::ROW_EXPR;
     }

--- a/include/expr/expr_node.h
+++ b/include/expr/expr_node.h
@@ -93,13 +93,13 @@ public:
     bool has_null() const {
         return _has_null;
     }
-    virtual bool has_last_insert_id() const {
+    virtual ExprNode* get_last_insert_id() {
         for (auto c : _children) {
-            if (c->has_last_insert_id()) {
-                return true;
+            if (c->get_last_insert_id() != nullptr) {
+                return c;
             }
         }
-        return false;
+        return nullptr;
     }
     bool is_row_expr() {
         return _node_type == pb::ROW_EXPR;
@@ -259,7 +259,7 @@ protected:
     pb::ExprNodeType _node_type;
     pb::PrimitiveType _col_type = pb::INVALID_TYPE;
     std::vector<ExprNode*> _children;
-    uint32_t _col_flag;
+    uint32_t _col_flag = 0;
     bool    _is_constant = true;
     bool    _has_null = false;
     bool    _replace_agg_to_slot = true;

--- a/include/expr/internal_functions.h
+++ b/include/expr/internal_functions.h
@@ -141,6 +141,7 @@ ExprValue tdigest_percentile(const std::vector<ExprValue>& input);
 ExprValue tdigest_location(const std::vector<ExprValue>& input);
 // other
 ExprValue version(const std::vector<ExprValue>& input);
+ExprValue last_insert_id(const std::vector<ExprValue>& input);
 }
 
 /* vim: set ts=4 sw=4 sts=4 tw=100 */

--- a/include/expr/scalar_fn_call.h
+++ b/include/expr/scalar_fn_call.h
@@ -33,6 +33,12 @@ public:
         ExprNode::transfer_pb(pb_node);
         pb_node->mutable_fn()->CopyFrom(_fn);
     }
+    bool has_last_insert_id() const {
+        if (_fn.name() == "last_insert_id") {
+            return true;
+        }
+        return ExprNode::has_last_insert_id();
+    }
 private:
     ExprValue multi_eq_value(MemRow* row) {
         for (size_t i = 0; i < children(0)->children_size(); i++) {

--- a/include/expr/scalar_fn_call.h
+++ b/include/expr/scalar_fn_call.h
@@ -33,11 +33,11 @@ public:
         ExprNode::transfer_pb(pb_node);
         pb_node->mutable_fn()->CopyFrom(_fn);
     }
-    bool has_last_insert_id() const {
+    ExprNode* get_last_insert_id() {
         if (_fn.name() == "last_insert_id") {
-            return true;
+            return this;
         }
-        return ExprNode::has_last_insert_id();
+        return ExprNode::get_last_insert_id();
     }
 private:
     ExprValue multi_eq_value(MemRow* row) {

--- a/include/expr/slot_ref.h
+++ b/include/expr/slot_ref.h
@@ -42,6 +42,7 @@ public:
         s->_slot_id = _slot_id;
         s->_node_type = _node_type;
         s->_col_type = _col_type;
+        s->_col_flag = _col_flag;
         return s;
     }
 

--- a/include/logical_plan/logical_planner.h
+++ b/include/logical_plan/logical_planner.h
@@ -142,8 +142,8 @@ protected:
         const std::string& alias);
 
     std::unordered_set<std::string> get_possible_databases(const std::string& table) {
-        if ( _plan_table_ctx->table_dbs_mapping.count(table) != 0) {
-            return _plan_table_ctx->table_dbs_mapping[table];
+        if ( _plan_table_ctx->table_dbs_mapping.count(try_to_lower(table)) != 0) {
+            return _plan_table_ctx->table_dbs_mapping[try_to_lower(table)];
         }
         return std::unordered_set<std::string>();
     }
@@ -157,7 +157,7 @@ protected:
     }
 
     TableInfo* get_table_info_ptr(const std::string& table) {
-        auto iter = _plan_table_ctx->table_info.find(table);
+        auto iter = _plan_table_ctx->table_info.find(try_to_lower(table));
         if (iter != _plan_table_ctx->table_info.end()) {
             return iter->second.get();
         }
@@ -165,7 +165,7 @@ protected:
     }
 
     FieldInfo* get_field_info_ptr(const std::string& field) {
-        auto iter = _plan_table_ctx->field_info.find(field);
+        auto iter = _plan_table_ctx->field_info.find(try_to_lower(field));
         if (iter != _plan_table_ctx->field_info.end()) {
             return iter->second;
         }

--- a/include/runtime/runtime_state.h
+++ b/include/runtime/runtime_state.h
@@ -374,6 +374,7 @@ public:
     std::string       raft_error_msg;
     ExplainType       explain_type = EXPLAIN_NULL;
     std::shared_ptr<CMsketch> cmsketch = nullptr;
+    int64_t         last_insert_id = INT64_MIN; //存储baikalStore last_insert_id(expr)更新的字段
 
     // global index ddl 使用
     int32_t             ddl_scan_size = 0;

--- a/include/sqlparser/ddl.h
+++ b/include/sqlparser/ddl.h
@@ -66,16 +66,24 @@ enum MysqlType : unsigned char {
     MYSQL_TYPE_GEOMETRY     = 255
 };
 
+// https://github.com/mysql/mysql-server/blob/8.0/include/mysql_com.h
 enum MysqlFieldFlag {
-    MYSQL_FIELD_FLAG_NOT_NULL = 0,
-    MYSQL_FIELD_FLAG_PRI_KEY,
-    MYSQL_FIELD_FLAG_UNIQ_KEY,
-    MYSQL_FIELD_FLAG_MULTI_KEY,
-    MYSQL_FIELD_FLAG_BLOB,
-    MYSQL_FIELD_FLAG_UNSIGNED,
-    MYSQL_FIELD_FLAG_ZEROFILL,
-    MYSQL_FIELD_FLAG_BINARY,
-    MYSQL_FIELD_FLAG_AUTO_INC
+    MYSQL_FIELD_FLAG_NOT_NULL       = 1 << 0,
+    MYSQL_FIELD_FLAG_PRI_KEY        = 1 << 1,
+    MYSQL_FIELD_FLAG_UNIQ_KEY       = 1 << 2,
+    MYSQL_FIELD_FLAG_MULTI_KEY      = 1 << 3,
+    MYSQL_FIELD_FLAG_BLOB           = 1 << 4,
+    MYSQL_FIELD_FLAG_UNSIGNED       = 1 << 5,
+    MYSQL_FIELD_FLAG_ZEROFILL       = 1 << 6,
+    MYSQL_FIELD_FLAG_BINARY         = 1 << 7,
+    MYSQL_FIELD_FLAG_ENUM           = 1 << 8,
+    MYSQL_FIELD_FLAG_AUTO_INC       = 1 << 9,
+    MYSQL_FIELD_FLAG_Timestamp      = 1 << 10,
+    MYSQL_FIELD_FLAG_SET            = 1 << 11,
+    MYSQL_FIELD_FLAG_NODEFAULTVALUE = 1 << 12,
+    MYSQL_FIELD_FLAG_ONUPDATENOW    = 1 << 13,
+    MYSQL_FIELD_FLAG_PARTKEY        = 1 << 14,
+    MYSQL_FIELD_FLAG_NUM            = 1 << 15
 };
 
 enum ColumnOptionType : unsigned char {

--- a/include/sqlparser/sql_lex.l
+++ b/include/sqlparser/sql_lex.l
@@ -205,6 +205,7 @@ VALUES { return VALUES; }
 LONG { return LONG; }
 VARCHAR { return VARCHAR; }
 VARBINARY { return VARBINARY; }
+_BINARY { return _BINARY; }
 VIRTUAL { return VIRTUAL; }
 WHEN { return WHEN; }
 WHERE { return WHERE; }

--- a/include/sqlparser/sql_parse.y
+++ b/include/sqlparser/sql_parse.y
@@ -232,6 +232,7 @@ extern int sql_error(YYLTYPE* yylloc, yyscan_t yyscanner, SqlParser* parser, con
     LONG
     VARCHAR
     VARBINARY
+    _BINARY
     VIRTUAL
     WHEN
     WHERE
@@ -2608,6 +2609,10 @@ SimpleExpr:
         $$ = FuncExpr::new_unary_op_node(FT_UMINUS, $2, parser->arena);
     }
     | '+' SimpleExpr %prec NEG { 
+        $$ = $2;
+    }
+    | _BINARY SimpleExpr %prec NEG {
+        // See https://dev.mysql.com/doc/refman/5.7/en/cast-functions.html#operator_binary 
         $$ = $2;
     }
     | NOT SimpleExpr {

--- a/include/sqlparser/sql_parse.y
+++ b/include/sqlparser/sql_parse.y
@@ -2585,6 +2585,9 @@ Literal:
     }
     | STRING_LIT {
     }
+    | _BINARY STRING_LIT {
+        $$ = $2;
+    }
     ;
 
 SimpleExpr:
@@ -2609,10 +2612,6 @@ SimpleExpr:
         $$ = FuncExpr::new_unary_op_node(FT_UMINUS, $2, parser->arena);
     }
     | '+' SimpleExpr %prec NEG { 
-        $$ = $2;
-    }
-    | _BINARY SimpleExpr %prec NEG {
-        // See https://dev.mysql.com/doc/refman/5.7/en/cast-functions.html#operator_binary 
         $$ = $2;
     }
     | NOT SimpleExpr {

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -63,6 +63,7 @@ message ExprNode {
     required int32 num_children = 3;
     optional Function fn = 4;
     optional DeriveExprNode derive_node = 5;
+    optional uint32 col_flag = 6;
 };
 
 message Expr {

--- a/proto/meta.interface.proto
+++ b/proto/meta.interface.proto
@@ -149,6 +149,7 @@ message FieldInfo {
     optional bytes comment            = 9;
     optional bytes on_update_value    = 10;
     optional bytes encrypt            = 11; //指定加密字段
+    optional uint32 flag              = 12;
 };
 
 enum IndexType {

--- a/proto/store.interface.proto
+++ b/proto/store.interface.proto
@@ -144,6 +144,7 @@ message StoreRes {
     repeated bytes binlogs       = 19; //直接存储binlog序列化结果，由capture反序列化
     repeated int64 commit_ts     = 20; //与上面的binlog一一对应
     optional PeerStatus region_status = 21;
+    optional int64 last_insert_id = 22;
 };
 message InitRegion {
     required RegionInfo region_info     = 1;

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -47,6 +47,9 @@ DEFINE_bool(enable_debug, false, "open DB_DEBUG log");
 DEFINE_bool(enable_self_trace, true, "open SELF_TRACE log");
 DEFINE_bool(servitysinglelog, true, "diff servity message in seperate logfile");
 DEFINE_int32(baikal_heartbeat_interval_us, 10 * 1000 * 1000, "baikal_heartbeat_interval(us)");
+DEFINE_bool(schema_ignore_case, false, "whether ignore case when match db/table name");
+DEFINE_bool(disambiguate_select_name, false, "whether use the first when select name is ambiguous, default false");
+
 int64_t timestamp_diff(timeval _start, timeval _end) {
     return (_end.tv_sec - _start.tv_sec) * 1000000 
         + (_end.tv_usec-_start.tv_usec); //macro second

--- a/src/common/heartbeat_interval_define.cpp
+++ b/src/common/heartbeat_interval_define.cpp
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 #include <gflags/gflags.h>
-#include "brpc/reloadable_flags.h"
 
 namespace baikaldb{
 DEFINE_int64(store_heart_beat_interval_us, 30 * 1000 * 1000, "store heart interval (30 s)");
@@ -23,7 +22,5 @@ DEFINE_int32(region_faulty_interval_times, 3, "region faulty interval times of h
 DEFINE_int32(store_faulty_interval_times, 3, "store faulty interval times of heart beat");
 DEFINE_int32(store_dead_interval_times, 60, "store dead interval times of heart beat");
 DEFINE_int32(healthy_check_interval_times, 1, "meta state machine healthy check interval times of heart beat");
-DEFINE_int32(balance_add_peer_num, 10, "add peer num each time, default(10)");
-BRPC_VALIDATE_GFLAG(balance_add_peer_num, brpc::PositiveInteger);
 }
 /* vim: set expandtab ts=4 sw=4 sts=4 tw=100: */

--- a/src/common/heartbeat_interval_define.cpp
+++ b/src/common/heartbeat_interval_define.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include <gflags/gflags.h>
+#include "brpc/reloadable_flags.h"
 
 namespace baikaldb{
 DEFINE_int64(store_heart_beat_interval_us, 30 * 1000 * 1000, "store heart interval (30 s)");
@@ -22,5 +23,7 @@ DEFINE_int32(region_faulty_interval_times, 3, "region faulty interval times of h
 DEFINE_int32(store_faulty_interval_times, 3, "store faulty interval times of heart beat");
 DEFINE_int32(store_dead_interval_times, 60, "store dead interval times of heart beat");
 DEFINE_int32(healthy_check_interval_times, 1, "meta state machine healthy check interval times of heart beat");
+DEFINE_int32(balance_add_peer_num, 10, "add peer num each time, default(10)");
+BRPC_VALIDATE_GFLAG(balance_add_peer_num, brpc::PositiveInteger);
 }
 /* vim: set expandtab ts=4 sw=4 sts=4 tw=100: */

--- a/src/common/schema_factory.cpp
+++ b/src/common/schema_factory.cpp
@@ -434,6 +434,7 @@ int SchemaFactory::update_table_internal(SchemaMapping& background, const pb::Sc
                 field_info.lower_short_name.begin(), ::tolower);
         field_info.lower_name = tbl_info.name + "." + field_info.lower_short_name;
         field_info.type = field.mysql_type();
+        field_info.flag = field.flag();
         field_info.can_null = field.can_null();
         field_info.auto_inc = field.auto_increment();
         field_info.deleted = field.deleted();

--- a/src/common/schema_factory.cpp
+++ b/src/common/schema_factory.cpp
@@ -170,7 +170,7 @@ void SchemaFactory::delete_table(const pb::SchemaInfo& table, SchemaMapping& bac
     }
     auto tbl_info_ptr = table_info_mapping[table_id];
     auto& tbl_info = *tbl_info_ptr;
-    std::string full_name = tbl_info.namespace_ + "." + tbl_info.name;
+    std::string full_name = try_to_lower(tbl_info.namespace_ + "." + tbl_info.name);
     DB_WARNING("full_name: %s, %ld", full_name.c_str(), table_name_id_mapping.size());
     table_name_id_mapping.erase(full_name);
     DB_WARNING("full_name deleted: %ld", table_name_id_mapping.size());
@@ -499,12 +499,12 @@ int SchemaFactory::update_table_internal(SchemaMapping& background, const pb::Sc
     }
 
     // create name => id mapping
-    db_name_id_mapping[_namespace + "." + _db_name] = database_id;
+    db_name_id_mapping[try_to_lower(_namespace + "." + _db_name)] = database_id;
 
     DB_WARNING("db_name_id_mapping: %s->%ld", std::string(_namespace + "." + _db_name).c_str(), 
         database_id);
 
-    std::string _db_table(_namespace + "." + _db_name + "." + _tbl_name);
+    std::string _db_table(try_to_lower(_namespace + "." + _db_name + "." + _tbl_name));
     //old_tbl_name = _namespace + "." + old_tbl_name;
     //if (!old_tbl_name.empty() && old_tbl_name != _db_table) {
         //table_name_id_mapping.erase(old_tbl_name);
@@ -1156,12 +1156,12 @@ int SchemaFactory::update_virtual_index_internal(SchemaMapping& background, cons
     auto& index_info_mapping = background.index_info_mapping;
     auto& table_name_id_mapping = background.table_name_id_mapping;
 
-    if (table_name_id_mapping.count(table_full_name) == 0) {
+    if (table_name_id_mapping.count(try_to_lower(table_full_name)) == 0) {
         DB_WARNING("can not find table_name: %s", table_full_name.c_str());
         return 0;
     }
 
-    int64_t table_id = table_name_id_mapping[table_full_name];
+    int64_t table_id = table_name_id_mapping[try_to_lower(table_full_name)];
 
     if (table_info_mapping.count(table_id) == 0) {
         DB_WARNING("can not find table_id: %ld", table_id);
@@ -1248,12 +1248,12 @@ int SchemaFactory::drop_virtual_index_internal(SchemaMapping& background, const 
     auto& table_name_id_mapping = background.table_name_id_mapping;
     auto& index_name_id_mapping = background.index_name_id_mapping;
 
-    if (table_name_id_mapping.count(table_full_name) == 0) {
+    if (table_name_id_mapping.count(try_to_lower(table_full_name)) == 0) {
         DB_WARNING("can not find table_name: %s", table_full_name.c_str());
         return 0;
     }
 
-    int64_t table_id = table_name_id_mapping[table_full_name];
+    int64_t table_id = table_name_id_mapping[try_to_lower(table_full_name)];
 
     if (table_info_mapping.count(table_id) == 0) {
         DB_WARNING("can not find table_id: %ld", table_id);
@@ -1635,10 +1635,10 @@ int SchemaFactory::get_table_id(const std::string& table_name, int64_t& table_id
         return -1; 
     }
     auto& table_name_id_mapping = table_ptr->table_name_id_mapping;
-    if (table_name_id_mapping.count(table_name) == 0) {
+    if (table_name_id_mapping.count(try_to_lower(table_name)) == 0) {
         return -1;
     }
-    table_id = table_name_id_mapping.at(table_name);
+    table_id = table_name_id_mapping.at(try_to_lower(table_name));
     return 0;
 }
 int SchemaFactory::get_region_capacity(int64_t global_index_id, int64_t& region_capacity) {
@@ -1884,10 +1884,10 @@ int SchemaFactory::get_database_id(const std::string& db_name, int64_t& db_id) {
         return -1;
     }
     auto& db_name_id_mapping = table_ptr->db_name_id_mapping;
-    if (db_name_id_mapping.count(db_name) == 0) {
+    if (db_name_id_mapping.count(try_to_lower(db_name)) == 0) {
         return -1;
     }
-    db_id = db_name_id_mapping.at(db_name);
+    db_id = db_name_id_mapping.at(try_to_lower(db_name));
     return 0;
 }
 bool SchemaFactory::exist_tableid(int64_t table_id) {

--- a/src/engine/rocks_wrapper.cpp
+++ b/src/engine/rocks_wrapper.cpp
@@ -55,6 +55,8 @@ DEFINE_int32(rocks_binlog_ttl_days, 7, "binlog ttl default 7 days");
 DEFINE_int32(level0_file_num_compaction_trigger, 5, "Number of files to trigger level-0 compaction");
 DEFINE_int32(max_bytes_for_level_base, 1024 * 1024 * 1024, "total size of level 1.");
 DEFINE_bool(enable_bottommost_compression, false, "enable zstd for bottommost_compression");
+DEFINE_int32(target_file_size_base, 128 * 1024 * 1024, "target_file_size_base");
+
 
 const std::string RocksWrapper::RAFT_LOG_CF = "raft_log";
 const std::string RocksWrapper::BIN_LOG_CF  = "bin_log";
@@ -133,7 +135,7 @@ int32_t RocksWrapper::init(const std::string& path) {
     _log_cf_option.level0_file_num_compaction_trigger = 5;
     _log_cf_option.level0_slowdown_writes_trigger = 10;
     _log_cf_option.level0_stop_writes_trigger = FLAGS_stop_write_sst_cnt;
-    _log_cf_option.target_file_size_base = 128 * 1024 * 1024;
+    _log_cf_option.target_file_size_base = FLAGS_target_file_size_base;
     _log_cf_option.max_bytes_for_level_base = 1024 * 1024 * 1024;
     _log_cf_option.level_compaction_dynamic_level_bytes = FLAGS_rocks_data_dynamic_level_bytes;
 
@@ -171,7 +173,7 @@ int32_t RocksWrapper::init(const std::string& path) {
     _data_cf_option.level0_slowdown_writes_trigger = 10;
     _data_cf_option.level0_stop_writes_trigger = FLAGS_stop_write_sst_cnt;
     _data_cf_option.hard_pending_compaction_bytes_limit = FLAGS_rocks_hard_pending_compaction_g * 1073741824ull;
-    _data_cf_option.target_file_size_base = 128 * 1024 * 1024;
+    _data_cf_option.target_file_size_base = FLAGS_target_file_size_base;
     _data_cf_option.max_bytes_for_level_multiplier = FLAGS_rocks_level_multiplier;
     _data_cf_option.level_compaction_dynamic_level_bytes = FLAGS_rocks_data_dynamic_level_bytes;
 

--- a/src/exec/dml_manager_node.cpp
+++ b/src/exec/dml_manager_node.cpp
@@ -24,6 +24,9 @@ int DmlManagerNode::open(RuntimeState* state) {
         return -1;
     }
     client_conn->seq_id++;
+    if (_return_empty) {
+        return 0;
+    }
     ExecNode* dml_node = _children[0];
     ret = _fetcher_store.run(state, _region_infos, dml_node, client_conn->seq_id, _op_type); 
     if (ret < 0) {

--- a/src/exec/dml_node.cpp
+++ b/src/exec/dml_node.cpp
@@ -542,6 +542,9 @@ int DMLNode::update_row(RuntimeState* state, SmartRecord record, MemRow* row) {
         auto expr = _update_exprs[i];
         record->set_value(record->get_field_by_tag(slot.field_id()),
                 expr->get_value(row).cast_to(slot.slot_type()));
+        if (expr->has_last_insert_id()) {
+            state->last_insert_id = expr->get_value(row).cast_to(slot.slot_type()).get_numberic<int64_t>();
+        }
     }
     ret = insert_row(state, record, true);
     if (ret < 0) {

--- a/src/exec/dml_node.cpp
+++ b/src/exec/dml_node.cpp
@@ -170,6 +170,7 @@ int DMLNode::insert_row(RuntimeState* state, SmartRecord record, bool is_update)
     }
     // LOCK_PRIMARY_NODE目前无法区分update与insert，暂用update兼容
     bool delete_before_put_primary = !_update_affect_primary &&
+            (_ttl_timestamp_us == 0) &&
             (is_update || _node_type == pb::LOCK_PRIMARY_NODE);
     bool need_increase = true;
     auto& reverse_index_map = state->reverse_index_map();

--- a/src/exec/dml_node.cpp
+++ b/src/exec/dml_node.cpp
@@ -169,7 +169,8 @@ int DMLNode::insert_row(RuntimeState* state, SmartRecord record, bool is_update)
         _indexes_ptr = &_all_indexes;
     }
     // LOCK_PRIMARY_NODE目前无法区分update与insert，暂用update兼容
-    bool delete_before_put_primary = !_update_affect_primary &&
+    // 由于cstore的字段是分开存储的,不涉及主键与ttl时,可以优化为更新部分涉及字段.
+    bool cstore_update_fields_partly = !_update_affect_primary &&
             (_ttl_timestamp_us == 0) &&
             (is_update || _node_type == pb::LOCK_PRIMARY_NODE);
     bool need_increase = true;
@@ -249,7 +250,7 @@ int DMLNode::insert_row(RuntimeState* state, SmartRecord record, bool is_update)
                         DB_WARNING_STATE(state, "remove fail, table_id:%ld ,ret:%d", _table_id, ret);
                         return -1;
                     }
-                    delete_before_put_primary = true;
+                    cstore_update_fields_partly = true;
                     ++affected_rows;
                 } else {
                     DB_WARNING_STATE(state, "insert row must not exist, index:%ld, ret:%d", _table_id, ret);
@@ -382,9 +383,9 @@ int DMLNode::insert_row(RuntimeState* state, SmartRecord record, bool is_update)
         }
     }
     // 列存为节省空间, 插入默认值或空值时不会put
-    // delete_before_put_primary为true时表示更新前旧值尚未被删除
+    // cstore_update_fields_partly为true时更新前旧值尚未被删除
     ret = _txn->put_primary(_region_id, *_pri_info, record,
-                            delete_before_put_primary ? &_update_field_ids : nullptr);
+                            cstore_update_fields_partly ? &_update_field_ids : nullptr);
     if (ret < 0) {
         DB_WARNING_STATE(state, "put table:%ld fail:%d", _table_id, ret);
         return -1;
@@ -543,8 +544,9 @@ int DMLNode::update_row(RuntimeState* state, SmartRecord record, MemRow* row) {
         auto expr = _update_exprs[i];
         record->set_value(record->get_field_by_tag(slot.field_id()),
                 expr->get_value(row).cast_to(slot.slot_type()));
-        if (expr->has_last_insert_id()) {
-            state->last_insert_id = expr->get_value(row).cast_to(slot.slot_type()).get_numberic<int64_t>();
+        auto last_insert_id_expr = expr->get_last_insert_id();
+        if (last_insert_id_expr != nullptr) {
+            state->last_insert_id = last_insert_id_expr->get_value(row).get_numberic<int64_t>();
         }
     }
     ret = insert_row(state, record, true);

--- a/src/exec/packet_node.cpp
+++ b/src/exec/packet_node.cpp
@@ -670,7 +670,7 @@ int PacketNode::pack_ok(int num_affected_rows, NetworkSocket* client) {
     if (_send_buf->_size > 0) {
         _send_buf->byte_array_clear();
     }
-    int64_t last_insert_id = (op_type() == pb::OP_INSERT)? client->last_insert_id : 0;
+    int64_t last_insert_id = (op_type() == pb::OP_INSERT || op_type() == pb::OP_UPDATE)? client->last_insert_id : 0;
 
     DataBuffer tmp_buf;
     tmp_buf.byte_array_append_length_coded_binary(0);

--- a/src/exec/packet_node.cpp
+++ b/src/exec/packet_node.cpp
@@ -20,6 +20,7 @@
 
 namespace baikaldb {
 DEFINE_int32(expect_bucket_count, 100, "expect_bucket_count");
+DEFINE_bool(field_charsetnr_set_by_client, false, "set charsetnr by client");
 int PacketNode::init(const pb::PlanNode& node) {
     int ret = 0;
     ret = ExecNode::init(node);
@@ -307,7 +308,11 @@ int PacketNode::fatch_expr_subquery_results(RuntimeState* state) {
 
 int PacketNode::open(RuntimeState* state) {
     _client = state->client_conn();
-
+    if (FLAGS_field_charsetnr_set_by_client) {
+        for (auto& field : _fields) {
+            field.charsetnr = _client->charset_num;
+        }
+    }
     _send_buf = state->send_buf();
     _wrapper = MysqlWrapper::get_instance();
     int ret = 0;

--- a/src/exec/update_manager_node.cpp
+++ b/src/exec/update_manager_node.cpp
@@ -196,8 +196,9 @@ void UpdateManagerNode::update_record(RuntimeState* state, SmartRecord record) {
         auto expr = _update_exprs[i];
         record->set_value(record->get_field_by_tag(slot.field_id()),
             expr->get_value(row).cast_to(slot.slot_type()));
-        if (expr->has_last_insert_id()) {
-            state->last_insert_id = expr->get_value(row).cast_to(slot.slot_type()).get_numberic<int64_t>();
+        auto last_insert_id_expr = expr->get_last_insert_id();
+        if (last_insert_id_expr != nullptr) {
+            state->last_insert_id = last_insert_id_expr->get_value(row).get_numberic<int64_t>();
             state->client_conn()->last_insert_id = state->last_insert_id;
         }
     }

--- a/src/exec/update_node.cpp
+++ b/src/exec/update_node.cpp
@@ -47,7 +47,9 @@ int UpdateNode::open(RuntimeState* state) {
     START_LOCAL_TRACE(get_trace(), state->get_trace_cost(), OPEN_TRACE, ([&num_affected_rows](TraceLocalNode& local_node) {
         local_node.set_affect_rows(num_affected_rows);
     }));
-
+    if (_return_empty) {
+        return 0;
+    }
     int ret = 0;
     ret = ExecNode::open(state);
     if (ret < 0) {

--- a/src/expr/expr_node.cpp
+++ b/src/expr/expr_node.cpp
@@ -198,6 +198,7 @@ void ExprNode::transfer_pb(pb::ExprNode* pb_node) {
     pb_node->set_node_type(_node_type);
     pb_node->set_col_type(_col_type);
     pb_node->set_num_children(_children.size());
+    pb_node->set_col_flag(_col_flag);
 }
 
 void ExprNode::create_pb_expr(pb::Expr* expr, ExprNode* root) {

--- a/src/expr/fn_manager.cpp
+++ b/src/expr/fn_manager.cpp
@@ -339,6 +339,10 @@ void FunctionManager::complete_fn_simple(pb::Function& fn, int num_args,
 
 void FunctionManager::complete_fn(pb::Function& fn, int num_args, 
         pb::PrimitiveType arg_type, pb::PrimitiveType ret_type) {
+    if (fn.return_type() == ret_type) {
+        // 避免prepare模式反复执行此函数,导致fn.name没有清理的bug
+        return;
+    }
     fn.clear_arg_types();
     fn.clear_return_type();
     std::string arg_str;
@@ -375,7 +379,7 @@ void FunctionManager::complete_fn(pb::Function& fn, int num_args,
     }
     for (int i = 0; i < num_args; i++) {
         fn.add_arg_types(arg_type);
-        fn.set_name(fn.name() + arg_str);
+        fn.set_name(fn.name() + arg_str); // 此处name没有清理,反复执行会导致内容增长
     }
     fn.set_return_type(ret_type);
 }

--- a/src/expr/fn_manager.cpp
+++ b/src/expr/fn_manager.cpp
@@ -229,6 +229,7 @@ void FunctionManager::register_operators() {
     register_object_ret("tdigest_location", tdigest_location, pb::DOUBLE);
 
     register_object_ret("version", version, pb::STRING);
+    register_object_ret("last_insert_id", last_insert_id, pb::INT64);
 }
 
 int FunctionManager::init() {

--- a/src/expr/internal_functions.cpp
+++ b/src/expr/internal_functions.cpp
@@ -1623,6 +1623,14 @@ ExprValue version(const std::vector<ExprValue>& input) {
     tmp.str_val = FLAGS_db_version;
     return tmp;
 }
+
+ExprValue last_insert_id(const std::vector<ExprValue>& input) {
+    if (input.size() == 0) {
+        return ExprValue::Null();
+    }
+    ExprValue tmp = input[0];
+    return tmp.cast_to(pb::INT64);
+}
 }
 
 /* vim: set ts=4 sw=4 sts=4 tw=100 */

--- a/src/expr/scalar_fn_call.cpp
+++ b/src/expr/scalar_fn_call.cpp
@@ -44,6 +44,10 @@ int ScalarFnCall::type_inferer() {
     if (ret < 0) {
         return ret;
     }
+    if (_fn_call != NULL) {
+        // 避免重复执行后续逻辑
+        return ret;
+    }
     // 兼容mysql， predicate 处理成列的类型
     switch (_fn.fn_op()) { 
         case parser::FT_EQ:

--- a/src/logical_plan/ddl_planner.cpp
+++ b/src/logical_plan/ddl_planner.cpp
@@ -142,6 +142,7 @@ int DDLPlanner::add_column_def(pb::SchemaInfo& table, parser::ColumnDef* column)
     if (!field->has_can_null()) {
         field->set_can_null(false);
     }
+    field->set_flag(column->type->flag);
     return 0;
 }
 

--- a/src/logical_plan/delete_planner.cpp
+++ b/src/logical_plan/delete_planner.cpp
@@ -100,7 +100,7 @@ int DeletePlanner::plan() {
     if (0 != create_scan_nodes()) {
         return -1;
     }
-    ScanTupleInfo& info = _plan_table_ctx->table_tuple_mapping[_current_tables[0]];
+    ScanTupleInfo& info = _plan_table_ctx->table_tuple_mapping[try_to_lower(_current_tables[0])];
     int64_t table_id = info.table_id;
     _ctx->prepared_table_id = table_id;
     if (!_ctx->is_prepared) {
@@ -111,7 +111,7 @@ int DeletePlanner::plan() {
 }
 
 int DeletePlanner::create_delete_node() {
-    if (_current_tables.size() != 1 || _plan_table_ctx->table_tuple_mapping.count(_current_tables[0]) == 0) {
+    if (_current_tables.size() != 1 || _plan_table_ctx->table_tuple_mapping.count(try_to_lower(_current_tables[0])) == 0) {
         DB_WARNING("invalid sql format: %s", _ctx->sql.c_str());
         return -1;
     }
@@ -119,7 +119,7 @@ int DeletePlanner::create_delete_node() {
         DB_WARNING("not support correlation subquery sql format: %s", _ctx->sql.c_str());
         return -1;
     }
-    ScanTupleInfo& info = _plan_table_ctx->table_tuple_mapping[_current_tables[0]];
+    ScanTupleInfo& info = _plan_table_ctx->table_tuple_mapping[try_to_lower(_current_tables[0])];
     int64_t table_id = info.table_id;
 
     pb::PlanNode* delete_node = _ctx->add_plan_node();

--- a/src/logical_plan/global_ddl_planner.cpp
+++ b/src/logical_plan/global_ddl_planner.cpp
@@ -168,6 +168,8 @@ std::unique_ptr<ScanNode> GlobalDDLPlanner::create_scan_node() {
     scan_node->init(_ctx->plan.nodes(0));
     _ctx->client_conn->txn_id = 0;
     set_dml_txn_state(_table_id);
+    _ctx->open_binlog = false;
+    _ctx->client_conn->open_binlog = false;
 
     scan_node->set_router_index_id(_table_id);
     pb::ScanNode* pb_scan_node = scan_node->mutable_pb_node()->

--- a/src/logical_plan/insert_planner.cpp
+++ b/src/logical_plan/insert_planner.cpp
@@ -119,7 +119,7 @@ int InsertPlanner::parse_db_table(pb::InsertNode* node) {
         DB_WARNING("invalid database or table:%s.%s", database.c_str(), table.c_str());
         return -1;
     }
-    _table_id = _plan_table_ctx->table_info[database + "." + table]->id;
+    _table_id = _plan_table_ctx->table_info[try_to_lower(database + "." + table)]->id;
     node->set_table_id(_table_id);
     //DB_WARNING("db:%s, tbl:%s, tbl_id:%lu", database.c_str(), table.c_str(), _table_id);
     return 0;

--- a/src/logical_plan/load_planner.cpp
+++ b/src/logical_plan/load_planner.cpp
@@ -118,7 +118,7 @@ int LoadPlanner::parse_load_info(pb::LoadNode* node, pb::InsertNode* insert_node
         DB_WARNING("invalid database or table:%s.%s", database.c_str(), table.c_str());
         return -1;
     }
-    _table_id = _plan_table_ctx->table_info[database + "." + table]->id;
+    _table_id = _plan_table_ctx->table_info[try_to_lower(database + "." + table)]->id;
     node->set_table_id(_table_id);
     insert_node->set_table_id(_table_id);
     std::string tmp_path = _load_stmt->path.to_string();

--- a/src/logical_plan/logical_planner.cpp
+++ b/src/logical_plan/logical_planner.cpp
@@ -1375,7 +1375,7 @@ int LogicalPlanner::handle_scalar_subquery(const parser::FuncExpr* func_item,
 int LogicalPlanner::create_scala_func_expr(const parser::FuncExpr* item, 
         pb::Expr& expr, parser::FuncType op, const CreateExprOptions& options) {
     if (op == parser::FT_COMMON) {
-        if (item->fn_name.to_lower() == "last_insert_id") {
+        if (item->fn_name.to_lower() == "last_insert_id" && item->children.size() == 0) {
             pb::ExprNode* node = expr.add_nodes();
             node->set_node_type(pb::INT_LITERAL);
             node->set_col_type(pb::INT64);

--- a/src/logical_plan/logical_planner.cpp
+++ b/src/logical_plan/logical_planner.cpp
@@ -2208,6 +2208,7 @@ int LogicalPlanner::create_term_slot_ref_node(
     node->mutable_derive_node()->set_tuple_id(slot.tuple_id()); //TODO
     node->mutable_derive_node()->set_slot_id(slot.slot_id());
     node->mutable_derive_node()->set_field_id(slot.field_id());
+    node->set_col_flag(field_info->flag);
     _ctx->ref_slot_id_mapping[slot.tuple_id()][col_expr->name.to_lower()] = slot.slot_id();
     return 0;
 }

--- a/src/logical_plan/logical_planner.cpp
+++ b/src/logical_plan/logical_planner.cpp
@@ -481,17 +481,17 @@ int LogicalPlanner::add_derived_table(const std::string& database, const std::st
     DatabaseInfo db;
     db.name = database;
     db.namespace_ = _ctx->user_info->namespace_;
-    if (_plan_table_ctx->table_dbs_mapping[table].count(database) == 0) {
-        _plan_table_ctx->table_dbs_mapping[table].emplace(database);
+    if (_plan_table_ctx->table_dbs_mapping[try_to_lower(table)].count(database) == 0) {
+        _plan_table_ctx->table_dbs_mapping[try_to_lower(table)].emplace(database);
     }
-    _plan_table_ctx->database_info.emplace(database, db);
+    _plan_table_ctx->database_info.emplace(try_to_lower(database), db);
     SmartTable tbl_info_ptr = std::make_shared<TableInfo>();
     TableInfo& tbl_info = *tbl_info_ptr;
     tbl_info.id = --_plan_table_ctx->derived_table_id;
     tbl_info.namespace_ = _ctx->user_info->namespace_;
     std::string table_name = database + "." + table;
     tbl_info.name = table_name;
-    bool ok = _plan_table_ctx->table_info.emplace(table_name, tbl_info_ptr).second;
+    bool ok = _plan_table_ctx->table_info.emplace(try_to_lower(table_name), tbl_info_ptr).second;
     if (ok) {
         ScanTupleInfo* tuple_info = get_scan_tuple(table_name, tbl_info.id);
         _ctx->derived_table_ctx_mapping[tuple_info->tuple_id] = _ctx->sub_query_plans.back();
@@ -515,7 +515,7 @@ int LogicalPlanner::add_derived_table(const std::string& database, const std::st
             tbl_info.fields.push_back(field_info);
         }
         for (auto& field : tbl_info.fields) {
-            _plan_table_ctx->field_info.emplace(field.lower_name, &field);
+            _plan_table_ctx->field_info.emplace(try_to_lower(field.lower_name), &field);
         }
     } else if (_table_names.count(table_name) != 0) {
         DB_WARNING("Not unique table/alias, db:%s, table:%s alias:%s", 
@@ -551,7 +551,7 @@ int LogicalPlanner::add_table(const std::string& database, const std::string& ta
     }
 
     DatabaseInfo db;
-    if (_plan_table_ctx->database_info.count(database) == 0) {
+    if (_plan_table_ctx->database_info.count(try_to_lower(database)) == 0) {
         int64_t databaseid = -1;
         if (0 != _factory->get_database_id(_namespace + "." + database_name, databaseid)) {
             DB_WARNING("unknown _namespace:%s database: %s", _namespace.c_str(), database.c_str());
@@ -566,16 +566,16 @@ int LogicalPlanner::add_table(const std::string& database, const std::string& ta
             _ctx->stat_info.error_msg << "database " << database << " not exist";
             return -1;
         }
-        _plan_table_ctx->database_info.emplace(database, db);
+        _plan_table_ctx->database_info.emplace(try_to_lower(database), db);
     } else {
-        db = _plan_table_ctx->database_info[database];
+        db = _plan_table_ctx->database_info[try_to_lower(database)];
     }
     // 后续的计算，全部以alias为准，无alias则使用表名
     std::string alias_name = alias.empty() ? table : alias;
     std::string alias_full_name = database + "." + alias_name;
     std::string org_table_full_name = database + "." + table;
     int64_t tableid = -1;
-    if (_plan_table_ctx->table_info.count(alias_full_name) == 0) {
+    if (_plan_table_ctx->table_info.count(try_to_lower(alias_full_name)) == 0) {
         std::string table_name = table;
         if (_ctx->has_information_schema) {
             std::transform(table_name.begin(), table_name.end(), table_name.begin(), ::toupper);
@@ -634,13 +634,13 @@ int LogicalPlanner::add_table(const std::string& database, const std::string& ta
         for (auto& field : tbl.fields) {
             std::string& col_name = field.lower_short_name;
             _plan_table_ctx->field_tbls_mapping[col_name].emplace(alias_full_name);
-            _plan_table_ctx->field_info.emplace(alias_full_name + "." + col_name, &field);
+            _plan_table_ctx->field_info.emplace(try_to_lower(alias_full_name + "." + col_name), &field);
         }
 
-        _plan_table_ctx->table_info.emplace(alias_full_name, tbl_ptr);
+        _plan_table_ctx->table_info.emplace(try_to_lower(alias_full_name), tbl_ptr);
         _table_names.emplace(alias_full_name);
-        if (_plan_table_ctx->table_dbs_mapping[alias_name].count(database) == 0) {
-            _plan_table_ctx->table_dbs_mapping[alias_name].emplace(database);
+        if (_plan_table_ctx->table_dbs_mapping[try_to_lower(alias_name)].count(database) == 0) {
+            _plan_table_ctx->table_dbs_mapping[try_to_lower(alias_name)].emplace(database);
         }
     } else if (_table_names.count(alias_full_name) != 0) {
         DB_WARNING("Not unique table/alias, db:%s, table:%s alias:%s", 
@@ -836,49 +836,49 @@ int LogicalPlanner::parse_using_cols(const parser::Vector<parser::ColumnName*>& 
 }
 int LogicalPlanner::fill_join_table_infos(JoinMemTmp* join_node_mem) {
     for (auto& table_name : join_node_mem->left_node->left_full_table_names) {
-        int64_t table_id = _plan_table_ctx->table_info[table_name]->id;
-        int32_t tuple_id = _plan_table_ctx->table_tuple_mapping[table_name].tuple_id;
-        if (join_node_mem->left_full_table_names.count(table_name) != 0) {
+        int64_t table_id = _plan_table_ctx->table_info[try_to_lower(table_name)]->id;
+        int32_t tuple_id = _plan_table_ctx->table_tuple_mapping[try_to_lower(table_name)].tuple_id;
+        if (join_node_mem->left_full_table_names.count(try_to_lower(table_name)) != 0) {
             DB_WARNING("not support self join");
             return -1;
         }
         join_node_mem->join_node.add_left_tuple_ids(tuple_id);
         join_node_mem->join_node.add_left_table_ids(table_id);
-        join_node_mem->left_full_table_names.insert(table_name);
+        join_node_mem->left_full_table_names.insert(try_to_lower(table_name));
     } 
     for (auto& table_name : join_node_mem->left_node->right_full_table_names) {
-        int64_t table_id = _plan_table_ctx->table_info[table_name]->id;
-        int32_t tuple_id = _plan_table_ctx->table_tuple_mapping[table_name].tuple_id;
-        if (join_node_mem->left_full_table_names.count(table_name) != 0) {
+        int64_t table_id = _plan_table_ctx->table_info[try_to_lower(table_name)]->id;
+        int32_t tuple_id = _plan_table_ctx->table_tuple_mapping[try_to_lower(table_name)].tuple_id;
+        if (join_node_mem->left_full_table_names.count(try_to_lower(table_name)) != 0) {
             DB_WARNING("not support self join");
             return -1;
         }
         join_node_mem->join_node.add_left_tuple_ids(tuple_id);
         join_node_mem->join_node.add_left_table_ids(table_id);
-        join_node_mem->left_full_table_names.insert(table_name);
+        join_node_mem->left_full_table_names.insert(try_to_lower(table_name));
     }
 
     for (auto& table_name : join_node_mem->right_node->left_full_table_names) {
-        int64_t table_id = _plan_table_ctx->table_info[table_name]->id;
-        int32_t tuple_id = _plan_table_ctx->table_tuple_mapping[table_name].tuple_id;
-        if (join_node_mem->right_full_table_names.count(table_name) != 0) {
+        int64_t table_id = _plan_table_ctx->table_info[try_to_lower(table_name)]->id;
+        int32_t tuple_id = _plan_table_ctx->table_tuple_mapping[try_to_lower(table_name)].tuple_id;
+        if (join_node_mem->right_full_table_names.count(try_to_lower(table_name)) != 0) {
             DB_WARNING("not support self join");
             return -1;
         }
         join_node_mem->join_node.add_right_tuple_ids(tuple_id);
         join_node_mem->join_node.add_right_table_ids(table_id);
-        join_node_mem->right_full_table_names.insert(table_name);
+        join_node_mem->right_full_table_names.insert(try_to_lower(table_name));
     }
     for (auto& table_name : join_node_mem->right_node->right_full_table_names) {
-        int64_t table_id = _plan_table_ctx->table_info[table_name]->id;
-        int32_t tuple_id = _plan_table_ctx->table_tuple_mapping[table_name].tuple_id;
-        if (join_node_mem->right_full_table_names.count(table_name) != 0) {
+        int64_t table_id = _plan_table_ctx->table_info[try_to_lower(try_to_lower(table_name))]->id;
+        int32_t tuple_id = _plan_table_ctx->table_tuple_mapping[try_to_lower(table_name)].tuple_id;
+        if (join_node_mem->right_full_table_names.count(try_to_lower(table_name)) != 0) {
             DB_WARNING("not support self join");
             return -1;
         }
         join_node_mem->join_node.add_right_tuple_ids(tuple_id);
         join_node_mem->join_node.add_right_table_ids(table_id);
-        join_node_mem->right_full_table_names.insert(table_name);
+        join_node_mem->right_full_table_names.insert(try_to_lower(table_name));
     }
     return 0;
 }
@@ -945,8 +945,8 @@ int LogicalPlanner::create_join_node_from_terminator(const std::string db,
     join_node_mem->left_full_table_names.insert(alias_full_name);
     join_node_mem->is_derived_table = is_derived_table;
     //这些表在这些map中肯定存在，不需要再判断
-    int64_t table_id = _plan_table_ctx->table_info[alias_full_name]->id;
-    int32_t tuple_id = _plan_table_ctx->table_tuple_mapping[alias_full_name].tuple_id;
+    int64_t table_id = _plan_table_ctx->table_info[try_to_lower(alias_full_name)]->id;
+    int32_t tuple_id = _plan_table_ctx->table_tuple_mapping[try_to_lower(alias_full_name)].tuple_id;
     join_node_mem->join_node.add_left_tuple_ids(tuple_id);
     join_node_mem->join_node.add_left_table_ids(table_id);
     *join_root_ptr = join_node_mem.release();
@@ -1985,7 +1985,7 @@ std::string LogicalPlanner::get_field_alias_name(const parser::ColumnName* colum
             }
             DB_WARNING("no database found for field: %s", column->to_string().c_str());
             return "";
-        } else if (dbs.size() > 1) {
+        } else if (dbs.size() > 1 && !FLAGS_disambiguate_select_name) {
             if (_ctx->stat_info.error_code == ER_ERROR_FIRST) {
                 _ctx->stat_info.error_code = ER_AMBIGUOUS_FIELD_TERM;
                 _ctx->stat_info.error_msg << "column  \'" << column->name << "\' is ambiguous";
@@ -2019,15 +2019,17 @@ std::string LogicalPlanner::get_field_alias_name(const parser::ColumnName* colum
             if (meet_tables.size() == 1) {
                 return meet_tables[0];
             }
-            for (auto& t : meet_tables) {
-                DB_WARNING("ambiguous field_name: %s t:%s", column->to_string().c_str(),
-                    t.c_str());
+            if (!FLAGS_disambiguate_select_name) {
+                for (auto& t : meet_tables) {
+                    DB_WARNING("ambiguous field_name: %s t:%s", column->to_string().c_str(),
+                        t.c_str());
+                }
+                if (_ctx->stat_info.error_code == ER_ERROR_FIRST) {
+                    _ctx->stat_info.error_code = ER_AMBIGUOUS_FIELD_TERM;
+                    _ctx->stat_info.error_msg << "column \'" << column->name << "\' is ambiguous";
+                }
+                return "";
             }
-            if (_ctx->stat_info.error_code == ER_ERROR_FIRST) {
-                _ctx->stat_info.error_code = ER_AMBIGUOUS_FIELD_TERM;
-                _ctx->stat_info.error_msg << "column \'" << column->name << "\' is ambiguous";
-            }
-            return "";
         }
         alias_name += *tables.begin();
         return alias_name;
@@ -2040,11 +2042,11 @@ std::string LogicalPlanner::get_field_alias_name(const parser::ColumnName* colum
 
 ScanTupleInfo* LogicalPlanner::get_scan_tuple(const std::string& table_name, int64_t table_id) {
     ScanTupleInfo* tuple_info = nullptr;
-    auto iter = _plan_table_ctx->table_tuple_mapping.find(table_name);
+    auto iter = _plan_table_ctx->table_tuple_mapping.find(try_to_lower(table_name));
     if (iter != _plan_table_ctx->table_tuple_mapping.end()) {
         tuple_info = &(iter->second);
     } else {
-        tuple_info = &(_plan_table_ctx->table_tuple_mapping[table_name]);
+        tuple_info = &(_plan_table_ctx->table_tuple_mapping[try_to_lower(table_name)]);
         tuple_info->tuple_id = _plan_table_ctx->tuple_cnt++;
         tuple_info->table_id = table_id;
         tuple_info->slot_cnt = 1;
@@ -2115,7 +2117,7 @@ int LogicalPlanner::create_alias_node(const parser::ColumnName* column, pb::Expr
     }
     std::string lower_name = column->name.to_lower();
     int match_count = _select_alias_mapping.count(lower_name);
-    if (match_count > 1) {
+    if (match_count > 1 && !FLAGS_disambiguate_select_name) {
         DB_WARNING("column name: %s is ambiguous", column->name.c_str());
         return -2;
     } else if (match_count == 0) {

--- a/src/logical_plan/select_planner.cpp
+++ b/src/logical_plan/select_planner.cpp
@@ -400,6 +400,7 @@ void SelectPlanner::add_single_table_columns(const std::string& table_name, Tabl
         node->mutable_derive_node()->set_tuple_id(slot.tuple_id()); //TODO
         node->mutable_derive_node()->set_slot_id(slot.slot_id());
         node->mutable_derive_node()->set_field_id(slot.field_id());
+        node->set_col_flag(field.flag);
 
         std::string& select_name = field.short_name;
         _select_exprs.push_back(select_expr);

--- a/src/logical_plan/select_planner.cpp
+++ b/src/logical_plan/select_planner.cpp
@@ -318,11 +318,12 @@ int SelectPlanner::create_agg_node() {
 
         for (uint32_t idx = 0; idx < _select_exprs.size(); ++idx) {
             pb::Expr* expr = agg->add_group_exprs();
-            if (_select_exprs[idx].nodes_size() != 1) {
-                DB_WARNING("invalid distinct expr");
-                return -1;
-            }
-            expr->add_nodes()->CopyFrom(_select_exprs[idx].nodes(0));
+            expr->CopyFrom(_select_exprs[idx]);
+//            if (_select_exprs[idx].nodes_size() != 1) {
+//                DB_WARNING("invalid distinct expr");
+//                return -1;
+//            }
+//            expr->add_nodes()->CopyFrom(_select_exprs[idx].nodes(0));
         }
         agg->set_agg_tuple_id(-1);
         return 0;

--- a/src/logical_plan/select_planner.cpp
+++ b/src/logical_plan/select_planner.cpp
@@ -406,9 +406,9 @@ void SelectPlanner::add_single_table_columns(const std::string& table_name, Tabl
         std::string& select_name = field.short_name;
         _select_exprs.push_back(select_expr);
         _select_names.push_back(select_name);
-        std::transform(select_name.begin(), select_name.end(), select_name.begin(), ::tolower);
-        _ctx->ref_slot_id_mapping[slot.tuple_id()][select_name] = slot.slot_id();
-        _ctx->field_column_id_mapping[select_name] = _column_id++;
+//        std::transform(select_name.begin(), select_name.end(), select_name.begin(), ::tolower);
+        _ctx->ref_slot_id_mapping[slot.tuple_id()][field.lower_short_name] = slot.slot_id();
+        _ctx->field_column_id_mapping[field.lower_short_name] = _column_id++;
     }
 }
 
@@ -452,7 +452,7 @@ int SelectPlanner::parse_select_star(parser::SelectField* field) {
                 }
                 DB_WARNING("no database found for field: %s", table_name.c_str());
                 return -1;
-            } else if (dbs.size() > 1) {
+            } else if (dbs.size() > 1 && !FLAGS_disambiguate_select_name) {
                 if (_ctx->stat_info.error_code == ER_ERROR_FIRST) {
                     _ctx->stat_info.error_code = ER_AMBIGUOUS_FIELD_TERM;
                     _ctx->stat_info.error_msg << "table  \'" << table_name << "\' is ambiguous";

--- a/src/meta_server/region_manager.cpp
+++ b/src/meta_server/region_manager.cpp
@@ -27,6 +27,7 @@ DECLARE_int32(concurrency_num);
 DECLARE_int64(store_heart_beat_interval_us);
 DECLARE_int32(store_dead_interval_times);
 DECLARE_int32(region_faulty_interval_times);
+DECLARE_int32(balance_add_peer_num);
 
 //增加或者更新region信息
 //如果是增加，则需要更新表信息, 只有leader的上报会调用该接口
@@ -878,6 +879,7 @@ void RegionManager::peer_load_balance(const std::unordered_map<int64_t, int64_t>
             continue;
         }
         int64_t count = add_peer_count.second;
+        int32_t add_peer_num = 0;
         if (instance_regions.find(table_id) == instance_regions.end()) {
             continue;
         }
@@ -930,10 +932,11 @@ void RegionManager::peer_load_balance(const std::unordered_map<int64_t, int64_t>
             add_peer.add_new_peers(new_instance);
             add_peer_requests.push_back(std::pair<std::string, pb::AddPeer>(master_region_info->leader(), add_peer));
             --count;
+            ++add_peer_num;
             if (count <= 0) {
                 break;
             }
-            if (add_peer_requests.size() > 10) {
+            if (add_peer_num > FLAGS_balance_add_peer_num) {
                 break;
             }
         } 

--- a/src/meta_server/region_manager.cpp
+++ b/src/meta_server/region_manager.cpp
@@ -21,13 +21,15 @@
 #include "meta_util.h"
 #include "table_manager.h"
 #include "meta_rocksdb.h"
+#include "brpc/reloadable_flags.h"
 
 namespace baikaldb {
 DECLARE_int32(concurrency_num);
 DECLARE_int64(store_heart_beat_interval_us);
 DECLARE_int32(store_dead_interval_times);
 DECLARE_int32(region_faulty_interval_times);
-DECLARE_int32(balance_add_peer_num);
+DEFINE_int32(balance_add_peer_num, 10, "add peer num each time, default(10)");
+BRPC_VALIDATE_GFLAG(balance_add_peer_num, brpc::PositiveInteger);
 
 //增加或者更新region信息
 //如果是增加，则需要更新表信息, 只有leader的上报会调用该接口

--- a/src/meta_server/region_manager.cpp
+++ b/src/meta_server/region_manager.cpp
@@ -786,7 +786,7 @@ void RegionManager::leader_load_balance(bool whether_can_decide,
         }
         average_leader_counts[table_id] = average_leader_count;
         if (table_leader_count.second > (average_leader_count + average_leader_count * 5 / 100)) {
-            transfer_leader_count[table_id] = 
+            transfer_leader_count[table_id] =
                 2 * (table_leader_count.second - average_leader_count);
             response->add_trans_leader_table_id(table_id);
             response->add_trans_leader_count(table_leader_count.second - average_leader_count);
@@ -843,7 +843,8 @@ void RegionManager::leader_load_balance(bool whether_can_decide,
                 continue;
             }
             int64_t leader_count = get_leader_count(peer, table_id);
-            if (leader_count < average_leader_counts[table_id]
+            if (leader_count < average_leader_counts[table_id] + average_leader_counts[table_id] * 10 / 100
+                    && leader_count < table_leader_counts[table_id]
                     && leader_count < leader_count_for_transfer_peer) {
                 transfer_to_peer = peer;
                 leader_count_for_transfer_peer = leader_count;
@@ -858,6 +859,7 @@ void RegionManager::leader_load_balance(bool whether_can_decide,
             transfer_leader_count[table_id]--;
             *(response->add_trans_leader()) = transfer_request;
             add_leader_count(transfer_to_peer, table_id);
+            table_leader_counts[table_id]--;
         } 
     }
 }

--- a/src/physical_plan/index_selector.cpp
+++ b/src/physical_plan/index_selector.cpp
@@ -77,7 +77,7 @@ int IndexSelector::analyze(QueryContext* ctx) {
         }
         if (index_has_null) {
             ctx->return_empty = true;
-            DB_WARNING("normal predicate compare whih null");
+            DB_WARNING("normal predicate compare with null");
             return 0;
         }
         if (ret < 0) {

--- a/src/protocol/network_server.cpp
+++ b/src/protocol/network_server.cpp
@@ -308,7 +308,7 @@ void NetworkServer::print_agg_sql() {
                     std::string field_desc = "-";
                     index_recommend(pair.first, pair2.second.table_id, pair2.first, recommend_index, field_desc);
                     butil::MurmurHash3_x64_128(pair.first.c_str(), pair.first.size(), 0x1234, out);
-                    SQL_TRACE("date_hour_min=[%04d-%02d-%02d\t%02d\t%02d] sum_pv_avg_affected_scan_filter_err="
+                    DB_NOTICE_LONG("date_hour_min=[%04d-%02d-%02d\t%02d\t%02d] sum_pv_avg_affected_scan_filter_err="
                             "[%ld\t%ld\t%ld\t%ld\t%ld\t%ld\t%ld] sign_hostname_index=[%lu\t%s\t%s] sql_agg: %s "
                             "op_version_desc=[%ld\t%s\t%s\t%s]", 
                         1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday, tm.tm_hour, tm.tm_min,

--- a/src/protocol/network_server.cpp
+++ b/src/protocol/network_server.cpp
@@ -308,7 +308,7 @@ void NetworkServer::print_agg_sql() {
                     std::string field_desc = "-";
                     index_recommend(pair.first, pair2.second.table_id, pair2.first, recommend_index, field_desc);
                     butil::MurmurHash3_x64_128(pair.first.c_str(), pair.first.size(), 0x1234, out);
-                    DB_NOTICE_LONG("date_hour_min=[%04d-%02d-%02d\t%02d\t%02d] sum_pv_avg_affected_scan_filter_err="
+                    SQL_TRACE("date_hour_min=[%04d-%02d-%02d\t%02d\t%02d] sum_pv_avg_affected_scan_filter_err="
                             "[%ld\t%ld\t%ld\t%ld\t%ld\t%ld\t%ld] sign_hostname_index=[%lu\t%s\t%s] sql_agg: %s "
                             "op_version_desc=[%ld\t%s\t%s\t%s]", 
                         1900 + tm.tm_year, 1 + tm.tm_mon, tm.tm_mday, tm.tm_hour, tm.tm_min,

--- a/src/protocol/state_machine.cpp
+++ b/src/protocol/state_machine.cpp
@@ -28,7 +28,6 @@ DEFINE_int32(query_quota_per_user, 3000, "default user query quota by 1 second")
 DEFINE_string(log_plat_name, "test", "plat name for print log, distinguish monitor");
 DECLARE_int64(print_time_us);
 DECLARE_string(meta_server_bns);
-
 void StateMachine::run_machine(SmartSocket client,
         EpollInfo* epoll_info,
         bool shutdown) {
@@ -492,7 +491,7 @@ void StateMachine::_print_query_time(SmartSocket client) {
                 ctx->type,
                 client->username.c_str());
         }
-    } 
+    }
     SchemaFactory::use_backup.set_bthread_local(false);
     ctx->mysql_cmd = COM_SLEEP;
     client->last_active = time(NULL);
@@ -521,8 +520,10 @@ int StateMachine::_auth_read(SmartSocket sock) {
     }
     if (charset_num == 28) {
         sock->charset_name = "gbk";
+        sock->charset_num = 28;
     } else if (charset_num == 33) {
         sock->charset_name = "utf8";
+        sock->charset_num = 33;
     } else {
         DB_TRACE_CLIENT(sock, "unknown charset num: %u, charset will be set as gbk.",
             charset_num);
@@ -994,8 +995,10 @@ bool StateMachine::_query_process(SmartSocket client) {
             re2::RE2 reg(".*gbk.*", option);
             if (RE2::FullMatch(client->query_ctx->sql, reg)) {
                 client->charset_name = "gbk";
+                client->charset_num = 28;
             } else {
                 client->charset_name = "utf8";
+                client->charset_num = 33;
             }
             if (reg.error_code() != 0) {
                 DB_WARNING("charset regex match error.");
@@ -2664,7 +2667,7 @@ bool StateMachine::_handle_client_query_show_socket(SmartSocket client) {
         }
     }
 
-    std::sort(rows.begin(), rows.end(), 
+    std::sort(rows.begin(), rows.end(),
         [](const std::vector<std::string>& left, const std::vector<std::string>& right) {
             int l = atoi(left[1].c_str());
             int r = atoi(right[1].c_str());

--- a/src/protocol/state_machine.cpp
+++ b/src/protocol/state_machine.cpp
@@ -2867,6 +2867,7 @@ bool StateMachine::_handle_client_query_show_collation(SmartSocket client) {
     rows.push_back(row1);
     rows.push_back({"utf8_general_ci", "utf8", "33", "Yes", "Yes", "1"});
     rows.push_back({"utf8_bin", "utf8", "83", " ", "Yes", "1"});
+    rows.push_back({"binary", "binary", "63", " ", "Yes", "1"});
 
     // Make mysql packet.
     if (_make_common_resultset_packet(client, fields, rows) != 0) {

--- a/src/store/region.cpp
+++ b/src/store/region.cpp
@@ -4292,7 +4292,7 @@ void Region::write_local_rocksdb_for_split() {
         };
         copy_bth.run(read_and_write); 
     }
-    if (!_is_global_index) {
+    if (table_info.engine == pb::ROCKSDB_CSTORE && !_is_global_index) {
         // write all non-pk column values to cstore
         std::set<int32_t> pri_field_ids;
         for (auto& field_info : pk_info.fields) {

--- a/src/store/region.cpp
+++ b/src/store/region.cpp
@@ -290,6 +290,7 @@ int Region::init(bool new_region, int32_t snapshot_times) {
         //binlog region把start key和end key设置为空，防止filter把数据删掉
         SplitCompactionFilter::get_instance()->set_end_key(
                 _region_id, "");
+        SplitCompactionFilter::get_instance()->set_binlog_region(_region_id);
     } else {
         SplitCompactionFilter::get_instance()->set_end_key(
                 _region_id,

--- a/src/store/region.cpp
+++ b/src/store/region.cpp
@@ -1744,6 +1744,9 @@ void Region::dml_1pc(const pb::StoreReq& request, pb::OpType op_type,
         response.set_scan_rows(state.num_scan_rows());
         response.set_filter_rows(state.num_filter_rows());
         response.set_errcode(pb::SUCCESS);
+        if (state.last_insert_id != INT64_MIN) {
+            response.set_last_insert_id(state.last_insert_id);
+        }
     } else {
         response.set_errcode(pb::EXEC_FAIL);
         response.set_errmsg("txn commit failed.");
@@ -2352,6 +2355,9 @@ void Region::on_apply(braft::Iterator& iter) {
                     }
                     if (res.has_filter_rows()) {
                         ((DMLClosure*)done)->response->set_filter_rows(res.filter_rows());
+                    }
+                    if (res.has_last_insert_id()) {
+                        ((DMLClosure*)done)->response->set_last_insert_id(res.last_insert_id());
                     }
                 }
                 //DB_WARNING("dml_1pc %s", res.trace_nodes().DebugString().c_str());

--- a/src/store/region_binlog.cpp
+++ b/src/store/region_binlog.cpp
@@ -966,7 +966,7 @@ void Region::read_binlog(const pb::StoreReq* request,
         }
     }
 
-    if (return_nr == 0 && max_fake_binlog != 0) {
+    if (return_nr == 0 && max_fake_binlog != 0 && begin_ts < max_fake_binlog) {
         pb::StoreReq fake_binlog;
         DB_WARNING("region_id: %ld, fake binlog ts: %ld, %s", _region_id, max_fake_binlog, ts_to_datetime(max_fake_binlog).c_str());
         fake_binlog.set_op_type(pb::OP_FAKE_BINLOG);


### PR DESCRIPTION
- binlog元数据表支持ttl
- 兼容.netcore对string与binary的处理差异，支持_binary EXPR用法及blob类型返回
- 增加函数last_insert_id(expr)，可以在session级别保存表达式执行结果
- 支持库名，表名，别名，大小写不敏感用法，schema_ignore_case=true开启
- 支持多表查询时，不同表字段相同，查询时没有指定表名的歧义消除功能，disambiguate_select_name=true开启
- peer_load_balance增加balance_add_peer_num参数，默认每张表迁移10个，可不重启meta动态修改以调整迁移速度
- leader_load_balance放宽transfer leader的候选peer的选择限制
- 修复了一些bug