### PR TITLE
add rawkv api for store

### DIFF
--- a/include/common/datetime.h
+++ b/include/common/datetime.h
@@ -56,5 +56,8 @@ inline std::string date_to_str(uint32_t date) {
     snprintf(buf, sizeof(buf), "%04d-%02d-%02d", year, month, day);
     return std::string(buf);
 }
+
+extern bool tz_to_second(const char *time_zone, int32_t& result);
+
 } // namespace baikaldb
 

--- a/include/common/information_schema.h
+++ b/include/common/information_schema.h
@@ -54,6 +54,8 @@ private:
     void init_schemata();
     void init_tables();
     void init_routines();
+    void init_key_column_usage();
+    void init_referential_constraints();
 
     std::unordered_map<std::string, pb::SchemaInfo> _tables;
     //InformationSchema在baikaldb端运行

--- a/include/common/information_schema.h
+++ b/include/common/information_schema.h
@@ -53,6 +53,7 @@ private:
     void init_statistics();
     void init_schemata();
     void init_tables();
+    void init_routines();
 
     std::unordered_map<std::string, pb::SchemaInfo> _tables;
     //InformationSchema在baikaldb端运行

--- a/include/common/schema_factory.h
+++ b/include/common/schema_factory.h
@@ -143,6 +143,7 @@ struct FieldInfo {
     bool                deleted = false;
     bool                noskip = false;
     uint32_t            flag   = 0;
+    uint32_t            timestamp = 0;
 };
 
 struct DistInfo {

--- a/include/common/schema_factory.h
+++ b/include/common/schema_factory.h
@@ -269,6 +269,7 @@ struct TableInfo {
     std::vector<FieldInfo>  fields;
     std::vector<DistInfo>   dists;
     int64_t                 replica_num = 3;
+    std::string             comment;
     //table字段不变的话不需要重新构建动态pb
     std::string             fields_sign;
     //>0表示配置有ttl，单位s

--- a/include/engine/transaction.h
+++ b/include/engine/transaction.h
@@ -196,14 +196,15 @@ public:
     int remove_columns(const TableKey& primary_key);
 
     void print_txninfo_holding_lock(const std::string& key) {
-        return;
+//        return;
         //内部有pthread锁
         auto lock_info = _db->get_db()->GetLockStatusData();
         for (auto& it : lock_info) {
             if (it.second.key.size() == key.size() && it.second.key == key) {
                 for (auto txn_id : it.second.ids) {
-                    DB_WARNING("holding lock, txn_id: %lu, cf_id: %u, key_hex: %s", 
-                        txn_id, it.first, str_to_hex(key).c_str());
+                    DB_WARNING("holding lock, txn_id: %lu, rocksdb_txn_id: %lu, "
+                            "cf_id: %u, key_hex: %s",
+                            _txn_id, txn_id, it.first, str_to_hex(key).c_str());
                 }
                 break;
             }

--- a/include/exec/apply_node.h
+++ b/include/exec/apply_node.h
@@ -48,14 +48,23 @@ public:
 private:
     void extract_eq_inner_slots(ExprNode* expr_node);
     int hash_apply(RuntimeState* state);
+    int loop_hash_apply(RuntimeState* state);
     int nested_loop_apply(RuntimeState* state);
     int fetcher_inner_table_data(RuntimeState* state,
                             MemRow* outer_tuple_data,
                             std::vector<ExecNode*>& scan_nodes,
                             std::vector<MemRow*>& inner_tuple_data);
+    int fetcher_inner_table_data(RuntimeState* state,
+                            const std::vector<MemRow*>& outer_tuple_data,
+                            std::vector<ExecNode*>& scan_nodes,
+                            std::vector<MemRow*>& inner_tuple_data);
     int get_next_via_inner_hash_map(RuntimeState* state, RowBatch* batch, bool* eos);
     int get_next_via_outer_hash_map(RuntimeState* state, RowBatch* batch, bool* eos);
+    int get_next_via_loop_outer_hash_map(RuntimeState* state, RowBatch* batch, bool* eos);
     int get_next_for_nested_loop_join(RuntimeState* state, RowBatch* batch, bool* eos);
+    inline int get_loop_num() {
+        return _parent->get_limit() * std::pow(2, _loops);
+    }
 private:
     bool    _max_one_row = false;
     bool    _has_matched = false;

--- a/include/exec/dml_node.h
+++ b/include/exec/dml_node.h
@@ -96,7 +96,7 @@ protected:
     std::vector<pb::SlotDescriptor> _update_slots;
     std::vector<ExprNode*> _update_exprs;
     std::set<int32_t> _update_field_ids;
-    std::set<int32_t> _can_not_null_field_ids;
+    std::vector<FieldInfo*> _can_not_null_fields;
 
     SmartTransaction         _txn = nullptr; 
     SmartTable               _table_info;

--- a/include/exec/dml_node.h
+++ b/include/exec/dml_node.h
@@ -96,6 +96,7 @@ protected:
     std::vector<pb::SlotDescriptor> _update_slots;
     std::vector<ExprNode*> _update_exprs;
     std::set<int32_t> _update_field_ids;
+    std::set<int32_t> _can_not_null_field_ids;
 
     SmartTransaction         _txn = nullptr; 
     SmartTable               _table_info;

--- a/include/exec/filter_node.h
+++ b/include/exec/filter_node.h
@@ -39,6 +39,9 @@ public:
     void add_conjunct(ExprNode* conjunct) {
         _conjuncts.push_back(conjunct);
     }
+    const std::vector<ExprNode*>& pruned_conjuncts() {
+        return _pruned_conjuncts;
+    }
     virtual int open(RuntimeState* state);
     virtual int get_next(RuntimeState* state, RowBatch* batch, bool* eos);
     virtual void close(RuntimeState* state);

--- a/include/exec/joiner.h
+++ b/include/exec/joiner.h
@@ -147,6 +147,8 @@ protected:
     bool    _child_eos = false;
     bool    _is_apply = false;
     bool    _conditions_has_agg = false;
+    bool    _use_loop_hash_map = false;
+    size_t  _loops = 0;
     RowBatch _inner_row_batch;
     std::map<int32_t, std::set<int32_t>> _inner_equal_field_ids; // 用于检查内查询的等值条件是否具有唯一性
 };

--- a/include/exec/joiner.h
+++ b/include/exec/joiner.h
@@ -104,6 +104,12 @@ public:
                                MemRow* inner_mem_row,
                                bool& matched);
     int construct_null_result_batch(RowBatch* batch, MemRow* outer_mem_row);
+    std::unordered_set<int32_t>* left_tuple_ids() {
+        return &_left_tuple_ids;
+    }
+    std::unordered_set<int32_t>* right_tuple_ids() {
+        return &_right_tuple_ids;
+    }
 
 protected:
     pb::JoinType _join_type;

--- a/include/exec/scan_node.h
+++ b/include/exec/scan_node.h
@@ -157,8 +157,6 @@ public:
 
     int compare_two_path(SmartPath outer_path, SmartPath inner_path);
 
-    void inner_loop_and_compare(std::map<int64_t, SmartPath>::iterator outer_loop_iter);
-
     void set_fulltext_index_tree(const FulltextInfoTree& tree) {
         _fulltext_index_tree = tree;
     }
@@ -166,8 +164,8 @@ public:
     int create_fulltext_index_tree(FulltextInfoNode* node, pb::FulltextIndex* root);
     int create_fulltext_index_tree();
 
-// 两两比较，根据一些简单规则干掉次优索引
-    int64_t pre_process_select_index();
+    void calc_possible_index();
+    int64_t select_unique_index();
     
 protected:
     pb::Engine _engine = pb::ROCKSDB;
@@ -189,6 +187,8 @@ protected:
     FulltextInfoTree _fulltext_index_tree; //目前只有两层，第一层为and，第二层为or。
     std::unique_ptr<pb::FulltextIndex> _fulltext_index_pb;
     bool _fulltext_use_arrow = false;
+    int64_t _virtual_index_selected = 0;
+    bool _has_force_index = false;
 };
 }
 

--- a/include/expr/internal_functions.h
+++ b/include/expr/internal_functions.h
@@ -148,6 +148,12 @@ ExprValue tdigest_location(const std::vector<ExprValue>& input);
 // other
 ExprValue version(const std::vector<ExprValue>& input);
 ExprValue last_insert_id(const std::vector<ExprValue>& input);
+ExprValue cast_to_date(const std::vector<ExprValue>& inpt);
+ExprValue cast_to_time(const std::vector<ExprValue>& inpt);
+ExprValue cast_to_datetime(const std::vector<ExprValue>& inpt);
+ExprValue cast_to_signed(const std::vector<ExprValue>& inpt);
+ExprValue cast_to_unsigned(const std::vector<ExprValue>& inpt);
+ExprValue cast_to_string(const std::vector<ExprValue>& inpt);
 }
 
 /* vim: set ts=4 sw=4 sts=4 tw=100 */

--- a/include/expr/internal_functions.h
+++ b/include/expr/internal_functions.h
@@ -61,6 +61,8 @@ ExprValue replace(const std::vector<ExprValue>& input);
 ExprValue repeat(const std::vector<ExprValue>& input);
 ExprValue reverse(const std::vector<ExprValue>& input);
 ExprValue locate(const std::vector<ExprValue>& input);
+ExprValue lpad(const std::vector<ExprValue>& input);
+ExprValue rpad(const std::vector<ExprValue>& input);
 
 // datetime functions
 ExprValue unix_timestamp(const std::vector<ExprValue>& input);
@@ -75,6 +77,7 @@ ExprValue current_date(const std::vector<ExprValue>& input);
 ExprValue curtime(const std::vector<ExprValue>& input);
 ExprValue current_time(const std::vector<ExprValue>& input);
 ExprValue current_timestamp(const std::vector<ExprValue>& input);
+ExprValue timestamp(const std::vector<ExprValue>& input);
 ExprValue day(const std::vector<ExprValue>& input);
 ExprValue dayname(const std::vector<ExprValue>& input);
 ExprValue dayofweek(const std::vector<ExprValue>& input);

--- a/include/expr/internal_functions.h
+++ b/include/expr/internal_functions.h
@@ -70,6 +70,8 @@ ExprValue from_unixtime(const std::vector<ExprValue>& input);
 ExprValue now(const std::vector<ExprValue>& input);
 ExprValue utc_timestamp(const std::vector<ExprValue>& input);
 ExprValue date_format(const std::vector<ExprValue>& input);
+ExprValue time_format(const std::vector<ExprValue>& input);
+ExprValue convert_tz(const std::vector<ExprValue>& input);
 ExprValue timediff(const std::vector<ExprValue>& input);
 ExprValue timestampdiff(const std::vector<ExprValue>& input);
 ExprValue curdate(const std::vector<ExprValue>& input);
@@ -104,6 +106,7 @@ ExprValue case_when(const std::vector<ExprValue>& input);
 ExprValue case_expr_when(const std::vector<ExprValue>& input);
 ExprValue if_(const std::vector<ExprValue>& input);
 ExprValue ifnull(const std::vector<ExprValue>& input);
+ExprValue isnull(const std::vector<ExprValue>& input);
 ExprValue nullif(const std::vector<ExprValue>& input);
 // MurmurHash sign
 ExprValue murmur_hash(const std::vector<ExprValue>& input);

