### PR TITLE
mysql兼容性提升，添加函数与系统表，limit下推优化，bug fix

### DIFF
--- a/src/meta_server/region_manager.cpp
+++ b/src/meta_server/region_manager.cpp
@@ -2338,11 +2338,11 @@ void RegionManager::check_whether_illegal_peer(const pb::StoreHeartBeatRequest* 
             } else {
                 if (peer_info.has_exist_leader() && !peer_info.exist_leader()) {
                     bool find_in_legal = false;
-                    for(auto& peer_state : peer_state.legal_peers_state) {
-                        if (peer_state.peer_id() == instance) {
-                            peer_state.set_timestamp(timestamp);
-                            peer_state.set_table_id(peer_info.table_id());
-                            peer_state.set_peer_status(pb::STATUS_NO_LEADER);
+                    for(auto& ps : peer_state.legal_peers_state) {
+                        if (ps.peer_id() == instance) {
+                            ps.set_timestamp(timestamp);
+                            ps.set_table_id(peer_info.table_id());
+                            ps.set_peer_status(pb::STATUS_NO_LEADER);
                             find_in_legal = true;
                             break;
                         }
@@ -2385,11 +2385,11 @@ void RegionManager::check_whether_illegal_peer(const pb::StoreHeartBeatRequest* 
             bool legal_peer = check_legal_peer(master_region_info);
             if (!legal_peer) {
                 bool find_in_illegal = false;
-                for (auto& peer_state : peer_state.ilegal_peers_state) {
-                    if (peer_state.peer_id() == instance) {
-                        peer_state.set_timestamp(timestamp);
-                        peer_state.set_table_id(peer_info.table_id());
-                        peer_state.set_peer_status(pb::STATUS_ILLEGAL_PEER);
+                for (auto& ps : peer_state.ilegal_peers_state) {
+                    if (ps.peer_id() == instance) {
+                        ps.set_timestamp(timestamp);
+                        ps.set_table_id(peer_info.table_id());
+                        ps.set_peer_status(pb::STATUS_ILLEGAL_PEER);
                         find_in_illegal = true;
                         break;
                     }
@@ -2404,11 +2404,11 @@ void RegionManager::check_whether_illegal_peer(const pb::StoreHeartBeatRequest* 
                 }
             } else {
                 bool find_in_legal = false;
-                for (auto& peer_state : peer_state.legal_peers_state) {
-                    if (peer_state.peer_id() == instance) {
-                        peer_state.set_timestamp(timestamp);
-                        peer_state.set_table_id(peer_info.table_id());
-                        peer_state.set_peer_status(pb::STATUS_NO_LEADER);
+                for (auto& ps : peer_state.legal_peers_state) {
+                    if (ps.peer_id() == instance) {
+                        ps.set_timestamp(timestamp);
+                        ps.set_table_id(peer_info.table_id());
+                        ps.set_peer_status(pb::STATUS_NO_LEADER);
                         find_in_legal = true;
                         break;
                     }

--- a/src/protocol/network_server.cpp
+++ b/src/protocol/network_server.cpp
@@ -43,7 +43,7 @@ DEFINE_int32(backup_pv_threshold, 50, "backup_pv_threshold");
 DEFINE_double(backup_error_percent, 0.5, "use backup table if backup_error_percent > 0.5");
 DEFINE_int64(health_check_interval_us, 10 * 1000 * 1000, "health_check_interval_us");
 DEFINE_bool(need_health_check, true, "need_health_check");
-DEFINE_int64(health_check_timeout_ms, 2000, "health_check_timeout_ms");
+DEFINE_int64(health_check_store_timeout_ms, 2000, "health_check_store_timeout_ms");
 DEFINE_bool(fetch_instance_id, false, "fetch baikaldb instace id, used for generate transaction id");
 DEFINE_string(hostname, "HOSTNAME", "matrix instance name");
 DEFINE_bool(insert_agg_sql, false, "whether insert agg_sql");
@@ -601,9 +601,9 @@ void NetworkServer::store_health_check() {
             brpc::ChannelOptions option;
             option.max_retry = 1;
             option.connect_timeout_ms = 1000;
-            option.timeout_ms = FLAGS_health_check_timeout_ms;
+            option.timeout_ms = FLAGS_health_check_store_timeout_ms;
             if (old_status != pb::NORMAL) {
-                option.timeout_ms = FLAGS_health_check_timeout_ms / 2;
+                option.timeout_ms = FLAGS_health_check_store_timeout_ms / 2;
             }
             int ret = channel.Init(addr.c_str(), &option);
             if (ret != 0) {

--- a/src/protocol/show_helper.cpp
+++ b/src/protocol/show_helper.cpp
@@ -1442,9 +1442,7 @@ bool ShowHelper::_show_all_tables(const SmartSocket& client, const std::vector<s
     };
 
     if (type_func_map[split_vec[2]] != nullptr) {
-        factory->get_table_by_filter(database_table, [](const SmartTable& table) {
-            return table != nullptr && table->binlog_id > 0;
-        });
+        factory->get_table_by_filter(database_table, type_func_map[split_vec[2]]);
     } else {
         DB_WARNING("not support type:%s", split_vec[2].c_str());
         return false;
@@ -1991,7 +1989,7 @@ bool ShowHelper::_show_store_txn(const SmartSocket& client, const std::vector<st
     // Make fields.
     std::vector<ResultField> fields;
     std::vector<std::string> names = {"txn_id", "seq_id", "primary_region_id", "state"};
-    std::unordered_map<pb::TxnState, std::string> state = {
+    std::unordered_map<pb::TxnState, std::string, std::hash<int>> state = {
             {pb::TXN_ROLLBACKED, "TXN_ROLLBACKED"},
             {pb::TXN_COMMITTED, "TXN_COMMITTED"},
             {pb::TXN_PREPARED, "TXN_PREPARED"},
@@ -2044,7 +2042,7 @@ bool ShowHelper::_show_store_txn(const SmartSocket& client, const std::vector<st
 }
 
 bool ShowHelper::_show_ddl_work(const SmartSocket& client, const std::vector<std::string>& split_vec) {
-    std::unordered_map<pb::DdlWorkStatus, std::string> state = {
+    std::unordered_map<pb::DdlWorkStatus, std::string, std::hash<int>> state = {
             {pb::DdlWorkIdle,    "DdlWorkIdle"},
             {pb::DdlWorkDoing,   "DdlWorkDoing"},
             {pb::DdlWorkDone,    "DdlWorkDone"},
@@ -2053,7 +2051,7 @@ bool ShowHelper::_show_ddl_work(const SmartSocket& client, const std::vector<std
             {pb::DdlWorkError,   "DdlWorkError"}
 
     };
-    std::unordered_map<pb::IndexState, std::string> index_state = {
+    std::unordered_map<pb::IndexState, std::string, std::hash<int>> index_state = {
             {pb::IS_PUBLIC, "IS_PUBLIC"},
             {pb::IS_WRITE_LOCAL, "IS_WRITE_LOCAL"},
             {pb::IS_WRITE_ONLY, "IS_WRITE_ONLY"},
@@ -2353,7 +2351,7 @@ bool ShowHelper::_show_global_ddl_work(const SmartSocket& client, const std::vec
     std::vector<ResultField> fields;
     std::vector<std::string> names = {"region_id", "start_key", "end_key", "status", "op_type", "index_id",
                                       "address", "retry_time", "update_timestamp", "partition"};
-    std::unordered_map<pb::DdlWorkStatus, std::string> state = {
+    std::unordered_map<pb::DdlWorkStatus, std::string, std::hash<int>> state = {
             {pb::DdlWorkIdle, "DdlWorkIdle"},
             {pb::DdlWorkDoing, "DdlWorkDoing"},
             {pb::DdlWorkDone, "DdlWorkDone"},


### PR DESCRIPTION
# mysql兼容性提升
- 添加函数 timestamp, lpad, rpad, time_format, convert_tz, isnull, database()， cast, convert
- 去单行注释：remove single line comment #, --.
- force index兼容mysql 语义，优先级高于use index ，primary index
- 增加系统表： routines，KEY_COLUMN_USAGE ，REFERENTIAL_CONSTRAINTS
- 非空字段校验
-  support  set xx = DEFAULT
- drop index：第一次处理为索引屏蔽Disable状态，再次drop，立马删除
- 增加表注释，用法： comment= "table_comment"， 与 comment='{"comment":"table_comment"}' 均可
# 性能优化
- 增加FLAGS_transfer_leader_timeout_ms，控制选主速度，默认值有10s缩短为1s，减少选主失败导致SQL超时的概率
- other join 与global index下，limit算子下推优化
- add loop hash join for apply_node
# Bug fix