--- a/include/logical_plan/logical_planner.h
+++ b/include/logical_plan/logical_planner.h
@@ -44,6 +44,7 @@ struct JoinMemTmp {
     std::multiset<std::string> right_full_table_names;
     bool is_derived_table = false;
     std::set<std::int64_t> use_indexes;
+    std::set<std::int64_t> force_indexes;
     std::set<std::int64_t> ignore_indexes;
     virtual ~JoinMemTmp() {
         delete left_node;
@@ -192,6 +193,7 @@ protected:
                                          const std::string alias,
                                          const bool is_derived_table,
                                          const std::vector<std::string>& use_index_names,
+                                         const std::vector<std::string>& force_index_names,
                                          const std::vector<std::string>& ignore_index_names, 
                                          JoinMemTmp** join_root_ptr); 
 

--- a/include/meta_server/table_manager.h
+++ b/include/meta_server/table_manager.h
@@ -198,6 +198,7 @@ public:
     void update_dists(const pb::MetaManagerRequest& request, const int64_t apply_index, braft::Closure* done);
     void update_ttl_duration(const pb::MetaManagerRequest& request, const int64_t apply_index, braft::Closure* done);
     void update_resource_tag(const pb::MetaManagerRequest& request, const int64_t apply_index, braft::Closure* done);
+    void update_table_comment(const pb::MetaManagerRequest& request, const int64_t apply_index, braft::Closure* done);
 
     void add_field(const pb::MetaManagerRequest& request, const int64_t apply_index, braft::Closure* done);
     void add_index(const pb::MetaManagerRequest& request, const int64_t apply_index, braft::Closure* done);

--- a/include/physical_plan/predicate_pushdown.h
+++ b/include/physical_plan/predicate_pushdown.h
@@ -17,6 +17,7 @@
 #include "exec_node.h"
 #include "filter_node.h"
 #include "join_node.h"
+#include "apply_node.h"
 #include "query_context.h"
 
 namespace baikaldb {
@@ -26,7 +27,8 @@ public:
         ExecNode* plan = ctx->root;
         //目前只要有join节点的话才做谓词下推
         JoinNode* join = static_cast<JoinNode*>(plan->get_node(pb::JOIN_NODE));
-        if (join == NULL) {
+        ApplyNode* apply = static_cast<ApplyNode*>(plan->get_node(pb::APPLY_NODE));
+        if (join == NULL && apply == NULL) {
             //DB_WARNING("has no join, not predicate")
             return 0;
         }

--- a/include/protocol/mysql_wrapper.h
+++ b/include/protocol/mysql_wrapper.h
@@ -22,6 +22,36 @@
 
 namespace baikaldb {
 
+// https://dev.mysql.com/doc/internals/en/capability-flags.html
+enum MysqlCapability {
+    CLIENT_LONG_PASSWORD                    = 1 << 0,  /* new more secure passwords */
+    CLIENT_FOUND_ROWS                       = 1 << 1,  /* Found instead of affected rows */
+    CLIENT_LONG_FLAG                        = 1 << 2,  /* Get all column flags */
+    CLIENT_CONNECT_WITH_DB                  = 1 << 3,  /* One can specify db on connect */
+    CLIENT_NO_SCHEMA                        = 1 << 4,  /* Don't allow database.table.column */
+    CLIENT_COMPRESS                         = 1 << 5,  /* Can use compression protocol */
+    CLIENT_ODBC                             = 1 << 6,  /* Odbc client */
+    CLIENT_LOCAL_FILES                      = 1 << 7,  /* Can use LOAD DATA LOCAL */
+    CLIENT_IGNORE_SPACE                     = 1 << 8,  /* Ignore spaces before '(' */
+    CLIENT_PROTOCOL_41                      = 1 << 9,  /* New 4.1 protocol */
+    CLIENT_INTERACTIVE                      = 1 << 10, /* This is an interactive client */
+    CLIENT_SSL                              = 1 << 11, /* Switch to SSL after handshake */
+    CLIENT_IGNORE_SIGPIPE                   = 1 << 12, /* IGNORE sigpipes */
+    CLIENT_TRANSACTIONS                     = 1 << 13, /* Client knows about transactions */
+    CLIENT_RESERVED                         = 1 << 14, /* Old flag for 4.1 protocol  */
+    CLIENT_SECURE_CONNECTION                = 1 << 15, /* New 4.1 authentication */
+    CLIENT_MULTI_STATEMENTS                 = 1 << 16, /* Enable/disable multi-stmt support */
+    CLIENT_MULTI_RESULTS                    = 1 << 17, /* Enable/disable multi-results */
+    CLIENT_PS_MULTI_RESULTS                 = 1 << 18, /* Multi-results in PS-protocol */
+    CLIENT_PLUGIN_AUTH                      = 1 << 19, /* Client supports plugin authentication */
+    CLIENT_CONNECT_ATTRS                    = 1 << 20, /* Client supports connection attributes */
+    CLIENT_PLUGIN_AUTH_LENENC_CLIENT_DATA   = 1 << 21, /* Enable authentication response packet to be larger than 255 bytes. */
+    CLIENT_CAN_HANDLE_EXPIRED_PASSWORDS     = 1 << 22, /* Don't close the connection for a connection with expired password. */
+    CLIENT_SESSION_TRACK                    = 1 << 30,
+    CLIENT_DEPRECATE_EOF                    = 1 << 31,
+};
+
+
 class NetworkSocket;
 const uint32_t PACKET_LEN_MAX                    = 0x00ffffff;
 const uint32_t PACKET_HEADER_LEN                 = 4;

--- a/include/sqlparser/expr.cc
+++ b/include/sqlparser/expr.cc
@@ -162,7 +162,7 @@ void FuncExpr::to_stream(std::ostream& os) const {
         default:
             break;
     }
-    os << "(";
+//    os << "(";
     switch (func_type) {
         case FT_COMMON: {
         case FT_AGG:
@@ -237,7 +237,7 @@ void FuncExpr::to_stream(std::ostream& os) const {
         default:
             break;
     }
-    os << ")";
+//    os << ")";
 };
 
 void SubqueryExpr::to_stream(std::ostream& os) const {

--- a/include/sqlparser/sql_lex.l
+++ b/include/sqlparser/sql_lex.l
@@ -56,7 +56,7 @@ CHECK { return CHECK; }
 COLLATE { return COLLATE; }
 COLUMN { return COLUMN; }
 CONSTRAINT { return CONSTRAINT; }
-CONVERT { return CONVERT; }
+CONVERT { un_reserved_keyword(yylval, yyscanner, parser); return CONVERT;}
 CREATE { return CREATE; }
 CROSS { return CROSS; }
 CURRENT_DATE { un_reserved_keyword(yylval, yyscanner, parser); return CURRENT_DATE; }
@@ -504,6 +504,9 @@ VAR_SAMP { un_reserved_keyword(yylval, yyscanner, parser); return VAR_SAMP; }
     return IDENT;
 }
 
+"--".* {/* single line comment; do nothing */}
+"#".* {/* single line comment; do nothing */}
+
 [ \t\r\n] { }
 [\0] { return 0; }
 
@@ -511,8 +514,6 @@ VAR_SAMP { un_reserved_keyword(yylval, yyscanner, parser); return VAR_SAMP; }
 [][] { return yytext[0]; }
 
 "/*"([*]*(([^*/])+([/])*)*)*"*/" {/* comment; do nothing */}
-"--"([^\n])*"\n" {/* single line comment; do nothing */}                                                                                                                                                    
-"#"([^\n])*"\n" {/* single line comment; do nothing */}
 
 . { return CHINESE_DOT; }
 

--- a/include/sqlparser/sql_lex.l
+++ b/include/sqlparser/sql_lex.l
@@ -511,6 +511,8 @@ VAR_SAMP { un_reserved_keyword(yylval, yyscanner, parser); return VAR_SAMP; }
 [][] { return yytext[0]; }
 
 "/*"([*]*(([^*/])+([/])*)*)*"*/" {/* comment; do nothing */}
+"--"([^\n])*"\n" {/* single line comment; do nothing */}                                                                                                                                                    
+"#"([^\n])*"\n" {/* single line comment; do nothing */}
 
 . { return CHINESE_DOT; }
 

--- a/include/sqlparser/sql_parse.y
+++ b/include/sqlparser/sql_parse.y
@@ -4483,6 +4483,14 @@ AsOrToOpt:
     | TO
     {}
 
+ColumnPosOpt:
+    {}
+    | FIRST ColumnName
+    {}
+    | AFTER ColumnName
+    {}
+    ;
+
 AlterSpec:
     TableOptionList
     {
@@ -4493,7 +4501,7 @@ AlterSpec:
         }
         $$ = spec;
     }
-    | ADD ColumnKwdOpt ColumnDef
+    | ADD ColumnKwdOpt ColumnDef ColumnPosOpt
     {
         AlterTableSpec* spec = new_node(AlterTableSpec);
         spec->spec_type = ALTER_SPEC_ADD_COLUMN;

--- a/include/sqlparser/sql_parse.y
+++ b/include/sqlparser/sql_parse.y
@@ -1819,6 +1819,11 @@ FunctionCall:
         fun->children = $3->children;
         $$ = fun;
     }
+    | DATABASE '(' ')' {
+        FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "database";
+        $$ = fun;
+    }
     ;
 
 BuildInFun:
@@ -4183,6 +4188,13 @@ VarAssignItem:
         VarAssign* assign = new_node(VarAssign);
         assign->key = $1;
         assign->value = LiteralExpr::make_int("1", parser->arena);
+        $$ = assign;
+    }
+    | VarName EQ_OP DEFAULT
+    {
+        VarAssign* assign = new_node(VarAssign);
+        assign->key = "";
+        assign->value = LiteralExpr::make_string("", parser->arena);
         $$ = assign;
     }
     | VarName ASSIGN_OP Expr

--- a/include/sqlparser/sql_parse.y
+++ b/include/sqlparser/sql_parse.y
@@ -2080,6 +2080,114 @@ FunctionCallNonKeyword:
         fun->children.push_back($7, parser->arena);
         $$ = fun;
     }
+    | CONVERT '(' Expr ',' DATE ')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_date";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
+    | CAST '(' Expr AS DATE ')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_date";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
+    | CONVERT '(' Expr ',' DATETIME ')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_datetime";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
+    | CAST '(' Expr AS DATETIME ')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_datetime";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
+    | CONVERT '(' Expr ',' TIME ')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_time";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
+    | CAST '(' Expr AS TIME ')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_time";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
+    | CONVERT '(' Expr ',' CHAR ')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_string";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
+    | CAST '(' Expr AS CHAR ')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_string";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
+    | CONVERT '(' Expr ',' SIGNED INTEGER')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_signed";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
+    | CONVERT '(' Expr ',' SIGNED ')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_signed";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
+    | CAST '(' Expr AS SIGNED INTEGER')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_signed";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
+    | CAST '(' Expr AS SIGNED ')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_signed";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
+    | CONVERT '(' Expr ',' UNSIGNED INTEGER')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_unsigned";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
+    | CONVERT '(' Expr ',' UNSIGNED')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_unsigned";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
+    | CAST '(' Expr AS UNSIGNED INTEGER')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_unsigned";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
+    | CAST '(' Expr AS UNSIGNED ')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_unsigned";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
+    | CONVERT '(' Expr ',' BINARY ')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_string";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
+    | CAST '(' Expr AS BINARY ')' {
+	FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = "cast_to_string";
+        fun->children.push_back($3, parser->arena);
+        $$ = fun;
+    }
     | USER '(' ')' {
         FuncExpr* fun = new_node(FuncExpr);
         fun->fn_name = $1;

--- a/include/sqlparser/sql_parse.y
+++ b/include/sqlparser/sql_parse.y
@@ -260,6 +260,7 @@ extern int sql_error(YYLTYPE* yylloc, yyscan_t yyscanner, SqlParser* parser, con
     TRAILING
     YEAR_MONTH
     PRIMARY
+    CURRENT_TIMESTAMP
 
 %token<string>
     /* The following tokens belong to UnReservedKeyword. */
@@ -441,7 +442,6 @@ extern int sql_error(YYLTYPE* yylloc, yyscan_t yyscanner, SqlParser* parser, con
     MID
     MIN
     NOW
-    CURRENT_TIMESTAMP
     UTC_TIMESTAMP
     POSITION
     SESSION_USER
@@ -2023,6 +2023,11 @@ FunctionCallNonKeyword:
         fun->children.push_back($3, parser->arena);
         $$ = fun;
     }
+    | CURRENT_TIMESTAMP {
+        FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = $1;
+        $$ = fun; 
+    }
     | CURRENT_TIMESTAMP '(' ')' {
         FuncExpr* fun = new_node(FuncExpr);
         fun->fn_name = $1;
@@ -2037,6 +2042,12 @@ FunctionCallNonKeyword:
     | UTC_TIMESTAMP '(' ')' {
         FuncExpr* fun = new_node(FuncExpr);
         fun->fn_name = $1;
+        $$ = fun;
+    }
+    | TIMESTAMP '(' ExprList ')' {
+        FuncExpr* fun = new_node(FuncExpr);
+        fun->fn_name = $1;
+        fun->children = $3->children;
         $$ = fun;
     }
     | FunctionNameDateArithMultiForms '(' Expr ',' Expr ')' {

--- a/include/sqlparser/sql_parse.y
+++ b/include/sqlparser/sql_parse.y
@@ -100,7 +100,6 @@ extern int sql_error(YYLTYPE* yylloc, yyscan_t yyscanner, SqlParser* parser, con
     CONVERT
     CREATE
     CROSS
-    CURRENT_TIMESTAMP
     CURRENT_USER
     DATABASE
     DATABASES
@@ -260,7 +259,6 @@ extern int sql_error(YYLTYPE* yylloc, yyscan_t yyscanner, SqlParser* parser, con
     TRAILING
     YEAR_MONTH
     PRIMARY
-    CURRENT_TIMESTAMP
 
 %token<string>
     /* The following tokens belong to UnReservedKeyword. */
@@ -434,6 +432,7 @@ extern int sql_error(YYLTYPE* yylloc, yyscan_t yyscanner, SqlParser* parser, con
     COUNT
     CURDATE
     CURTIME
+    CURRENT_TIMESTAMP
     DATE_ADD
     DATE_SUB
     EXTRACT
@@ -478,6 +477,7 @@ extern int sql_error(YYLTYPE* yylloc, yyscan_t yyscanner, SqlParser* parser, con
     OptCollate
     DBName
     FunctionNameCurtime
+    FunctionNameCurTimestamp
     FunctionaNameCurdate
     FunctionaNameDateRelate
     FunctionNameDateArithMultiForms
@@ -3077,7 +3077,7 @@ ColumnOption:
         option->expr = $2;
         $$ = option;
     }
-    | ON UPDATE CURRENT_TIMESTAMP
+    | ON UPDATE FunctionCallCurTimestamp
     {
         FuncExpr* current_timestamp = new_node(FuncExpr);
         current_timestamp->func_type = FT_COMMON;
@@ -3095,7 +3095,7 @@ ColumnOption:
         $$ = option;
     }
     ;
-
+    
 SignedLiteral:
     Literal {}
     | '+' NumLiteral {
@@ -3114,7 +3114,7 @@ SignedLiteral:
     ;
 
 DefaultValue:
-    CURRENT_TIMESTAMP
+    FunctionCallCurTimestamp
     {
         FuncExpr* current_timestamp = new_node(FuncExpr);
         current_timestamp->func_type = FT_COMMON;
@@ -3125,6 +3125,14 @@ DefaultValue:
     {
         $$ = $1;
     }
+
+FunctionCallCurTimestamp:
+    FunctionNameCurTimestamp
+    | FunctionNameCurTimestamp '(' ')'
+    ;
+FunctionNameCurTimestamp:
+    CURRENT_TIMESTAMP | NOW
+    ;
 
 PrimaryOpt:
     {}

--- a/proto/meta.interface.proto
+++ b/proto/meta.interface.proto
@@ -131,6 +131,7 @@ message SchemaInfo {
     optional FieldInfo link_field           = 42;
     optional int32 region_num               = 43;
     optional string comment                 = 44;
+    optional bool  if_exist                 = 45;
 };
 
 message PartitionRegion {

--- a/proto/meta.interface.proto
+++ b/proto/meta.interface.proto
@@ -152,6 +152,7 @@ message FieldInfo {
     optional bytes on_update_value    = 10;
     optional bytes encrypt            = 11; //指定加密字段
     optional uint32 flag              = 12;
+    optional uint32 timestamp         = 13; //字段创建时间
 };
 
 enum IndexType {

--- a/proto/meta.interface.proto
+++ b/proto/meta.interface.proto
@@ -125,11 +125,12 @@ message SchemaInfo {
     repeated SplitKey split_keys            = 36;
     optional SchemaConf schema_conf         = 37; //一些可以随意修改的配置放在这里
     optional int64 ttl_duration             = 38; //0表示无ttl，>0表示有ttl，建表时指定
-    optional BinlogInfo    binlog_info = 39;
-    optional PartitionInfo partition_info = 40;
-    optional bool is_binlog = 41;
-    optional FieldInfo link_field = 42;
-    optional int32 region_num = 43;
+    optional BinlogInfo    binlog_info      = 39;
+    optional PartitionInfo partition_info   = 40;
+    optional bool is_binlog                 = 41;
+    optional FieldInfo link_field           = 42;
+    optional int32 region_num               = 43;
+    optional string comment                 = 44;
 };
 
 message PartitionRegion {

--- a/proto/optype.proto
+++ b/proto/optype.proto
@@ -120,4 +120,5 @@ enum OpType {
     OP_RESTART_DDL_WORK                     = 184; 
     OP_REMOVE_GLOBAL_INDEX_DATA             = 185;
     OP_UPDATE_MAIN_LOGICAL_ROOM             = 186;
+    OP_UPDATE_TABLE_COMMENT                 = 187; //修改表的comment
 };

--- a/proto/plan.proto
+++ b/proto/plan.proto
@@ -122,6 +122,7 @@ message ScanNode {
     repeated int64 ignore_indexes = 6;
     optional FulltextIndex fulltext_index = 7;
     optional LockCmdType lock = 8;
+    repeated int64 force_indexes = 9;
 };
 
 message LimitNode {

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -439,7 +439,8 @@ int primitive_to_proto_type(pb::PrimitiveType type) {
         { pb::HLL,          FieldDescriptorProto::TYPE_BYTES},
         { pb::BOOL,         FieldDescriptorProto::TYPE_BOOL},
         { pb::BITMAP,       FieldDescriptorProto::TYPE_BYTES},
-        { pb::TDIGEST,       FieldDescriptorProto::TYPE_BYTES}
+        { pb::TDIGEST,      FieldDescriptorProto::TYPE_BYTES},
+        { pb::NULL_TYPE,    FieldDescriptorProto::TYPE_BOOL}
     };
     if (_mysql_pb_type_mapping.count(type) == 0) {
         DB_WARNING("mysql_type %d not supported.", type);

--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -419,4 +419,54 @@ int32_t seconds_to_time(int32_t seconds) {
     }
     return time;
 }
+
+bool tz_to_second(const char* time_zone, int32_t& result) {
+    if (strcmp(time_zone, "SYSTEM") == 0) {
+        result = 0;
+        time_t time_utc;
+        struct tm tm_local;
+        time(&time_utc);
+ 
+        localtime_r(&time_utc, &tm_local);
+ 
+        time_t time_local;
+        struct tm tm_gmt;
+ 
+        time_local = mktime(&tm_local);
+ 
+        gmtime_r(&time_utc, &tm_gmt);
+        int hour = tm_local.tm_hour - tm_gmt.tm_hour;
+        if (hour < -12) {
+            hour += 24; 
+        } else if (hour > 12) {
+            hour -= 24;
+        }
+        result = hour * 3600;
+        return true;
+    }
+    int minu = 1;
+    if (strlen(time_zone) != 6) {
+        return false;
+    }
+    char minu_char = time_zone[0];
+    if (minu_char == '-' ){
+        minu = -1;
+    } else if (minu_char != '+') {
+        return false;
+    }
+    if (time_zone[3] != ':') {
+        return false;
+    }
+    if (!isdigit(time_zone[1]) || !isdigit(time_zone[2]) || !isdigit(time_zone[4]) || !isdigit(time_zone[5])) {
+        return false;
+    }
+    int hour = 10 * (time_zone[1] - '0') + time_zone[2] - '0';
+    int min = 10 * (time_zone[4] - '0') + time_zone[5] - '0';
+    if (hour > 12 || min > 59) {
+        return false;
+    }
+    result =  (hour * 3600 + min * 60 ) * minu;
+    return true;
+}
+
 }  // baikaldb

--- a/src/common/information_schema.cpp
+++ b/src/common/information_schema.cpp
@@ -428,8 +428,7 @@ void InformationSchema::init_referential_constraints() {
         {"UPDATE_RULE", pb::STRING},
         {"DELETE_RULE", pb::STRING},
         {"TABLE_NAME", pb::STRING},
-        {"REFERENCED_TABLE_NAME", pb::STRING},
-        {"REFERENCED_COLUMN_NAME", pb::STRING}
+        {"REFERENCED_TABLE_NAME", pb::STRING}
     };
     int64_t table_id = construct_table("REFERENTIAL_CONSTRAINTS", fields);
     // 定义操作

--- a/src/common/information_schema.cpp
+++ b/src/common/information_schema.cpp
@@ -30,6 +30,8 @@ int InformationSchema::init() {
     init_schemata();
     init_tables();
     init_routines();
+    init_key_column_usage();
+    init_referential_constraints();
     return 0;
 }
 
@@ -412,6 +414,95 @@ void InformationSchema::init_columns() {
             return records;
     };
 }
+
+void InformationSchema::init_referential_constraints() {
+    // 定义字段信息
+    FieldVec fields {
+        {"CONSTRAINT_CATALOG", pb::STRING},
+        {"CONSTRAINT_SCHEMA", pb::STRING},
+        {"CONSTRAINT_NAME", pb::STRING},
+        {"UNIQUE_CONSTRAINT_CATALOG", pb::STRING},
+        {"UNIQUE_CONSTRAINT_SCHEMA", pb::STRING},
+        {"UNIQUE_CONSTRAINT_NAME", pb::STRING},
+        {"MATCH_OPTION", pb::STRING},
+        {"UPDATE_RULE", pb::STRING},
+        {"DELETE_RULE", pb::STRING},
+        {"TABLE_NAME", pb::STRING},
+        {"REFERENCED_TABLE_NAME", pb::STRING},
+        {"REFERENCED_COLUMN_NAME", pb::STRING}
+    };
+    int64_t table_id = construct_table("REFERENTIAL_CONSTRAINTS", fields);
+    // 定义操作
+    _calls[table_id] = [table_id](RuntimeState* state, std::vector<ExprNode*>& conditions) -> 
+        std::vector<SmartRecord> {
+            std::vector<SmartRecord> records;
+            return records;
+    };
+}
+
+void InformationSchema::init_key_column_usage() {
+    // 定义字段信息
+    FieldVec fields {
+        {"CONSTRAINT_CATALOG", pb::STRING},
+        {"CONSTRAINT_SCHEMA", pb::STRING},
+        {"CONSTRAINT_NAME", pb::STRING},
+        {"TABLE_CATALOG", pb::STRING},
+        {"TABLE_SCHEMA", pb::STRING},
+        {"TABLE_NAME", pb::STRING},
+        {"COLUMN_NAME", pb::STRING},
+        {"ORDINAL_POSITION", pb::INT64},
+        {"POSITION_IN_UNIQUE_CONSTRAINT", pb::INT64},
+        {"REFERENCED_TABLE_SCHEMA", pb::STRING},
+        {"REFERENCED_TABLE_NAME", pb::STRING},
+        {"REFERENCED_COLUMN_NAME", pb::STRING}
+    };
+    int64_t table_id = construct_table("KEY_COLUMN_USAGE", fields);
+    // 定义操作
+    _calls[table_id] = [table_id](RuntimeState* state, std::vector<ExprNode*>& conditions) -> 
+        std::vector<SmartRecord> {
+            std::vector<SmartRecord> records;
+            if (state->client_conn() == nullptr) {
+                return records;
+            }
+            std::string namespace_ = state->client_conn()->user_info->namespace_;
+            std::string table_name;
+            auto* factory = SchemaFactory::get_instance();
+            auto tb_vec = factory->get_table_list(namespace_, state->client_conn()->user_info.get());
+            records.reserve(tb_vec.size() * 10);
+            for (auto& table_info : tb_vec) {
+                int i = 0;
+                std::vector<std::string> items;
+                boost::split(items, table_info->name, boost::is_any_of("."));
+                std::string db = items[0];
+
+                std::multimap<int32_t, IndexInfo> field_index;
+                for (auto& index_id : table_info->indices) {
+                    IndexInfo index_info = factory->get_index_info(index_id);
+                    auto index_type = index_info.type;
+                    if (index_type != pb::I_PRIMARY && index_type != pb::I_UNIQ) {
+                        continue;
+                    }
+                    int idx = 0;
+                    for (auto& field : index_info.fields) {
+                        idx ++;
+                        auto record = factory->new_record(table_id);
+                        record->set_string(record->get_field_by_name("CONSTRAINT_CATALOG"), "def");
+                        record->set_string(record->get_field_by_name("CONSTRAINT_SCHEMA"), db);
+                        record->set_string(record->get_field_by_name("CONSTRAINT_NAME"), index_type == pb::I_PRIMARY ? "PRIMARY":"name_key");
+                        record->set_string(record->get_field_by_name("TABLE_CATALOG"), "def");
+                        record->set_string(record->get_field_by_name("TABLE_SCHEMA"), db);
+                        record->set_string(record->get_field_by_name("TABLE_NAME"), table_info->short_name);
+                        record->set_string(record->get_field_by_name("COLUMN_NAME"), field.short_name);
+                        record->set_int64(record->get_field_by_name("ORDINAL_POSITION"), idx);
+                        records.emplace_back(record);
+
+                    }
+                }
+            }
+            return records;
+    };
+}
+
 void InformationSchema::init_statistics() {
     // 定义字段信息
     FieldVec fields {

--- a/src/common/information_schema.cpp
+++ b/src/common/information_schema.cpp
@@ -29,6 +29,7 @@ int InformationSchema::init() {
     init_statistics();
     init_schemata();
     init_tables();
+    init_routines();
     return 0;
 }
 
@@ -594,6 +595,49 @@ void InformationSchema::init_tables() {
                 record->set_int64(record->get_field_by_name("TABLE_ID"), table_info->id);
                 records.emplace_back(record);
             }
+            return records;
+    };
+}
+void InformationSchema::init_routines() {
+    // 定义字段信息
+    FieldVec fields {
+        {"SPECIFIC_NAME", pb::STRING},
+        {"ROUTINE_CATALOG", pb::STRING},
+        {"ROUTINE_SCHEMA", pb::STRING},
+        {"ROUTINE_NAME", pb::STRING},
+        {"ROUTINE_TYPE", pb::STRING},
+        {"DATA_TYPE", pb::STRING},
+        {"CHARACTER_MAXIMUM_LENGTH", pb::INT64},
+        {"CHARACTER_OCTET_LENGTH", pb::INT64},
+        {"NUMERIC_PRECISION", pb::UINT64},
+        {"NUMERIC_SCALE", pb::INT64},
+        {"DATETIME_PRECISION", pb::UINT64},
+        {"CHARACTER_SET_NAME", pb::STRING},
+        {"COLLATION_NAME", pb::STRING},
+        {"DTD_IDENTIFIER", pb::STRING},
+        {"ROUTINE_BODY", pb::STRING},
+        {"ROUTINE_DEFINITION" , pb::STRING},
+        {"EXTERNAL_NAME" , pb::STRING},
+        {"EXTERNAL_LANGUAGE" , pb::STRING},
+        {"PARAMETER_STYLE", pb::STRING},
+        {"IS_DETERMINISTIC", pb::STRING},
+        {"SQL_DATA_ACCESS", pb::STRING},
+        {"SQL_PATH", pb::STRING},
+        {"SECURITY_TYPE", pb::STRING},
+        {"CREATED",  pb::STRING},
+        {"LAST_ALTERED",  pb::DATETIME},
+        {"SQL_MODE", pb::DATETIME},
+        {"ROUTINE_COMMENT", pb::STRING},
+        {"DEFINER", pb::STRING},
+        {"CHARACTER_SET_CLIENT", pb::STRING},
+        {"COLLATION_CONNECTION", pb::STRING},
+        {"DATABASE_COLLATION", pb::STRING},
+    };
+    int64_t table_id = construct_table("ROUTINES", fields);
+    // 定义操作
+    _calls[table_id] = [table_id](RuntimeState* state, std::vector<ExprNode*>& conditions) ->
+        std::vector<SmartRecord> {
+            std::vector<SmartRecord> records;
             return records;
     };
 }

--- a/src/common/schema_factory.cpp
+++ b/src/common/schema_factory.cpp
@@ -2407,7 +2407,7 @@ int SchemaFactory::fill_default_value(SmartRecord record, FieldInfo& field) {
         return 0;
     }
     ExprValue default_value = field.default_expr_value;
-    if (field.default_value == "(current_timestamp())") {
+    if (field.default_value == "current_timestamp()") {
         default_value = ExprValue::Now();
         default_value.cast_to(field.type);
     }

--- a/src/common/schema_factory.cpp
+++ b/src/common/schema_factory.cpp
@@ -356,6 +356,9 @@ int SchemaFactory::update_table_internal(SchemaMapping& background, const pb::Sc
     tbl_info.tbl_proto->set_name(table_name);
     tbl_info.namespace_ = _namespace;
     tbl_info.resource_tag = table.resource_tag();
+    if (table.has_comment()) {
+        tbl_info.comment = table.comment();
+    }
     tbl_info.main_logical_room = table.main_logical_room();
     tbl_info.charset = table.charset();
     tbl_info.engine = pb::ROCKSDB;

--- a/src/common/tuple_record.cpp
+++ b/src/common/tuple_record.cpp
@@ -62,8 +62,10 @@ int TupleRecord::decode_fields(const std::map<int32_t, FieldInfo*>& fields,
             auto field = get_field(iter->second, field_slot, record, tuple_id, mem_row);
             //add default value
             ExprValue default_value = iter->second->default_expr_value;
-            if (iter->second->default_value == "current_timestamp()") {
-                default_value = ExprValue::Now();
+            if (iter->second->default_value == "current_timestamp()" ||
+                iter->second->default_value == "(current_timestamp())") {
+                default_value = ExprValue(pb::TIMESTAMP);
+                default_value._u.uint32_val = iter->second->timestamp;
                 default_value.cast_to(iter->second->type);
             }
             MessageHelper::set_value(field, message, default_value);
@@ -224,8 +226,10 @@ int TupleRecord::decode_fields(const std::map<int32_t, FieldInfo*>& fields,
         auto field = get_field(iter->second, field_slot, record, tuple_id, mem_row);
         //add default value
         ExprValue default_value = iter->second->default_expr_value;
-        if (iter->second->default_value == "current_timestamp()") {
-            default_value = ExprValue::Now();
+        if (iter->second->default_value == "current_timestamp()" ||
+            iter->second->default_value == "(current_timestamp())") {
+            default_value = ExprValue(pb::TIMESTAMP);
+            default_value._u.uint32_val = iter->second->timestamp;
             default_value.cast_to(iter->second->type);
         }
         MessageHelper::set_value(field, message, default_value);

--- a/src/common/tuple_record.cpp
+++ b/src/common/tuple_record.cpp
@@ -62,7 +62,7 @@ int TupleRecord::decode_fields(const std::map<int32_t, FieldInfo*>& fields,
             auto field = get_field(iter->second, field_slot, record, tuple_id, mem_row);
             //add default value
             ExprValue default_value = iter->second->default_expr_value;
-            if (iter->second->default_value == "(current_timestamp())") {
+            if (iter->second->default_value == "current_timestamp()") {
                 default_value = ExprValue::Now();
                 default_value.cast_to(iter->second->type);
             }
@@ -224,7 +224,7 @@ int TupleRecord::decode_fields(const std::map<int32_t, FieldInfo*>& fields,
         auto field = get_field(iter->second, field_slot, record, tuple_id, mem_row);
         //add default value
         ExprValue default_value = iter->second->default_expr_value;
-        if (iter->second->default_value == "(current_timestamp())") {
+        if (iter->second->default_value == "current_timestamp()") {
             default_value = ExprValue::Now();
             default_value.cast_to(iter->second->type);
         }

--- a/src/exec/apply_node.cpp
+++ b/src/exec/apply_node.cpp
@@ -22,6 +22,7 @@
 #include "logical_planner.h"
 #include "agg_node.h"
 #include "literal.h"
+#include "math.h"
 
 namespace baikaldb {
 int ApplyNode::init(const pb::PlanNode& node) {
@@ -244,6 +245,11 @@ int ApplyNode::open(RuntimeState* state) {
     }
     DB_WARNING("_use_hash_map:%d _max_one_row:%d _conditions_has_agg:%d", _use_hash_map, _max_one_row, _conditions_has_agg);
     if (_use_hash_map && !_max_one_row && !_conditions_has_agg) {
+        // inner_node会被多次调用
+        if (_parent->get_limit() > 0 && _join_type != pb::LEFT_JOIN && _join_type != pb::ANTI_SEMI_JOIN) {
+            _use_loop_hash_map = true;
+            return loop_hash_apply(state);
+        }
         return hash_apply(state);
     } else {
         _use_hash_map = false;
@@ -277,7 +283,7 @@ int ApplyNode::nested_loop_apply(RuntimeState* state) {
         _inner_node->create_trace();
         ret = _inner_node->open(state);
         if (ret < 0) {
-            DB_WARNING("ExecNode::inner table open fial");
+            DB_WARNING("ExecNode::inner table open fail");
             return -1;
         }
         return 0;
@@ -335,7 +341,7 @@ int ApplyNode::hash_apply(RuntimeState* state) {
     _inner_node->create_trace();
     ret = _inner_node->open(state);
     if (ret < 0) {
-        DB_WARNING("ExecNode::inner table open fial");
+        DB_WARNING("ExecNode::inner table open fail");
         return -1;
     }
     if (_join_type == pb::LEFT_JOIN || _join_type == pb::ANTI_SEMI_JOIN) {
@@ -352,10 +358,58 @@ int ApplyNode::hash_apply(RuntimeState* state) {
     return 0;
 }
 
+int ApplyNode::loop_hash_apply(RuntimeState* state) {
+    int ret = _outer_node->open(state);
+    if (ret < 0) {
+        DB_WARNING("ExecNode:: left table open fail");
+        return ret;
+    }
+    ret = fetcher_full_table_data(state, _outer_node, _outer_tuple_data);
+    if (ret < 0) {
+        DB_WARNING("ExecNode::join open fail when fetch left table");
+        return ret;
+    }
+    DB_WARNING("data size:%ld", _outer_tuple_data.size());
+    _outer_iter = _outer_tuple_data.begin();
+
+    std::vector<MemRow*> outer_tuple_data;
+    while (_outer_iter != _outer_tuple_data.end() && outer_tuple_data.size() < get_loop_num()) {
+        outer_tuple_data.emplace_back(*_outer_iter);
+        _outer_iter++;
+    }
+    if (outer_tuple_data.size() == 0) {
+        DB_WARNING("no data");
+        _outer_table_is_null = true;
+        return 0;
+    }
+    _hash_map.clear();
+    construct_hash_map(outer_tuple_data, _outer_equal_slot);
+
+    if (_is_explain) {
+        _inner_node->create_trace();
+        ret = _inner_node->open(state);
+        if (ret < 0) {
+            DB_WARNING("ExecNode::inner table open fail");
+            return -1;
+        }
+        return 0;
+    }
+    _loops = 0;
+    _inner_node->get_node(pb::SCAN_NODE, _scan_nodes);
+    ret = fetcher_inner_table_data(state, outer_tuple_data, _scan_nodes, _inner_tuple_data);
+    if (ret < 0) {
+        return -1;
+    }
+    _inner_iter = _inner_tuple_data.begin();
+    return 0;
+}
 int ApplyNode::get_next(RuntimeState* state, RowBatch* batch, bool* eos) {
     if (_outer_table_is_null) {
         *eos = true;
         return 0;
+    }
+    if (_use_loop_hash_map) {
+        return get_next_via_loop_outer_hash_map(state, batch, eos);
     }
     if (_use_hash_map) {
         if (_join_type == pb::LEFT_JOIN || _join_type == pb::ANTI_SEMI_JOIN) {
@@ -403,7 +457,7 @@ int ApplyNode::fetcher_inner_table_data(RuntimeState* state,
     _inner_node->create_trace();
     ret = _inner_node->open(state);
     if (ret < 0) {
-        DB_WARNING("ExecNode::inner table open fial");
+        DB_WARNING("ExecNode::inner table open fail");
         return -1;
     }
     ret = fetcher_full_table_data(state, _inner_node, inner_tuple_data);
@@ -420,6 +474,54 @@ int ApplyNode::fetcher_inner_table_data(RuntimeState* state,
     
     _inner_node->remove_additional_predicate(in_exprs_back);
     _inner_node->close(state);
+    return 0;
+}
+
+int ApplyNode::fetcher_inner_table_data(RuntimeState* state,
+                                        const std::vector<MemRow*>& outer_tuple_data,
+                                        std::vector<ExecNode*>& scan_nodes,
+                                        std::vector<MemRow*>& inner_tuple_data) {
+    TimeCost time_cost;
+    _outer_join_values.clear();
+    construct_equal_values(outer_tuple_data, _outer_equal_slot);
+    std::vector<ExprNode*> in_exprs;
+    int ret = construct_in_condition(_inner_equal_slot, _outer_join_values, in_exprs);
+    if (ret < 0) {
+        DB_WARNING("ExecNode::create in condition for right table fail");
+        return ret;
+    }
+    std::vector<ExprNode*> in_exprs_back = in_exprs;
+    //表达式下推，下推的那个节点重新做索引选择，路由选择
+    _inner_node->predicate_pushdown(in_exprs);
+    if (in_exprs.size() > 0) {
+        DB_WARNING("inner node add filter node");
+        _inner_node->add_filter_node(in_exprs);
+    }
+    do_plan_router(state, scan_nodes);
+    _inner_node->create_trace();
+    ret = _inner_node->open(state);
+    if (ret < 0) {
+        DB_WARNING("ExecNode::inner table open fail");
+        return -1;
+    }
+    ret = fetcher_full_table_data(state, _inner_node, inner_tuple_data);
+    if (ret < 0) {
+        DB_WARNING("fetcher inner node fail");
+        return ret;
+    }
+    if (_max_one_row && inner_tuple_data.size() > 1) {
+        state->error_code = ER_SUBQUERY_NO_1_ROW;
+        state->error_msg << "Subquery returns more than 1 row";
+        DB_WARNING("Subquery returns more than 1 row");
+        return -1;
+    }
+
+    _inner_node->remove_additional_predicate(in_exprs_back);
+    _inner_node->close(state);
+
+    _loops++;
+    DB_WARNING("fetcher_inner_table_data, loops:%d, outer:%ld, inner:%ld, time_cost:%ld",
+               _loops,  outer_tuple_data.size(), inner_tuple_data.size(), time_cost.get_time());
     return 0;
 }
 
@@ -620,6 +722,79 @@ int ApplyNode::get_next_via_outer_hash_map(RuntimeState* state, RowBatch* batch,
     return 0;
 }
 
+int ApplyNode::get_next_via_loop_outer_hash_map(RuntimeState* state, RowBatch* batch, bool* eos) {
+    if (_inner_iter == _inner_tuple_data.end()) {
+        // clear previous inner
+        for (auto& mem_row : _inner_tuple_data) {
+            delete mem_row;
+        }
+        _inner_tuple_data.clear();
+
+        // construct outer
+        if (_outer_iter == _outer_tuple_data.end()) {
+            DB_WARNING("when join, outer iter is end, loops:%d", _loops);
+            *eos = true;
+            return 0;
+        }
+        std::vector<MemRow*> outer_tuple_data;
+        while (_outer_iter != _outer_tuple_data.end() && outer_tuple_data.size() < get_loop_num()) {
+            outer_tuple_data.emplace_back(*_outer_iter);
+            _outer_iter++;
+        }
+        _hash_map.clear();
+        construct_hash_map(outer_tuple_data, _outer_equal_slot);
+
+        // fetcher inner
+        int ret = fetcher_inner_table_data(state, outer_tuple_data, _scan_nodes, _inner_tuple_data);
+        if (ret < 0) {
+            return -1;
+        }
+        _inner_iter = _inner_tuple_data.begin();
+    }
+
+    while (_inner_iter != _inner_tuple_data.end()) {
+        MemRow* inner_mem_row = *_inner_iter;
+        MutTableKey inner_key;
+        encode_hash_key(inner_mem_row, _inner_equal_slot, inner_key);
+        auto outer_mem_rows = _hash_map.seek(inner_key.data());
+        if (outer_mem_rows != NULL) {
+            for (; _result_row_index < outer_mem_rows->size(); ++_result_row_index) {
+                if (reached_limit()) {
+                    *eos = true;
+                    return 0;
+                }
+                if (batch->is_full()) {
+                    return 0;
+                }
+                bool matched = false;
+                int ret = construct_result_batch(batch, (*outer_mem_rows)[_result_row_index], inner_mem_row, matched);
+                if (ret < 0) {
+                    DB_WARNING("construct result batch fail");
+                    return ret;
+                }
+                _has_matched |= matched;
+                _all_matched &= matched;
+                ++_num_rows_returned;
+            }
+            if (_has_matched && _join_type == pb::SEMI_JOIN) {
+                if (_compare_type == pb::CMP_ALL && _all_matched) {
+                    int ret = construct_null_result_batch(batch, (*outer_mem_rows)[_result_row_index]);
+                    if (ret < 0) {
+                        DB_WARNING("construct result batch fail");
+                        return ret;
+                    }
+                }
+                _hash_map.erase(inner_key.data());
+            }
+        }
+        _result_row_index = 0;
+        _has_matched = false;
+        _all_matched = true;
+        _inner_iter++;
+    }
+
+    return 0;
+}
 }//namespace
 
 /* vim: set expandtab ts=4 sw=4 sts=4 tw=100: */

--- a/src/exec/dml_node.cpp
+++ b/src/exec/dml_node.cpp
@@ -18,6 +18,8 @@
 namespace baikaldb {
 
 DEFINE_bool(replace_no_get, false, "no get before replace if true");
+DEFINE_bool(strict_mode_not_null_fields_check, false,
+            "return failed when not null field's value is null if true");
 
 int DMLNode::expr_optimize(QueryContext* ctx) {
     int ret = 0;
@@ -177,10 +179,12 @@ int DMLNode::insert_row(RuntimeState* state, SmartRecord record, bool is_update)
                  return -1;
             }
             std::string& field_name = field_info->lower_short_name;
-            DB_WARNING_STATE(state, "filed_id:%s can not null", field_name.c_str());
-            state->error_code = ER_NO_DEFAULT_FOR_FIELD;
-            state->error_msg << "Field '" << field_name << "' doesn't have a default value";
-            return -1;
+            DB_WARNING_STATE(state, "filed_name: %s can not null", field_name.c_str());
+            if (FLAGS_strict_mode_not_null_fields_check) {
+                state->error_code = ER_NO_DEFAULT_FOR_FIELD;
+                state->error_msg << "Field '" << field_name << "' doesn't have a default value";
+                return -1;
+            }
         }
     }
     // update更新部分索引，会在update_row里指定索引

--- a/src/exec/fetcher_store.cpp
+++ b/src/exec/fetcher_store.cpp
@@ -22,6 +22,11 @@
 #include "binlog_context.h"
 #include "dml_node.h"
 #include "trace_state.h"
+#ifdef BAIDU_INTERNAL
+#include "baidu/rpc/reloadable_flags.h"
+#else
+#include "brpc/reloadable_flags.h"
+#endif
 
 namespace baikaldb {
 
@@ -29,6 +34,11 @@ DEFINE_int64(retry_interval_us, 500 * 1000, "retry interval ");
 DEFINE_int32(single_store_concurrency, 20, "max request for one store");
 DEFINE_int64(max_select_rows, 10000000, "query will be fail when select too much rows");
 DEFINE_int64(print_time_us, 10000, "print log when time_cost > print_time_us(us)");
+#ifdef BAIDU_INTERNAL
+BAIDU_RPC_VALIDATE_GFLAG(print_time_us, brpc::NonNegativeInteger);
+#else
+BRPC_VALIDATE_GFLAG(print_time_us, brpc::NonNegativeInteger);
+#endif
 DEFINE_int32(fetcher_request_timeout, 100000,
                     "store as server request timeout, default:10000ms");
 DEFINE_int32(fetcher_connect_timeout, 1000,

--- a/src/exec/filter_node.cpp
+++ b/src/exec/filter_node.cpp
@@ -596,11 +596,6 @@ int FilterNode::get_next(RuntimeState* state, RowBatch* batch, bool* eos) {
                 continue;
             }
         }
-        if (reached_limit()) {
-            DB_WARNING_STATE(state, "reach limit size:%lu", batch->size());
-            *eos = true;
-            return 0;
-        }
         std::unique_ptr<MemRow>& row = _child_row_batch.get_row();
         if (_is_explain || need_copy(row.get())) {
             batch->move_row(std::move(row));
@@ -609,6 +604,11 @@ int FilterNode::get_next(RuntimeState* state, RowBatch* batch, bool* eos) {
             state->inc_num_filter_rows();
             ++where_filter_cnt;
             memory_limit_release(state, row.get());
+        }
+        if (reached_limit()) {
+            DB_WARNING_STATE(state, "reach limit size:%lu", batch->size());
+            *eos = true;
+            return 0;
         }
         _child_row_batch.next();
     }

--- a/src/exec/joiner.cpp
+++ b/src/exec/joiner.cpp
@@ -145,6 +145,9 @@ void Joiner::do_plan_router(RuntimeState* state, std::vector<ExecNode*>& scan_no
     //重新做路由选择
     for (auto& exec_node : scan_nodes) {
         RocksdbScanNode* scan_node = static_cast<RocksdbScanNode*>(exec_node);
+        if (scan_node->engine() == pb::INFORMATION_SCHEMA) {
+            continue;
+        }
         ExecNode* parent_node_ptr = scan_node->get_parent();
         FilterNode* filter_node = nullptr;
         if (parent_node_ptr->node_type() == pb::WHERE_FILTER_NODE

--- a/src/exec/load_node.cpp
+++ b/src/exec/load_node.cpp
@@ -304,7 +304,7 @@ int LoadNode::fill_field_value(SmartRecord record, FieldInfo& field, ExprValue& 
         return 0;
     }
     ExprValue default_value = field.default_expr_value;
-    if (field.default_value == "(current_timestamp())") {
+    if (field.default_value == "current_timestamp()") {
         default_value = ExprValue::Now();
         default_value.cast_to(field.type);
     }

--- a/src/exec/load_node.cpp
+++ b/src/exec/load_node.cpp
@@ -304,7 +304,8 @@ int LoadNode::fill_field_value(SmartRecord record, FieldInfo& field, ExprValue& 
         return 0;
     }
     ExprValue default_value = field.default_expr_value;
-    if (field.default_value == "current_timestamp()") {
+    if (field.default_value == "current_timestamp()" ||
+        field.default_value == "(current_timestamp())") {
         default_value = ExprValue::Now();
         default_value.cast_to(field.type);
     }

--- a/src/exec/scan_node.cpp
+++ b/src/exec/scan_node.cpp
@@ -92,8 +92,8 @@ int64_t ScanNode::select_index() {
 
         // 使用了force index, 则primary优先级最低
         if (_has_force_index && path->hint != AccessPath::FORCE_INDEX) {
-	    prefix_ratio_index_score = 0;
-	}
+            prefix_ratio_index_score = 0;
+        }
         prefix_ratio_id_mapping.insert(std::make_pair(prefix_ratio_index_score, index_id));
 
         // 优先选倒排，没有就取第一个
@@ -375,11 +375,10 @@ int64_t ScanNode::select_unique_index() {
     //判断是否有强制索引
     _has_force_index = false;
     for (auto index_iter = _paths.begin(); index_iter != _paths.end(); index_iter ++ ) {
-	if (index_iter->second->hint == AccessPath::FORCE_INDEX) {
-	    _has_force_index = true;
-	}
+        if (index_iter->second->hint == AccessPath::FORCE_INDEX) {
+            _has_force_index = true;
+        }
     }
-    return 0;
     int64_t ret_index_id = 0;
     for (auto index_iter = _paths.begin(); index_iter != _paths.end(); index_iter ++ ) {
         if (!index_iter->second->is_possible) {
@@ -391,8 +390,8 @@ int64_t ScanNode::select_unique_index() {
                 == index_iter->second->hit_index_field_ids.size() && ret_index_id == 0) {
                 // 主键或唯一键全命中，直接选择
                 if (_has_force_index && index_iter->second->hint != AccessPath::FORCE_INDEX) {
-		    continue;
-		}
+                    continue;
+                }
                 if (index_iter->second->is_virtual) {
                     //虚拟索引命中。
                     if (_virtual_index_selected == 0) {

--- a/src/exec/scan_node.cpp
+++ b/src/exec/scan_node.cpp
@@ -263,6 +263,9 @@ int64_t ScanNode::select_index_by_cost() {
         } else if (!path->is_possible) {
             continue;
         }
+        if (_has_force_index && path->hint != AccessPath::FORCE_INDEX) {
+            continue;
+        }
         
         int64_t index_id = pair.first;
         path->calc_cost(nullptr, _filed_selectiy);

--- a/src/exec/scan_node.cpp
+++ b/src/exec/scan_node.cpp
@@ -379,6 +379,7 @@ int64_t ScanNode::select_unique_index() {
 	    _has_force_index = true;
 	}
     }
+    return 0;
     int64_t ret_index_id = 0;
     for (auto index_iter = _paths.begin(); index_iter != _paths.end(); index_iter ++ ) {
         if (!index_iter->second->is_possible) {

--- a/src/exec/select_manager_node.cpp
+++ b/src/exec/select_manager_node.cpp
@@ -16,6 +16,8 @@
 #include "filter_node.h"
 #include "network_socket.h"
 #include "rocksdb_scan_node.h"
+#include "limit_node.h"
+#include "agg_node.h"
 
 namespace baikaldb {
 int SelectManagerNode::open(RuntimeState* state) {
@@ -159,6 +161,40 @@ int SelectManagerNode::open_global_index(RuntimeState* state, ExecNode* exec_nod
     auto client_conn = state->client_conn();
     //二级索引只执行scan_node，因为索引条件已经被下推到scan_node了
     ExecNode* store_exec = scan_node;
+    bool need_pushdown = true;
+    AggNode* agg_node = static_cast<AggNode*>(get_node(pb::AGG_NODE));;
+    SortNode* sort_node = static_cast<SortNode*>(get_node(pb::SORT_NODE));
+    FilterNode* filter_node = static_cast<FilterNode*>(get_node(pb::WHERE_FILTER_NODE));
+    if (need_pushdown && _limit < 0) {
+        need_pushdown = false;
+    }
+    if (need_pushdown && agg_node != nullptr) {
+        need_pushdown = false;
+    }
+    if (need_pushdown && filter_node != nullptr &&
+            filter_node->pruned_conjuncts().size() > 0) {
+        need_pushdown = false;
+    }
+    if (need_pushdown && sort_node != nullptr) {
+        std::unordered_set<int32_t> index_field_ids;
+        SmartIndex index_info = _factory->get_index_info_ptr(global_index_id);
+        for (auto& field : index_info->fields) {
+            index_field_ids.insert(field.id);
+        }
+        std::unordered_set<int32_t> expr_field_ids;
+        for (auto expr : sort_node->slot_order_exprs()) {
+            expr->get_all_field_ids(expr_field_ids);
+        }
+        for (auto field_id : expr_field_ids) {
+            if (index_field_ids.count(field_id) == 0) {
+                need_pushdown = false;
+                break;
+            }
+        }
+    }
+    if (need_pushdown) {
+        store_exec = _children[0];
+    }
     //agg or sort 不在二级索引表上执行
     /*
     if (_children[0]->node_type() != pb::SCAN_NODE

--- a/src/exec/select_manager_node.cpp
+++ b/src/exec/select_manager_node.cpp
@@ -56,7 +56,7 @@ int SelectManagerNode::open(RuntimeState* state) {
         ret = open_global_index(state, scan_node, router_index_id, main_table_id);
     } 
     if (ret < 0) {
-        DB_WARNING("select manager fetcher mnager node open fail, txn_id: %lu, log_id:%lu", 
+        DB_WARNING("select manager fetcher manager node open fail, txn_id: %lu, log_id:%lu",
                 state->txn_id, state->log_id());
         return ret;
     }

--- a/src/expr/fn_manager.cpp
+++ b/src/expr/fn_manager.cpp
@@ -236,6 +236,12 @@ void FunctionManager::register_operators() {
 
     register_object_ret("version", version, pb::STRING);
     register_object_ret("last_insert_id", last_insert_id, pb::INT64);
+    register_object_ret("cast_to_date", cast_to_date, pb::DATE);
+    register_object_ret("cast_to_time", cast_to_time, pb::TIME);
+    register_object_ret("cast_to_datetime", cast_to_datetime, pb::DATETIME);
+    register_object_ret("cast_to_string", cast_to_string, pb::STRING);
+    register_object_ret("cast_to_signed", cast_to_signed, pb::INT64);
+    register_object_ret("cast_to_unsigned", cast_to_unsigned, pb::INT64);
 }
 
 int FunctionManager::init() {

--- a/src/expr/fn_manager.cpp
+++ b/src/expr/fn_manager.cpp
@@ -148,8 +148,8 @@ void FunctionManager::register_operators() {
     register_object_ret("repeat", repeat, pb::STRING);
     register_object_ret("reverse", reverse, pb::STRING);
     register_object_ret("locate", locate, pb::INT32);
-    register_object_ret("lpad", locate, pb::STRING);
-    register_object_ret("rpad", locate, pb::STRING);
+    register_object_ret("lpad", lpad, pb::STRING);
+    register_object_ret("rpad", rpad, pb::STRING);
 
     // date funcs
     register_object_ret("unix_timestamp", unix_timestamp, pb::UINT32);

--- a/src/expr/fn_manager.cpp
+++ b/src/expr/fn_manager.cpp
@@ -158,8 +158,10 @@ void FunctionManager::register_operators() {
     register_object_ret("sysdate", now, pb::DATETIME);
     register_object_ret("utc_timestamp", utc_timestamp, pb::DATETIME);
     register_object_ret("date_format", date_format, pb::STRING);
+    register_object_ret("time_format", time_format, pb::STRING);
     register_object_ret("timediff", timediff, pb::TIME);
     register_object_ret("timestampdiff", timestampdiff, pb::INT64);
+    register_object_ret("convert_tz", convert_tz, pb::STRING);
     register_object_ret("curdate", curdate, pb::DATE);
     register_object_ret("current_date", current_date, pb::DATE);
     register_object_ret("curtime", curtime, pb::TIME);
@@ -193,6 +195,7 @@ void FunctionManager::register_operators() {
     register_object_ret("if", if_, pb::STRING);
     register_object_ret("ifnull", ifnull, pb::STRING);
     register_object_ret("nullif", nullif, pb::STRING);
+    register_object_ret("isnull", isnull, pb::BOOL);
     // MurmurHash sign
     register_object_ret("murmur_hash", murmur_hash, pb::UINT64);
     register_object_ret("md5", md5, pb::STRING);

--- a/src/expr/fn_manager.cpp
+++ b/src/expr/fn_manager.cpp
@@ -148,6 +148,8 @@ void FunctionManager::register_operators() {
     register_object_ret("repeat", repeat, pb::STRING);
     register_object_ret("reverse", reverse, pb::STRING);
     register_object_ret("locate", locate, pb::INT32);
+    register_object_ret("lpad", locate, pb::STRING);
+    register_object_ret("rpad", locate, pb::STRING);
 
     // date funcs
     register_object_ret("unix_timestamp", unix_timestamp, pb::UINT32);
@@ -163,6 +165,7 @@ void FunctionManager::register_operators() {
     register_object_ret("curtime", curtime, pb::TIME);
     register_object_ret("current_time", current_time, pb::TIME);
     register_object_ret("current_timestamp", current_timestamp, pb::TIMESTAMP);
+    register_object_ret("timestamp", timestamp, pb::TIMESTAMP);
     register_object_ret("day", day, pb::UINT32);
     register_object_ret("dayname", dayname, pb::STRING);
     register_object_ret("dayofweek", dayofweek, pb::UINT32);

--- a/src/expr/internal_functions.cpp
+++ b/src/expr/internal_functions.cpp
@@ -797,6 +797,59 @@ ExprValue date_format(const std::vector<ExprValue>& input) {
     format_result.str_val = s;
     return format_result;
 }
+
+ExprValue time_format(const std::vector<ExprValue>& input) {
+    if (input.size() != 2) {
+        return ExprValue::Null();
+    }
+    for (auto& s : input) {
+        if (s.is_null()) {
+            return ExprValue::Null();
+        }
+    }
+    ExprValue tmp = input[0];
+    struct tm t_result;
+    uint32_t second = str_to_time(tmp.str_val.c_str());
+    
+    t_result.tm_hour = (second >> 12) & 0x3FF;
+    t_result.tm_min = (second >> 6) & 0x3F;
+    t_result.tm_sec = second & 0x3F;
+    char s[DATE_FORMAT_LENGTH];
+    std::string format = input[1].str_val;
+    boost::replace_all(format, "\%i", "\%M");
+    boost::replace_all(format, "\%s", "\%S");
+    boost::replace_all(format, "\%h", "\%I");
+    strftime(s, sizeof(s), format.c_str(), &t_result);
+    ExprValue format_result(pb::STRING);
+    format_result.str_val = s;
+    return format_result;
+}
+
+ExprValue convert_tz(const std::vector<ExprValue>& input) {
+    if (input.size() != 3){
+        return ExprValue::Null();
+    }
+    for (auto& s : input) {
+        if (s.is_null()) {
+            return ExprValue::Null();
+        }
+    }
+    ExprValue time = input[0];
+    ExprValue from_tz = input[1];
+    ExprValue to_tz = input[2];
+    int from_tz_second, to_tz_second;
+    if (!tz_to_second(from_tz.str_val.c_str(), from_tz_second)) {
+        return ExprValue::Null();
+    }
+    if (!tz_to_second(to_tz.str_val.c_str(), to_tz_second)) {
+        return ExprValue::Null();
+    }
+    int second_diff = to_tz_second - from_tz_second;
+    ExprValue ret = time.cast_to(pb::TIMESTAMP);
+    ret._u.uint32_val += second_diff;
+    return ret.cast_to(pb::DATETIME);
+}
+
 ExprValue timediff(const std::vector<ExprValue>& input) {
     if (input.size() < 2) {
         return ExprValue::Null();
@@ -1268,6 +1321,19 @@ ExprValue ifnull(const std::vector<ExprValue>& input) {
         return ExprValue::Null();
     }
     return input[0].is_null() ? input[1] : input[0];
+}
+
+ExprValue isnull(const std::vector<ExprValue>& input) {
+    if (input.size() != 1) {
+        return ExprValue::Null();
+    }
+    ExprValue tmp(pb::BOOL);
+    if (input[0].is_null()) {
+        tmp._u.bool_val = true;
+    } else {
+        tmp._u.bool_val = false;
+    }
+   return tmp;
 }
 
 ExprValue nullif(const std::vector<ExprValue>& input) {

--- a/src/expr/internal_functions.cpp
+++ b/src/expr/internal_functions.cpp
@@ -710,6 +710,19 @@ ExprValue current_timestamp(const std::vector<ExprValue>& input) {
 ExprValue utc_timestamp(const std::vector<ExprValue>& input) {
     return ExprValue::UTC_TIMESTAMP();
 }
+
+ExprValue timestamp(const std::vector<ExprValue>& input) {
+    if (input.size() == 0 || input.size() > 2) {
+        return ExprValue::Null();
+    }
+    ExprValue arg1 = input[0];
+    ExprValue ret = arg1.cast_to(pb::DATETIME).cast_to(pb::TIMESTAMP);
+    if (input.size() == 2) {
+        ret._u.uint32_val += time_to_sec(std::vector<ExprValue>(input.begin() + 1, input.end()))._u.int32_val;
+    }
+    return ret;
+}
+
 ExprValue date_format(const std::vector<ExprValue>& input) {
     if (input.size() != 2) {
         return ExprValue::Null();

--- a/src/expr/internal_functions.cpp
+++ b/src/expr/internal_functions.cpp
@@ -1765,6 +1765,54 @@ ExprValue last_insert_id(const std::vector<ExprValue>& input) {
     ExprValue tmp = input[0];
     return tmp.cast_to(pb::INT64);
 }
+
+ExprValue cast_to_date(const std::vector<ExprValue>& input) {
+    if (input.size() != 1) {
+	return ExprValue::Null();
+    }
+    ExprValue tmp = input[0];
+    return tmp.cast_to(pb::DATE);
+}
+
+ExprValue cast_to_datetime(const std::vector<ExprValue>& input) {
+    if (input.size() != 1) {
+	return ExprValue::Null();
+    }
+    ExprValue tmp = input[0];
+    return tmp.cast_to(pb::DATETIME);
+}
+
+ExprValue cast_to_time(const std::vector<ExprValue>& input) {
+    if (input.size() != 1) {
+	return ExprValue::Null();
+    }
+    ExprValue tmp = input[0];
+    return tmp.cast_to(pb::TIME);
+}
+
+ExprValue cast_to_string(const std::vector<ExprValue>& input) {
+    if (input.size() != 1) {
+	return ExprValue::Null();
+    }
+    ExprValue tmp = input[0];
+    return tmp.cast_to(pb::STRING);
+}
+
+ExprValue cast_to_signed(const std::vector<ExprValue>& input) {
+    if (input.size() != 1) {
+	return ExprValue::Null();
+    }
+    ExprValue tmp = input[0];
+    return tmp.cast_to(pb::INT64);
+}
+
+ExprValue cast_to_unsigned(const std::vector<ExprValue>& input) {
+    if (input.size() != 1) {
+	return ExprValue::Null();
+    }
+    ExprValue tmp = input[0];
+    return tmp.cast_to(pb::UINT64);
+}
 }
 
 /* vim: set ts=4 sw=4 sts=4 tw=100 */

--- a/src/expr/internal_functions.cpp
+++ b/src/expr/internal_functions.cpp
@@ -477,6 +477,61 @@ ExprValue rtrim(const std::vector<ExprValue>& input) {
     return tmp;
 }
 
+ExprValue lpad(const std::vector<ExprValue>& input) {
+    if (input.size() != 3) {
+        return ExprValue::Null();
+    }
+    ExprValue tmp(pb::STRING);
+    std::string str = input[0].get_string();
+    int64_t len = input[1].get_numberic<int64_t>();
+    if (len <= 0 || len > UINT16_MAX) {
+        return ExprValue::Null();
+    }
+    if (len <= str.length()) {
+        tmp.str_val.append(str.begin(), str.begin() + len);
+        return tmp;
+    }
+    std::string padstr = input[2].get_string();
+    if (padstr.length() == 0) {
+        return ExprValue::Null();
+    }
+    size_t padlen = len - str.length();
+    while (padlen > padstr.length()) {
+        tmp.str_val.append(padstr);
+        padlen -= padstr.length();
+    }
+    tmp.str_val.append(padstr.begin(), padstr.begin() + padlen);
+    tmp.str_val.append(str);
+    return tmp;
+}
+ExprValue rpad(const std::vector<ExprValue>& input) {
+    if (input.size() != 3) {
+        return ExprValue::Null();
+    }
+    ExprValue tmp(pb::STRING);
+    std::string str = input[0].get_string();
+    int64_t len = input[1].get_numberic<int64_t>();
+    if (len <= 0 || len > UINT16_MAX) {
+        return ExprValue::Null();
+    }
+    if (len <= str.length()) {
+        tmp.str_val.append(str.begin(), str.begin() + len);
+        return tmp;
+    }
+    std::string padstr = input[2].get_string();
+    if (padstr.length() == 0) {
+        return ExprValue::Null();
+    }
+    tmp.str_val.append(str);
+    size_t padlen = len - str.length();
+    while (padlen > padstr.length()) {
+        tmp.str_val.append(padstr);
+        padlen -= padstr.length();
+    }
+    tmp.str_val.append(padstr.begin(), padstr.begin() + padlen);
+    return tmp;
+}
+
 ExprValue concat_ws(const std::vector<ExprValue>& input) {
     if (input.size() < 2) {
         return ExprValue::Null();

--- a/src/logical_plan/ddl_planner.cpp
+++ b/src/logical_plan/ddl_planner.cpp
@@ -290,10 +290,13 @@ int DDLPlanner::parse_create_table(pb::SchemaInfo& table) {
             try {
                 root.Parse<0>(option->str_value.value);
                 if (root.HasParseError()) {
+                    // 兼容mysql语法
+                    table.set_comment(option->str_value.value);
                     rapidjson::ParseErrorCode code = root.GetParseError();
                     DB_WARNING("parse create table json comments error [code:%d][%s]", 
                         code, option->str_value.value);
-                    return -1;
+                    continue;
+//                    return -1;
                 }
                 auto json_iter = root.FindMember("resource_tag");
                 if (json_iter != root.MemberEnd()) {
@@ -406,8 +409,10 @@ int DDLPlanner::parse_create_table(pb::SchemaInfo& table) {
                     DB_WARNING("comment: %s", comment.c_str());
                 }
             } catch (...) {
+                // 兼容mysql语法
+                table.set_comment(option->str_value.value);
                 DB_WARNING("parse create table json comments error [%s]", option->str_value.value);
-                return -1;
+//                return -1;
             }
         } else if (option->type == parser::TABLE_OPT_PARTITION) {
             // range 分区这里进行配置。
@@ -478,6 +483,7 @@ int DDLPlanner::parse_drop_table(pb::SchemaInfo& table) {
     }
     table.set_table_name(table_name->table.value);
     table.set_namespace_name(_ctx->user_info->namespace_);
+    table.set_if_exist(stmt->if_exist);
     DB_WARNING("drop table: %s.%s.%s", 
         table.namespace_name().c_str(), table.database().c_str(), table.table_name().c_str());
     return 0;

--- a/src/logical_plan/ddl_planner.cpp
+++ b/src/logical_plan/ddl_planner.cpp
@@ -392,6 +392,12 @@ int DDLPlanner::parse_create_table(pb::SchemaInfo& table) {
                         return -1;
                     }
                 }
+                json_iter = root.FindMember("comment");
+                if (json_iter != root.MemberEnd()) {
+                    std::string comment = json_iter->value.GetString();
+                    table.set_comment(comment);
+                    DB_WARNING("comment: %s", comment.c_str());
+                }
             } catch (...) {
                 DB_WARNING("parse create table json comments error [%s]", option->str_value.value);
                 return -1;

--- a/src/logical_plan/ddl_planner.cpp
+++ b/src/logical_plan/ddl_planner.cpp
@@ -107,6 +107,7 @@ int DDLPlanner::add_column_def(pb::SchemaInfo& table, parser::ColumnDef* column)
         return -1;
     }
     field->set_mysql_type(data_type);
+    field->set_can_null(true);
     int option_len = column->options.size();
     for (int opt_idx = 0; opt_idx < option_len; ++opt_idx) {
         parser::ColumnOption* col_option = column->options[opt_idx];
@@ -128,6 +129,12 @@ int DDLPlanner::add_column_def(pb::SchemaInfo& table, parser::ColumnDef* column)
             index->set_index_type(pb::I_UNIQ);
             index->add_field_names(col_name);
         } else if (col_option->type == parser::COLUMN_OPT_DEFAULT_VAL) {
+            if (col_option->expr->expr_type == parser::ET_LITETAL) {
+                if (static_cast<parser::LiteralExpr*>(col_option->expr)->literal_type
+                        == parser::LT_NULL) {
+                    continue;
+                }
+            }
             field->set_default_value(col_option->expr->to_string());
         } else if (col_option->type == parser::COLUMN_OPT_COMMENT) {
             field->set_comment(col_option->expr->to_string());

--- a/src/logical_plan/logical_planner.cpp
+++ b/src/logical_plan/logical_planner.cpp
@@ -1400,6 +1400,20 @@ int LogicalPlanner::create_scala_func_expr(const parser::FuncExpr* item,
             node->mutable_derive_node()->set_int_val(_ctx->client_conn->last_insert_id);
             return 0;
         }
+        if (item->fn_name.to_lower() == "database") {
+            pb::ExprNode* node = expr.add_nodes();
+            if (_ctx->client_conn->current_db == "") {
+                node->set_node_type(pb::NULL_LITERAL);
+                node->set_col_type(pb::NULL_TYPE);
+            } else{
+                node->set_node_type(pb::STRING_LITERAL);
+                node->set_col_type(pb::STRING);
+                node->set_num_children(0);
+                node->mutable_derive_node()->set_string_val(_ctx->client_conn->current_db);
+            }
+
+            return 0;
+        }
         if (FunctionManager::instance()->get_object(item->fn_name.to_lower()) == nullptr) {
             if (_ctx->stat_info.error_code == ER_ERROR_FIRST) {
                 _ctx->stat_info.error_code = ER_NOT_SUPPORTED_YET;

--- a/src/logical_plan/setkv_planner.cpp
+++ b/src/logical_plan/setkv_planner.cpp
@@ -28,6 +28,10 @@ int SetKVPlanner::plan() {
     for (int idx = 0; idx < var_len; ++idx) {
         parser::VarAssign* var_assign = var_list[idx];
         std::string key(var_assign->key.value);
+        if (key.empty()) {
+            _ctx->succ_after_logical_plan = true;
+            return 0;
+        }
         if (var_assign->value == nullptr) {
             DB_WARNING("var_assign->value is null: %s", var_assign->key.value);
             return -1;

--- a/src/logical_plan/update_planner.cpp
+++ b/src/logical_plan/update_planner.cpp
@@ -158,7 +158,8 @@ int UpdatePlanner::parse_kv_list() {
             DB_WARNING("create update value expr failed");
             return -1;
         }
-        if (field_info->on_update_value == "current_timestamp()") {
+        if (field_info->on_update_value == "current_timestamp()" ||
+            field_info->on_update_value == "(current_timestamp())") {
             if (value_expr.nodes(0).node_type() == pb::NULL_LITERAL) {
                 auto node = value_expr.mutable_nodes(0);
                 node->set_num_children(0);
@@ -173,7 +174,8 @@ int UpdatePlanner::parse_kv_list() {
         if (update_field_ids.count(field.id) != 0) {
             continue;
         }
-        if (field.on_update_value == "current_timestamp()") {
+        if (field.on_update_value == "current_timestamp()" ||
+            field.on_update_value == "(current_timestamp())") {
             pb::Expr value_expr;
             auto node = value_expr.add_nodes();
             node->set_num_children(0);

--- a/src/logical_plan/update_planner.cpp
+++ b/src/logical_plan/update_planner.cpp
@@ -158,7 +158,7 @@ int UpdatePlanner::parse_kv_list() {
             DB_WARNING("create update value expr failed");
             return -1;
         }
-        if (field_info->on_update_value == "(current_timestamp())") {
+        if (field_info->on_update_value == "current_timestamp()") {
             if (value_expr.nodes(0).node_type() == pb::NULL_LITERAL) {
                 auto node = value_expr.mutable_nodes(0);
                 node->set_num_children(0);
@@ -173,7 +173,7 @@ int UpdatePlanner::parse_kv_list() {
         if (update_field_ids.count(field.id) != 0) {
             continue;
         }
-        if (field.on_update_value == "(current_timestamp())") {
+        if (field.on_update_value == "current_timestamp()") {
             pb::Expr value_expr;
             auto node = value_expr.add_nodes();
             node->set_num_children(0);

--- a/src/meta_server/meta_server.cpp
+++ b/src/meta_server/meta_server.cpp
@@ -259,7 +259,8 @@ void MetaServer::meta_manager(google::protobuf::RpcController* controller,
             || request->op_type() == pb::OP_UPDATE_GLOBAL_REGION_DDL_WORK
             || request->op_type() == pb::OP_SUSPEND_DDL_WORK
             || request->op_type() == pb::OP_RESTART_DDL_WORK
-            || request->op_type() == pb::OP_UPDATE_MAIN_LOGICAL_ROOM) {
+            || request->op_type() == pb::OP_UPDATE_MAIN_LOGICAL_ROOM
+            || request->op_type() == pb::OP_UPDATE_TABLE_COMMENT) {
         SchemaManager::get_instance()->process_schema_info(controller,
                                              request,
                                              response,

--- a/src/meta_server/meta_state_machine.cpp
+++ b/src/meta_server/meta_state_machine.cpp
@@ -399,6 +399,10 @@ void MetaStateMachine::on_apply(braft::Iterator& iter) {
             TableManager::get_instance()->update_schema_conf(request, iter.index(), done);
             break;
         }
+        case pb::OP_UPDATE_TABLE_COMMENT: {
+            TableManager::get_instance()->update_table_comment(request, iter.index(), done);
+            break;
+        }
         case pb::OP_DROP_REGION: {
             RegionManager::get_instance()->drop_region(request, iter.index(), done);
             break;

--- a/src/meta_server/schema_manager.cpp
+++ b/src/meta_server/schema_manager.cpp
@@ -112,7 +112,8 @@ void SchemaManager::process_schema_info(google::protobuf::RpcController* control
     case pb::OP_LINK_BINLOG:
     case pb::OP_UNLINK_BINLOG:
     case pb::OP_SET_INDEX_HINT_STATUS:
-    case pb::OP_UPDATE_MAIN_LOGICAL_ROOM: {
+    case pb::OP_UPDATE_MAIN_LOGICAL_ROOM:
+    case pb::OP_UPDATE_TABLE_COMMENT: {
         if (!request->has_table_info()) { 
             ERROR_SET_RESPONSE(response, pb::INPUT_PARAM_ERROR, 
                     "no schema_info", request->op_type(), log_id);
@@ -134,6 +135,12 @@ void SchemaManager::process_schema_info(google::protobuf::RpcController* control
                 && !request->table_info().has_schema_conf()) {
             ERROR_SET_RESPONSE(response, pb::INPUT_PARAM_ERROR,
                     "no schema_conf", request->op_type(), log_id);
+            return;
+        }
+        if (request->op_type() == pb::OP_UPDATE_TABLE_COMMENT
+                && !request->table_info().has_comment()) {
+            ERROR_SET_RESPONSE(response, pb::INPUT_PARAM_ERROR,
+                    "no table comment", request->op_type(), log_id);
             return;
         }
         if (request->op_type() == pb::OP_RENAME_TABLE

--- a/src/meta_server/table_manager.cpp
+++ b/src/meta_server/table_manager.cpp
@@ -994,6 +994,7 @@ void TableManager::add_field(const pb::MetaManagerRequest& request,
         pb::FieldInfo* add_field = mem_schema_pb.add_fields();
         *add_field = field;
         add_field->set_field_id(++tmp_max_field_id);
+        add_field->set_timestamp(time(NULL));
         add_field_id_map[field.field_name()] = tmp_max_field_id;
     }
     mem_schema_pb.set_version(mem_schema_pb.version() + 1);

--- a/src/meta_server/table_manager.cpp
+++ b/src/meta_server/table_manager.cpp
@@ -4025,7 +4025,8 @@ void TableManager::set_index_hint_status(const pb::MetaManagerRequest& request, 
                 for (const auto& index_info : request.table_info().indexs()) {
                     auto index_iter = mem_schema_pb.mutable_indexs()->begin();
                     for (; index_iter != mem_schema_pb.mutable_indexs()->end(); index_iter++) {
-                        if (index_iter->index_name() == index_info.index_name() &&
+                        // 索引匹配不区分大小写
+                        if (boost::algorithm::iequals(index_iter->index_name(), index_info.index_name()) &&
                             index_iter->index_type() != pb::I_PRIMARY &&
                             index_iter->hint_status() != index_info.hint_status()) {
                             index_iter->set_hint_status(index_info.hint_status());

--- a/src/meta_server/table_manager.cpp
+++ b/src/meta_server/table_manager.cpp
@@ -434,6 +434,10 @@ void TableManager::drop_table(const pb::MetaManagerRequest& request, const int64
     int64_t drop_table_id = 0;
     auto ret = check_table_exist(request.table_info(), namespace_id, database_id, drop_table_id);
     if (ret < 0) {
+        if (request.table_info().if_exist()) {
+            IF_DONE_SET_RESPONSE(done, pb::SUCCESS, "table not exist");
+            return;
+        }
         DB_WARNING("input table not exit, request: %s", request.ShortDebugString().c_str());
         IF_DONE_SET_RESPONSE(done, pb::INPUT_PARAM_ERROR, "table not exist");
         return;

--- a/src/meta_server/table_manager.cpp
+++ b/src/meta_server/table_manager.cpp
@@ -946,6 +946,16 @@ void TableManager::update_ttl_duration(const pb::MetaManagerRequest& request,
         });
 }
 
+void TableManager::update_table_comment(const pb::MetaManagerRequest& request,
+                                const int64_t apply_index,
+                                braft::Closure* done) {
+    update_table_internal(request, apply_index, done,
+        [](const pb::MetaManagerRequest& request, pb::SchemaInfo& mem_schema_pb) {
+            mem_schema_pb.set_version(mem_schema_pb.version() + 1);
+            mem_schema_pb.set_comment(request.table_info().comment());
+        });
+}
+
 void TableManager::add_field(const pb::MetaManagerRequest& request,
                              const int64_t apply_index,
                              braft::Closure* done) {

--- a/src/meta_server/table_manager.cpp
+++ b/src/meta_server/table_manager.cpp
@@ -3035,6 +3035,14 @@ void TableManager::add_index(const pb::MetaManagerRequest& request,
     }
     DB_DEBUG("DDL_LOG[add_index] check field success.");
 
+    if (request.table_info().indexs(0).is_global() && (table_info.ttl_duration() > 0)) {
+        DB_WARNING("ttl table: %s can not support to add global index: %s",
+                    table_info.table_name().c_str(),
+                    request.table_info().indexs(0).index_name().c_str());
+        IF_DONE_SET_RESPONSE(done, pb::INPUT_PARAM_ERROR, "ttl table is not support add global index");
+        return;
+    }
+
     if (_table_info_map.find(table_id) == _table_info_map.end()) {
         DB_WARNING("DDL_LOG[add_index] table not in table_info_map, request:%s", request.DebugString().c_str());
         IF_DONE_SET_RESPONSE(done, pb::INPUT_PARAM_ERROR, "table not in table_info_map");

--- a/src/physical_plan/index_selector.cpp
+++ b/src/physical_plan/index_selector.cpp
@@ -520,7 +520,18 @@ int64_t IndexSelector::index_selector(const std::vector<pb::TupleDescriptor>& tu
     }
 
     std::vector<int64_t> index_ids = table_info->indices;
-    if (pb_scan_node->use_indexes_size() != 0) {
+    std::set<int64_t> force_indexs;
+    force_indexs.insert(std::begin(pb_scan_node->force_indexes()),
+	    std::end(pb_scan_node->force_indexes()));
+    if (pb_scan_node->force_indexes_size() != 0){
+	index_ids.clear();
+	for (auto& index_id : pb_scan_node->force_indexes()) {
+	    index_ids.push_back(index_id);
+	}
+        if (force_indexs.count(table_id) == 0){
+	    index_ids.push_back(table_id);
+	}
+    } else if (pb_scan_node->use_indexes_size() != 0) {
         index_ids.clear();
         for (auto& index_id : pb_scan_node->use_indexes()) {
             index_ids.push_back(index_id);
@@ -558,10 +569,14 @@ int64_t IndexSelector::index_selector(const std::vector<pb::TupleDescriptor>& tu
             continue;
         }
         SmartPath access_path = std::make_shared<AccessPath>();
+	if (force_indexs.count(index_id) == 1) {
+	    access_path->hint = AccessPath::FORCE_INDEX;
+	}
         // 只有primary会走到这里
         if (ignore_indexs.count(index_id) == 1) {
             access_path->hint = AccessPath::IGNORE_INDEX;
         }
+
         access_path->field_range_map = field_range_map;
         access_path->table_info_ptr = table_info;
         access_path->index_info_ptr = info_ptr;

--- a/src/protocol/mysql_wrapper.cpp
+++ b/src/protocol/mysql_wrapper.cpp
@@ -44,21 +44,24 @@ int MysqlWrapper::handshake_send(SmartSocket sock) {
 
     // Send handshake package.
     const uint8_t packet_handshake_2[] =
-        "\x26\x4f\x37\x58"
-        "\x43\x7a\x6c\x53"  // auth-plugin-data-part-1
+        ""                  // connection id
+        "\x26\x4f\x37\x58"  // auth-plugin-data-part-1
+        "\x43\x7a\x6c\x53"  //
         "\x00"              // filter
         "\x0c\xa2"          // capability flags (lower 2 bytes)
         "\x1c"              // server language encoding :cp 1257 change to gbk
         "\x02\x00"          // server status
-        "\x00\x00"          // capability flags (upper 2 bytes)
-        "\x00"              // length of auth-plugin-data
+        "\x08\x00"          // capability flags (upper 2 bytes), CLIENT_PLUGIN_AUTH
+        "\x15"              // length of auth-plugin-data
         "\x00\x00\x00\x00"
         "\x00\x00\x00\x00"
         "\x00\x00"          // 10bytes reserved
         "\x21\x25\x65\x57"
         "\x62\x35\x42\x66"
         "\x6f\x34\x62\x49"
-        "\x00";             // auth-plugin-data-part-2 len=13
+        "\x00"              // auth-plugin-data-part-2 len=13
+        "mysql_native_password\x00";    // auth-plugin name
+
 
     size_t len1 = sizeof(packet_handshake_1) - 1;
     size_t len2 = sizeof(packet_handshake_2) - 1;

--- a/src/protocol/state_machine.cpp
+++ b/src/protocol/state_machine.cpp
@@ -1595,14 +1595,14 @@ bool StateMachine::_handle_client_query_show_create_table(SmartSocket client) {
         oss << (field.can_null ? "NULL " : "NOT NULL ");
         if (!field.default_expr_value.is_null()) {
             oss << "DEFAULT ";
-            if (field.default_value == "(current_timestamp())") {
+            if (field.default_value == "current_timestamp()") {
                 oss << "CURRENT_TIMESTAMP ";
             } else {
                 oss << "'" << field.default_value << "' ";
             }
         }
         if (!field.on_update_value.empty()) {
-            if (field.on_update_value == "(current_timestamp())") {
+            if (field.on_update_value == "current_timestamp()") {
                 oss << "ON UPDATE " << "CURRENT_TIMESTAMP ";
             }
         }

--- a/src/protocol/state_machine.cpp
+++ b/src/protocol/state_machine.cpp
@@ -1595,14 +1595,16 @@ bool StateMachine::_handle_client_query_show_create_table(SmartSocket client) {
         oss << (field.can_null ? "NULL " : "NOT NULL ");
         if (!field.default_expr_value.is_null()) {
             oss << "DEFAULT ";
-            if (field.default_value == "current_timestamp()") {
+            if (field.default_value == "current_timestamp()" ||
+                field.default_value == "(current_timestamp())") {
                 oss << "CURRENT_TIMESTAMP ";
             } else {
                 oss << "'" << field.default_value << "' ";
             }
         }
         if (!field.on_update_value.empty()) {
-            if (field.on_update_value == "current_timestamp()") {
+            if (field.on_update_value == "current_timestamp()" ||
+                field.on_update_value == "(current_timestamp())") {
                 oss << "ON UPDATE " << "CURRENT_TIMESTAMP ";
             }
         }

--- a/src/protocol/state_machine.cpp
+++ b/src/protocol/state_machine.cpp
@@ -1665,6 +1665,9 @@ bool StateMachine::_handle_client_query_show_create_table(SmartSocket client) {
     oss << " DEFAULT CHARSET=" << charset_map[info.charset];
     oss <<" AVG_ROW_LENGTH=" << info.byte_size_per_record;
     oss << " COMMENT='{\"resource_tag\":\"" << info.resource_tag << "\"";
+    if (!info.comment.empty()) {
+        oss << ", \"comment\":\"" << info.comment << "\"";
+    }
     oss << ", \"replica_num\":" << info.replica_num;
     oss << ", \"region_split_lines\":" << info.region_split_lines;
     if (info.ttl_duration > 0) {

--- a/src/store/region.cpp
+++ b/src/store/region.cpp
@@ -2093,8 +2093,11 @@ int Region::select_sample(RuntimeState& state, ExecNode* root, const pb::Analyze
                 if (count > 0) {
                     int32_t random = butil::fast_rand() % count; 
                     if (random < sample_cnt) {
+                        state.memory_limit_release(sample_batch.get_row(random)->used_size());
                         sample_batch.replace_row(std::move(batch.get_row()), random);
-                    }
+                    } else {
+			state.memory_limit_release(batch.get_row()->used_size());
+		    }
                 }
             }
         }

--- a/src/store/region.cpp
+++ b/src/store/region.cpp
@@ -53,6 +53,7 @@ namespace baikaldb {
 DEFINE_bool(use_fulltext_wordweight_segment, true, "load wordweight dict");
 DEFINE_bool(use_fulltext_wordseg_wordrank_segment, true, "load wordseg wordrank dict");
 DEFINE_int32(election_timeout_ms, 1000, "raft election timeout(ms)");
+DEFINE_int32(transfer_leader_timeout_ms, 1000, "raft transfer_leader timeout(ms)");
 DEFINE_int32(skew, 5, "split skew, default : 45% - 55%");
 DEFINE_int32(reverse_level2_len, 5000, "reverse index level2 length, default : 5000");
 DEFINE_string(raftlog_uri, "myraftlog://my_raft_log?id=", "raft log uri");
@@ -4953,7 +4954,7 @@ void Region::complete_split() {
         return;
     }
     int64_t average_cost = _dml_time_cost.latency();
-    if ((_applied_index - max_applied_index) * average_cost > FLAGS_election_timeout_ms * 1000LL) {
+    if ((_applied_index - max_applied_index) * average_cost > FLAGS_transfer_leader_timeout_ms * 1000LL) {
         DB_WARNING("peer applied index: %ld is less than applied index: %ld, average_cost: %ld",
                     max_applied_index, _applied_index, average_cost);
         return;

--- a/src/store/region.cpp
+++ b/src/store/region.cpp
@@ -1603,7 +1603,7 @@ void Region::dml_1pc(const pb::StoreReq& request, pb::OpType op_type,
         // if txn in pool (new_txn == false), remove it from pool
         // else directly delete it
         if (!is_new_txn) {
-            _txn_pool.remove_txn(state.txn_id, false);
+            _txn_pool.remove_txn(state.txn_id, true);
         }
     });
     auto txn = state.txn();

--- a/src/store/region.cpp
+++ b/src/store/region.cpp
@@ -429,6 +429,9 @@ int Region::execute_cached_cmd(const pb::StoreReq& request, pb::StoreRes& respon
             }
             return -1;
         }
+        if (res.has_last_insert_id()) {
+            response.set_last_insert_id(res.last_insert_id());
+        }
         
         // if this is the BEGIN cmd, we need to refresh the txn handler
         if (op_type == pb::OP_BEGIN && (nullptr == (txn = _txn_pool.get_txn(txn_id)))) {
@@ -1463,6 +1466,9 @@ void Region::dml_2pc(const pb::StoreReq& request,
         txn->dml_num_affected_rows = affected_rows;
     }
     response.set_affected_rows(affected_rows);
+    if (state.last_insert_id != INT64_MIN) {
+        response.set_last_insert_id(state.last_insert_id);
+    }
     root->close(&state);
     ExecNode::destroy_tree(root);
     response.set_errcode(pb::SUCCESS);
@@ -2784,6 +2790,9 @@ void Region::apply_txn_request(const pb::StoreReq& request, braft::Closure* done
         }
         if (res.has_affected_rows()) {
             ((DMLClosure*)done)->response->set_affected_rows(res.affected_rows());
+        }
+        if (res.has_last_insert_id()) {
+            ((DMLClosure*)done)->response->set_last_insert_id(res.last_insert_id());
         }
     }
 }

--- a/src/store/region_binlog.cpp
+++ b/src/store/region_binlog.cpp
@@ -724,7 +724,7 @@ int Region::write_binlog_value(const std::map<std::string, ExprValue>& field_val
                 continue;
             }
             ExprValue default_value = field.default_expr_value;
-            if (field.default_value == "(current_timestamp())") {
+            if (field.default_value == "current_timestamp()") {
                 default_value = ExprValue::Now();
                 default_value.cast_to(field.type);
             }

--- a/src/store/region_binlog.cpp
+++ b/src/store/region_binlog.cpp
@@ -724,7 +724,8 @@ int Region::write_binlog_value(const std::map<std::string, ExprValue>& field_val
                 continue;
             }
             ExprValue default_value = field.default_expr_value;
-            if (field.default_value == "current_timestamp()") {
+            if (field.default_value == "current_timestamp()" ||
+                field.default_value == "(current_timestamp())") {
                 default_value = ExprValue::Now();
                 default_value.cast_to(field.type);
             }

--- a/src/store/region_control.cpp
+++ b/src/store/region_control.cpp
@@ -27,6 +27,7 @@ namespace baikaldb {
 DECLARE_string(snapshot_uri);
 DECLARE_string(stable_uri);
 DECLARE_int32(election_timeout_ms);
+DECLARE_int32(transfer_leader_timeout_ms);
 DEFINE_int32(compact_interval, 1, "compact_interval xx (s)");
 int RegionControl::remove_data(int64_t drop_region_id) {
     rocksdb::WriteOptions options;
@@ -357,7 +358,7 @@ int RegionControl::transfer_leader(const pb::TransLeaderRequest& trans_leader_re
         int64_t average_cost = region->_dml_time_cost.latency();
         int64_t peer_applied_index = RpcSender::get_peer_applied_index(new_leader, _region_id);
         if ((region->_applied_index - peer_applied_index) * average_cost 
-                > FLAGS_election_timeout_ms * 1000LL) {
+                > FLAGS_transfer_leader_timeout_ms * 1000LL) {
             DB_WARNING("peer applied index: %ld is less than applied index: %ld, average_cost: %ld",
                     peer_applied_index, region->_applied_index, average_cost);
             return;

--- a/src/tools/script/drop_index.sh
+++ b/src/tools/script/drop_index.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#Created on 2021-09-02 
+
+echo -e "\n"
+echo -e "drop index\n"
+curl -d '{
+   "op_type":"OP_DROP_INDEX",
+    "table_info": {
+        "table_name": "t",
+        "database": "TestDB",
+        "namespace_name": "TEST",
+        "indexs": [ {
+                        "index_name" : "idx_name"
+                    }
+                  ]
+
+    }
+}' http://$1/MetaService/meta_manager
+echo -e "\n"


### PR DESCRIPTION
- 接口定义：proto/store.interface.proto 的`query_rawkv` 方法
  - OP_RAWKV_BATCH_GET：   随机读，输入：一个或多个key， 输出：value，对应rocksdb的Get/MultiGet
  - OP_RAWKV_BATCH_WRITE： 随机写，输入：一个或多个key/value/ttl， 对应rocksdb的Write,支持PUT/DELETE
  - OP_RAWKV_RANGE_SCAN：  顺序读，输入：[start_key, end_key)， 输出：key/value，对应rocksdb的Iterator
  - ~~OP_RAWKV_RANGE_DELETE：顺序删，输入：[start_key, end_key)，对应rocksdb的DeleteRange~~
- 创建kv表：`bash rawkv_create_table.sh $meta`
kv表是一张专门用kv操作的表，只有k与v两列，除此之外与其它表没有任何区别，你可以用mysql客户端正常访问它。
- 相关命令： 
提供了一些脚本用于快速上手，测试使用rawkv接口，所有脚本位于：`src/tools/script/rawkv_*.sh`
支持的命令如下：
  - PUT
  - DELETE
  - BATCH_WRITE
  - ~~RANGE_DELETE~~
  - GET
  - BATCH_GET
  - RANGE_SCAN
