### PR TITLE
merge internal

### DIFF
--- a/include/common/meta_server_interact.hpp
+++ b/include/common/meta_server_interact.hpp
@@ -123,7 +123,7 @@ public:
                 continue;
             }
             if (response.errcode() == pb::NOT_LEADER) {
-                DB_WARNING("connect with meat server:%s fail. not leader, redirect to :%s, log_id:%lu",
+                DB_WARNING("connect with meta server:%s fail. not leader, redirect to :%s, log_id:%lu",
                             butil::endpoint2str(cntl.remote_side()).c_str(),
                             response.leader().c_str(), cntl.log_id());
                 butil::EndPoint leader_addr;

--- a/include/common/mut_table_key.h
+++ b/include/common/mut_table_key.h
@@ -33,6 +33,10 @@ public:
         _full(full), 
         _data(key.data_, key.size_) {}
 
+    MutTableKey(const std::string& key, bool full) : 
+        _full(full),
+        _data(key.data(), key.size()) { }
+
     MutTableKey(const TableKey& key);
 
     MutTableKey& append_i8(int8_t val) {
@@ -70,10 +74,10 @@ public:
     }
 
     MutTableKey& replace_i32(int32_t val, size_t pos) { // cstore
-       uint32_t encode = KeyEncoder::to_endian_u32(KeyEncoder::encode_i32(val));
-       size_t len = sizeof(uint32_t);
-       _data.replace(pos, len, (char*)&encode, sizeof(uint32_t));
-       return *this;
+        uint32_t encode = KeyEncoder::to_endian_u32(KeyEncoder::encode_i32(val));
+        size_t len = sizeof(uint32_t);
+        _data.replace(pos, len, (char*)&encode, sizeof(uint32_t));
+        return *this;
     }
 
     MutTableKey& append_u32(uint32_t val) {
@@ -181,7 +185,6 @@ public:
         _data.append(key);
         return *this;
     }
-
 
     int append_index(IndexInfo& index, TableRecord* record, int field_cnt, bool clear);
 

--- a/include/common/table_record.h
+++ b/include/common/table_record.h
@@ -159,6 +159,7 @@ public:
 
     int decode(const std::string& in) {
         if (_message->ParseFromString(in)) {
+            _used_size += in.size();
             return 0;
         }
         return -1;
@@ -258,9 +259,14 @@ public:
         }
     }
 
+    int64_t used_size() {
+        return sizeof(TableRecord) + _used_size + get_protobuf_space_size(*_message);
+    }
+
     static SmartRecord new_record(int64_t tableid);
 
 private:
     Message* _message = nullptr;
+    int64_t  _used_size = 0;
 };
 }

--- a/include/engine/rocks_wrapper.h
+++ b/include/engine/rocks_wrapper.h
@@ -208,6 +208,18 @@ public:
     }
     void begin_split_adjust_option();
     void stop_split_adjust_option();
+    void collect_rocks_options();
+    void adjust_option(std::map<std::string, std::string> new_options);
+    int get_rocks_statistic(uint64_t& level0_sst, uint64_t& pending_compaction_size) {
+        rocksdb::ColumnFamilyMetaData cf_meta;
+        _txn_db->GetColumnFamilyMetaData(get_data_handle(), &cf_meta);
+        if (cf_meta.levels.size() == 0) {
+            return -1;
+        }
+        level0_sst = cf_meta.levels[0].files.size();
+        _txn_db->GetIntProperty(get_data_handle(), "rocksdb.estimate-pending-compaction-bytes", &pending_compaction_size);
+        return 0;
+    }
 private:
 
     RocksWrapper();
@@ -231,5 +243,8 @@ private:
     bvar::Adder<int64_t>     _mata_cf_remove_range_count;
 
     std::atomic<int32_t> _split_num;
+    bthread::Mutex _options_mutex;
+    std::unordered_map<std::string, std::string> _rocks_options;
+    std::map<std::string, std::string> _defined_options;
 };
 }

--- a/include/engine/table_iterator.h
+++ b/include/engine/table_iterator.h
@@ -18,6 +18,7 @@
 #include "rocks_wrapper.h"
 #include "schema_factory.h"
 #include "mut_table_key.h"
+#include "table_key.h"
 #include "table_record.h"
 #include "item_batch.hpp"
 #include "my_rocksdb.h"
@@ -36,8 +37,8 @@ struct IndexRange {
     TableRecord* right = nullptr;
 
     // input bound in TableKey format
-    TableKey* left_key = nullptr;
-    TableKey* right_key = nullptr;
+    TableKey left_key;
+    TableKey right_key;
 
     // region & table & index info for the current scan
     IndexInfo*  index_info = nullptr;
@@ -68,6 +69,27 @@ struct IndexRange {
         bool _like_prefix) :
         left(_left),
         right(_right),
+        index_info(_index_info),
+        pri_info(_pri_info),
+        region_info(_region_info),
+        left_field_cnt(left_cnt),
+        right_field_cnt(right_cnt),
+        left_open(_l_open),
+        right_open(_r_open),
+        like_prefix(_like_prefix) {}
+    
+    IndexRange(MutTableKey& _left, 
+        MutTableKey& _right,
+        IndexInfo*  _index_info,
+        IndexInfo*  _pri_info,
+        pb::RegionInfo* _region_info,
+        int left_cnt,
+        int right_cnt,
+        bool _l_open,
+        bool _r_open,
+        bool _like_prefix) :
+        left_key(_left),
+        right_key(_right),
         index_info(_index_info),
         pri_info(_pri_info),
         region_info(_region_info),

--- a/include/engine/transaction_pool.h
+++ b/include/engine/transaction_pool.h
@@ -101,14 +101,21 @@ public:
 
     void update_txn_num_rows_after_split(const std::vector<pb::TransactionInfo>& txn_infos);
 
-    void txn_query_primary_region(SmartTransaction txn, Region* region, pb::RegionInfo& region_info);
-    void txn_commit_through_raft(SmartTransaction txn, pb::RegionInfo& region_info, pb::OpType op_type);
+    void txn_query_primary_region(uint64_t txn_id, Region* region, pb::RegionInfo& region_info);
+    void txn_commit_through_raft(uint64_t txn_id, pb::RegionInfo& region_info, pb::OpType op_type);
     void get_txn_state(const pb::StoreReq* request, pb::StoreRes* response);
     void read_only_txn_process(int64_t region_id, SmartTransaction txn, pb::OpType op_type, bool optimize_1pc);
     int get_region_info_from_meta(int64_t region_id, pb::RegionInfo& region_info);
     //清空所有的状态
     void clear();
 private:
+    struct TxnParams {
+        bool is_primary_region = true;
+        bool is_finished = false;
+        bool is_prepared = false;
+        int seq_id = 0;
+        int64_t primary_region_id = -1;
+    };
     int64_t _region_id = 0;
     int64_t _latest_active_txn_ts = 0;
     bool _use_ttl = false;

--- a/include/exec/access_path.h
+++ b/include/exec/access_path.h
@@ -55,6 +55,9 @@ enum IndexHint {
                 break;
         }
     }
+
+    bool need_add_to_learner_paths();
+    bool need_select_learner_index();
     
     void calc_row_expr_range(std::vector<int32_t>& range_fields, ExprNode* expr, bool in_open,
             std::vector<ExprValue>& values, SmartRecord record, size_t field_idx, bool* out_open, int* out_field_cnt);
@@ -95,7 +98,6 @@ enum IndexHint {
                 // primary 没有过滤index_conjuncts，后续store会增加这个过滤
                 if (all_in_index(expr_field_ids, cover_field_ids) && index_type != pb::I_PRIMARY) {
                     index_other_condition.insert(expr);
-                    ExprNode::create_pb_expr(pos_index.add_index_conjuncts(), expr);
                     index_other_field_ids.insert(expr_field_ids.begin(), expr_field_ids.end());
                 } else {
                     other_condition.insert(expr);

--- a/include/exec/agg_node.h
+++ b/include/exec/agg_node.h
@@ -49,8 +49,6 @@ public:
     virtual void transfer_pb(int64_t region_id, pb::PlanNode* pb_node);
     void encode_agg_key(MemRow* row, MutTableKey& key);
     void process_row_batch(RuntimeState* state, RowBatch& batch, int64_t& used_size, int64_t& release_size);
-    void memory_limit_release(RuntimeState* state, int64_t size);
-    int memory_limit_exceeded(RuntimeState* state, int64_t size);
     std::vector<ExprNode*>* mutable_group_exprs() {
         return &_group_exprs;
     }
@@ -74,6 +72,7 @@ private:
     //需要推导_agg_tuple_id内部slot的类型
     std::vector<ExprNode*> _group_exprs;
     int32_t _agg_tuple_id;
+    int     _row_cnt = 0;
     pb::TupleDescriptor* _group_tuple_desc;
     std::vector<AggFnCall*> _agg_fn_calls;
     std::set<int> _agg_slot_set;

--- a/include/exec/fetcher_store.h
+++ b/include/exec/fetcher_store.h
@@ -13,35 +13,269 @@
 // limitations under the License.
 
 #pragma once
-
+#ifdef BAIDU_INTERNAL
+#include <bthread.h>
+#else
+#include <bthread/bthread.h>
+#endif
+#include <bthread/condition_variable.h>
+#include <bthread/mutex.h>
 #include "table_record.h"
 #include "schema_factory.h"
 #include "runtime_state.h"
 #include "exec_node.h"
 #include "network_socket.h"
 #include "proto/store.interface.pb.h"
-
 namespace baikaldb {
 enum ErrorType {
     E_OK = 0,
     E_WARNING,
     E_FATAL,
     E_BIG_SQL,
-    E_RETURN
+    E_RETURN,
+    E_ASYNC,
+    E_RETRY
 };
 
-struct TraceDesc {
-    int64_t region_id;
-    std::shared_ptr<pb::TraceNode> trace_node = nullptr;
+class RPCCtrl;
+class FetcherStore;
+#define DB_DONE(level, _fmt_, args...) \
+    do {\
+        DB_##level("old_region_id[%ld], region_id[%ld], retry_times[%d], start_seq_id[%d], current_seq_id[%d], "   \
+                   "op_type[%s], log_id[%lu], txn_id[%lu], sign[%lu], addr[%s], backup[%s]." _fmt_,                \
+            _old_region_id, _region_id, _retry_times, _start_seq_id, _current_seq_id,                              \
+            pb::OpType_Name(_op_type).c_str(), _state->log_id(), _state->txn_id, _state->sign,                     \
+            _addr.c_str(), _backup.c_str(), ##args);                                                               \
+    } while (0);
+
+class OnRPCDone: public google::protobuf::Closure {
+public:
+    OnRPCDone(FetcherStore* fetcher_store, RuntimeState* state, ExecNode* store_request, pb::RegionInfo* info_ptr, 
+        int64_t old_region_id, int64_t region_id, int start_seq_id, int current_seq_id, pb::OpType op_type);
+    virtual ~OnRPCDone();
+    virtual void Run();
+    std::string key() {
+        return _store_addr;
+    }
+
+    void retry_times_inc() {
+        _retry_times++;
+    }
+    
+    void set_rpc_ctrl(RPCCtrl* ctrl) {
+        _rpc_ctrl = ctrl;
+    }
+
+    std::shared_ptr<pb::TraceNode> get_trace() {
+        return _trace_node;
+    }
+
+    ErrorType check_status();
+    ErrorType send_async();
+    ErrorType fill_request();
+    void select_addr();
+    void send_request();
+    ErrorType handle_version_old();
+    ErrorType handle_response(const std::string& remote_side);
+
+private:
+    FetcherStore* _fetcher_store;
+    RuntimeState* _state;
+    ExecNode* _store_request;
+    pb::RegionInfo& _info;
+    int64_t _old_region_id = 0;
+    int64_t _region_id = 0;
+    int _retry_times = 0;
+    int _start_seq_id = 0;
+    int _current_seq_id = 0;
+    const pb::OpType _op_type;
+
+    TimeCost _total_cost;
+    TimeCost _query_time;
+    bool _access_learner = false;
+    std::string _addr;
+    std::string _backup;
+    NetworkSocket* _client_conn = nullptr;
+
+    pb::StoreReq _request;
+    pb::StoreRes _response;
+    bool _has_fill_request = false;
+    std::shared_ptr<pb::TraceNode> _trace_node = nullptr;
+    brpc::Controller _cntl;
+    RPCCtrl* _rpc_ctrl = nullptr;
+    std::string _store_addr;
+    static bvar::Adder<int64_t>  async_rpc_region_count;
+    static bvar::LatencyRecorder total_send_request;
+    static bvar::LatencyRecorder add_backup_send_request;
+    static bvar::LatencyRecorder has_backup_send_request;
+};
+
+// RPCCtrl只控制rpc的异步发送和并发控制，具体rpc的成功与否结果收集由fetcher_store处理
+class RPCCtrl {
+public:
+    explicit RPCCtrl(int concurrency_per_store) : _task_concurrency_per_group(concurrency_per_store) { }
+    ~RPCCtrl() { }
+
+    // 0：获取任务成功；1：任务完成
+    // 完成的情况下会等待异步任务结束返回
+    int fetch_task(std::vector<OnRPCDone*>& tasks) {
+        std::unique_lock<bthread::Mutex> lck(_mutex);
+        while(true) {
+            // 完成
+            if (_todo_cnt == 0 && _doing_cnt == 0) {
+                return 1;
+            }
+
+            // 获取任务 
+            tasks.clear();
+            if (_todo_cnt > 0) {
+                for (auto& iter : _ip_task_group_map) {
+                    auto task_group = iter.second;
+                    while (!task_group->todo_tasks.empty()) {
+                        if (task_group->doing_cnt < _task_concurrency_per_group) {
+                            _doing_cnt++;
+                            _todo_cnt--;
+                            task_group->doing_cnt++;
+                            tasks.emplace_back(task_group->todo_tasks.back());
+                            task_group->todo_tasks.pop_back();
+                        } else {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (tasks.empty()) {
+                // 没有获取到任务，等待唤醒
+                _cv.wait(lck);
+            } else {
+                // 获取成功
+                return 0;
+            }
+        }
+
+        return 0;
+    }
+
+    void add_new_task(OnRPCDone* task) {
+        std::unique_lock<bthread::Mutex> lck(_mutex);
+        auto iter = _ip_task_group_map.find(task->key());
+        if (iter != _ip_task_group_map.end()) {
+            iter->second->todo_tasks.emplace_back(task);
+        } else {
+            auto ptr = std::make_shared<TaskGroup>();
+            ptr->todo_tasks.emplace_back(task);
+            _ip_task_group_map[task->key()] = ptr;
+        }
+        task->set_rpc_ctrl(this);
+        _todo_cnt++;
+    } 
+
+    void task_finish(OnRPCDone* task) {
+        std::unique_lock<bthread::Mutex> lck(_mutex);
+        auto task_group = _ip_task_group_map.at(task->key());
+        _doing_cnt--;
+        _done_cnt++;
+        task_group->doing_cnt--;
+        task_group->done_tasks.emplace_back(task);
+
+        // 唤醒主线程
+        _cv.notify_one();
+    }
+
+    void task_retry(OnRPCDone* task) {
+        task->retry_times_inc();
+        std::unique_lock<bthread::Mutex> lck(_mutex);
+        auto task_group = _ip_task_group_map.at(task->key());
+        _doing_cnt--;
+        _todo_cnt++;
+        task_group->doing_cnt--;
+        task_group->todo_tasks.emplace_back(task);
+
+        // 唤醒主线程
+        _cv.notify_one();
+    }
+    
+
+    void execute() {
+        while (true) {
+            std::vector<OnRPCDone*> tasks;
+            int ret = fetch_task(tasks);
+            if (ret == 1) {
+                return;
+            }
+
+            for (OnRPCDone* task : tasks) {
+                task->send_request();
+            }
+        }
+    }
+
+private:
+    struct TaskGroup {
+        TaskGroup() { }
+
+        ~TaskGroup() {
+            if (doing_cnt != 0) {
+                DB_FATAL("memory leak, doing_cnt: %d", doing_cnt);
+            }
+
+            clear_tasks(todo_tasks);
+            clear_tasks(done_tasks);
+        }
+
+        void clear_tasks(std::vector<OnRPCDone*>& tasks) {
+            for (auto task : tasks) {
+                if (task != nullptr) {
+                    delete task;
+                }
+            }
+            tasks.clear();
+        }
+
+        int doing_cnt = 0;
+        std::vector<OnRPCDone*> todo_tasks;
+        std::vector<OnRPCDone*> done_tasks;
+        DISALLOW_COPY_AND_ASSIGN(TaskGroup);
+    };
+
+    int _task_concurrency_per_group;
+    int _todo_cnt  = 0;
+    int _done_cnt  = 0;
+    int _doing_cnt = 0;
+    std::map<std::string, std::shared_ptr<TaskGroup>> _ip_task_group_map;
+    bthread::ConditionVariable _cv;
+    bthread::Mutex _mutex;
+};
+
+// 全局二级索引降级使用，将主备请求分别发往不同集群
+enum GlobalBackupType {
+    GBT_INIT = 0, // 默认值，不是全局索引降级的请求
+    GBT_MAIN,     // 主索引强制访问主集群
+    GBT_LEARNER,  // 降级backup请求强制访问learner
+};
+
+class LearnerStatus {
+public:
+    void set_learner_cannot_access(int64_t region_id, const std::string& peer) {
+        BAIDU_SCOPED_LOCK(_lock);
+        _region_id_dead_learner_peers[region_id].insert(peer);
+    }
+
+    bool can_learner_access(int64_t region_id, const std::string& peer) {
+        BAIDU_SCOPED_LOCK(_lock);
+        return _region_id_dead_learner_peers[region_id].count(peer) <= 0;
+    }
+private:
+    bthread::Mutex  _lock;
+    std::map<int64_t, std::set<std::string>> _region_id_dead_learner_peers;
 };
 
 class FetcherStore {
 public:
     FetcherStore() {
-        bthread_mutex_init(&region_lock, NULL);
     }
     virtual ~FetcherStore() {
-        bthread_mutex_destroy(&region_lock);
     }
     
     void clear() {
@@ -56,49 +290,99 @@ public:
         scan_rows = 0;
         filter_rows = 0;
         row_cnt = 0;
-        analyze_fail_cnt = 0;
-        used_bytes = 0;
         primary_timestamp_updated = false;
         no_copy_cache_plan_set.clear();
         dynamic_timeout_ms = -1;
+        callids.clear();
     }
 
-    // send (cached) cmds with seq_id >= start_seq_id
-    ErrorType send_request(RuntimeState* state,
-                            ExecNode* store_request, 
-                            pb::RegionInfo& info, 
-                            pb::TraceNode* trace_node,
-                            int64_t old_region_id, 
-                            int64_t region_id, 
-                            uint64_t log_id, 
-                            int retry_times, 
-                            int start_seq_id,
-                            int current_seq_id,
-                            pb::OpType op_type);
-    ErrorType send_request(RuntimeState* state,
+    void cancel_rpc() {
+        BAIDU_SCOPED_LOCK(region_lock);
+        for (auto& callid : callids) {
+            brpc::StartCancel(callid);
+        }
+        is_cancelled = true;
+    }
+
+    void insert_callid(const brpc::CallId& callid) {
+        BAIDU_SCOPED_LOCK(region_lock);
+        callids.insert(callid);
+    }
+
+    // send_request不返回执行错误，外部获取fetcher_store.error判断执行结果
+    void send_request(RuntimeState* state,
                            ExecNode* store_request, 
-                           pb::RegionInfo& info, 
-                           int64_t old_region_id, 
-                           int64_t region_id, 
-                           uint64_t log_id, 
-                           int retry_times, 
+                           pb::RegionInfo* info, 
                            int start_seq_id,
                            int current_seq_id,
                            pb::OpType op_type) {
-        return send_request(state, store_request, info, nullptr, old_region_id, region_id,
-                     log_id, retry_times, start_seq_id, current_seq_id, op_type);
+        std::vector<pb::RegionInfo*> infos;
+        infos.emplace_back(info);
+        send_request(state, store_request, infos, start_seq_id, current_seq_id, op_type);
     }
 
-    int run(RuntimeState* state, 
+    void send_request(RuntimeState* state,
+                           ExecNode* store_request, 
+                           std::vector<pb::RegionInfo*> infos, 
+                           int start_seq_id,
+                           int current_seq_id,
+                           pb::OpType op_type) {
+        int64_t limit_single_store_concurrency_cnts = 0;
+        limit_single_store_concurrency_cnts = state->get_single_store_concurrency();
+        std::set<std::shared_ptr<pb::TraceNode>> traces;
+
+        RPCCtrl rpc_ctrl(limit_single_store_concurrency_cnts);
+        for (auto info : infos) {
+            auto task = new OnRPCDone(this, state, store_request, info, 
+                    info->region_id(), info->region_id(), start_seq_id, current_seq_id, op_type);
+            rpc_ctrl.add_new_task(task);
+            traces.insert(task->get_trace());
+        }
+
+        rpc_ctrl.execute();
+
+        if (store_request->get_trace() != nullptr) {           
+            for (auto trace : traces) {
+                (*store_request->get_trace()->add_child_nodes()) = *trace;
+            }
+        }
+    }
+
+    int run_not_set_state(RuntimeState* state, 
             std::map<int64_t, pb::RegionInfo>& region_infos,
             ExecNode* store_request,
             int start_seq_id,
             int current_seq_id,
-            pb::OpType op_type);
+            pb::OpType op_type, 
+            GlobalBackupType backup_type);
+
+    int run(RuntimeState* state,
+                    std::map<int64_t, pb::RegionInfo>& region_infos,
+                    ExecNode* store_request,
+                    int start_seq_id,
+                    int current_seq_id,
+                    pb::OpType op_type,
+                    GlobalBackupType backup_type = GBT_INIT) {
+        int ret = run_not_set_state(state, region_infos, store_request, start_seq_id, current_seq_id, op_type, backup_type);
+        update_state_info(state);
+        if (ret < 0) {
+            state->error_code = error_code;
+            state->error_msg.swap(error_msg);
+            return -1;
+        }
+        return affected_rows.load();
+    }
+
+    void update_state_info(RuntimeState* state) {
+        state->region_count += region_count;
+        state->set_num_scan_rows(state->num_scan_rows() + scan_rows.load());
+        state->set_num_filter_rows(state->num_filter_rows() + filter_rows.load());
+    }
 
     template<typename Repeated>
-    void choose_opt_instance(int64_t region_id, Repeated&& peers, std::string& addr, std::string* backup) {
+    static void choose_opt_instance(int64_t region_id, Repeated&& peers, std::string& addr, pb::Status& addr_status, std::string* backup) {
         SchemaFactory* schema_factory = SchemaFactory::get_instance();
+        addr_status = pb::NORMAL;
         std::string baikaldb_logical_room = schema_factory->get_logical_room();
         if (baikaldb_logical_room.empty()) {
             return;
@@ -160,11 +444,11 @@ public:
                 addr = normal_peers[1];
             }
         } else {
+            addr_status = pb::FAULTY;
             DB_DEBUG("all peer faulty, %ld", region_id);
         }
     }
-    void choose_other_if_faulty(pb::RegionInfo& info, std::string& addr);
-    void other_normal_peer_to_leader(pb::RegionInfo& info, std::string& addr);
+
     bool need_process_binlog(RuntimeState* state, pb::OpType op_type) {
         if (op_type == pb::OP_PREPARE
             || op_type == pb::OP_COMMIT) {
@@ -178,6 +462,8 @@ public:
         }
         return false;
     }
+    static void choose_other_if_faulty(pb::RegionInfo& info, std::string& addr);
+    static void other_normal_peer_to_leader(pb::RegionInfo& info, std::string& addr);
     ErrorType process_binlog_start(RuntimeState* state, pb::OpType op_type);
     void process_binlog_done(RuntimeState* state, pb::OpType op_type) {
         binlog_cond.wait();
@@ -186,38 +472,39 @@ public:
                            const pb::OpType op_type,
                            const uint64_t log_id);
     int64_t get_commit_ts();
-    int memory_limit_exceeded(RuntimeState* state, MemRow* row);
-    void memory_limit_release(RuntimeState* state) {
-        state->memory_limit_release(used_bytes);
-        used_bytes = 0;
-    }
+    static int64_t get_dynamic_timeout_ms(ExecNode* store_request, pb::OpType op_type, uint64_t sign);
+
 public:
     std::map<int64_t, std::vector<SmartRecord>>  index_records; //key: index_id
     std::map<int64_t, std::shared_ptr<RowBatch>> region_batch;
     std::map<int64_t, std::shared_ptr<RowBatch>> split_region_batch;
-    bthread::Mutex  ttl_timestamp_mutex;
     std::map<int64_t, std::vector<int64_t>> region_id_ttl_timestamp_batch;
 
     std::multimap<std::string, int64_t> start_key_sort;
     std::multimap<std::string, int64_t> split_start_key_sort;
-    bthread_mutex_t region_lock;
+    bthread::Mutex region_lock;
     std::set<int64_t> skip_region_set;
-    ErrorType error = E_OK;
+    std::atomic<ErrorType> error = {E_OK};
     // 因为split会导致多region出来,加锁保护公共资源
     std::atomic<int64_t> row_cnt = {0};
     std::atomic<int64_t> affected_rows = {0};
     std::atomic<int64_t> scan_rows = {0};
     std::atomic<int64_t> filter_rows = {0};
-    std::atomic<int> analyze_fail_cnt = {0};
+    bool is_cancelled = false;
     BthreadCond binlog_cond;
     NetworkSocket* client_conn = nullptr;
     bool  binlog_prepare_success = false;
     bool  need_get_binlog_region = true;
-    std::atomic<int64_t> used_bytes = {0};
     std::atomic<bool> primary_timestamp_updated{false};
     std::set<int64_t> no_copy_cache_plan_set;
     int64_t dynamic_timeout_ms = -1;
     TimeCost binlog_prewrite_time;
+    LearnerStatus learner_status;
+    MysqlErrCode      error_code = ER_ERROR_FIRST;
+    std::ostringstream error_msg;
+    int32_t region_count = 0;
+    std::set<brpc::CallId> callids;
+    GlobalBackupType global_backup_type = GBT_INIT;
 };
 }
 

--- a/include/exec/index_ddl_manager_node.h
+++ b/include/exec/index_ddl_manager_node.h
@@ -40,7 +40,6 @@ public:
     }
 
 private:
-    FetcherStore    _fetcher_store;
     int64_t _table_id {0};
     int64_t _index_id {0};
     std::string _task_id;

--- a/include/exec/insert_manager_node.h
+++ b/include/exec/insert_manager_node.h
@@ -60,8 +60,6 @@ public:
         _on_dup_key_update_records.clear();
         _record_ids.clear();
         _index_keys_record_map.clear();
-        _insert_scan_records.clear();
-        _del_scan_records.clear();
         _seq_ids.clear();
         _primary_record_key_record_map_construct = false;
         _primary_record_key_record_map.clear();
@@ -139,7 +137,7 @@ public:
     }
 
 private:
-    void update_record(SmartRecord record);
+    void update_record(const SmartRecord& record, const SmartRecord& origin_record);
     int64_t     _table_id = -1;
     int32_t     _tuple_id = -1;
     int32_t     _values_tuple_id = -1;
@@ -154,17 +152,17 @@ private:
     std::vector<ExprNode*>            _update_exprs;
     std::vector<pb::SlotDescriptor>   _update_slots;
     std::vector<ExprNode*>   _insert_values;
-    std::vector<SmartRecord> _origin_records;
+    std::vector<SmartRecord> _origin_records;  // insert的数据
+    std::set<int32_t>            _record_ids; // 对应的_origin_records的下标
+    // index_id -> <key->record_id>
+    std::map<int64_t, std::map<std::string, std::set<int32_t>>> _index_keys_record_map;
+    std::map<int64_t, SmartIndex> _index_info_map;
     // index_id -> records
     std::map<int64_t, std::vector<SmartRecord>> _store_records;
     /* on_dup_key_update冲突时更新的是原表数据，_on_dup_key_update_records保存原表记录
        index_id -> <key -> record> 
     */
     std::map<int64_t, std::map<std::string, SmartRecord>> _on_dup_key_update_records;
-    std::set<int32_t>            _record_ids;
-    // index_id -> <key->record_id>
-    std::map<int64_t, std::map<std::string, std::set<int32_t>>> _index_keys_record_map;
-    std::map<int64_t, SmartIndex> _index_info_map;
 
     std::vector<int32_t>     _selected_field_ids;
 

--- a/include/exec/rocksdb_scan_node.h
+++ b/include/exec/rocksdb_scan_node.h
@@ -56,9 +56,6 @@ public:
         } 
         return false;
     }
-    std::map<int64_t, pb::PossibleIndex>* mutable_region_primary() {
-        return &_region_primary;
-    }
     void set_related_manager_node(SelectManagerNode* manager_node) {
         _related_manager_node = manager_node;
     }
@@ -71,12 +68,6 @@ public:
         for (auto& expr : _index_conjuncts) {
             expr->find_place_holder(placeholders);
         }
-    }
-    void add_index_id(int64_t index_id) {
-        _index_ids.push_back(index_id);
-    }
-    const std::vector<int64_t>& index_ids() {
-        return _index_ids;
     }
 
     int32_t get_partition_field() {
@@ -116,8 +107,6 @@ private:
         return false;
     }
 
-    int memory_limit_exceeded(RuntimeState* state, RowBatch* batch);
-
 private:
     std::map<int32_t, FieldInfo*> _field_ids;
     std::vector<int32_t> _filt_field_ids;
@@ -132,9 +121,6 @@ private:
     bool _is_ddl_work = false;
     int64_t _ddl_index_id = -1;
 
-    //record all used indices here (LIKE & MATCH may use multiple indices)
-    std::vector<int64_t> _index_ids;
-
     // 如果用了排序列做索引，就不需要排序了
     bool _sort_use_index = false;
     bool _scan_forward = true; //scan的方向
@@ -142,11 +128,14 @@ private:
     //被选择的索引
     std::vector<SmartRecord> _left_records;
     std::vector<SmartRecord> _right_records;
+    std::vector<MutTableKey> _left_keys;
+    std::vector<MutTableKey> _right_keys;
     std::vector<int> _left_field_cnts;
     std::vector<int> _right_field_cnts;
     std::vector<bool> _left_opens;
     std::vector<bool> _right_opens;
     std::vector<bool> _like_prefixs;
+    bool _use_encoded_key = false;
     // trace使用
     int _scan_rows = 0;
     size_t _idx = 0;
@@ -169,7 +158,6 @@ private:
     MutilReverseIndex<ArrowSchema> _m_arrow_index;
     bool _bool_and = false;
 
-    std::map<int64_t, pb::PossibleIndex> _region_primary;
     std::map<int32_t, int32_t> _index_slot_field_map;
     pb::StorageType _storage_type = pb::ST_UNKNOWN;
     std::vector<int64_t> _partitions {0};

--- a/include/exec/scan_node.h
+++ b/include/exec/scan_node.h
@@ -46,6 +46,150 @@ using IndexFieldRange = std::pair<int64_t, range::FieldRange>;
 using FulltextInfoTree = FulltextTree<pb::FulltextNodeType, IndexFieldRange>;
 using FulltextInfoNode = FulltextNode<pb::FulltextNodeType, IndexFieldRange>;
 
+class AccessPathMgr {
+public:
+    AccessPathMgr() { }
+    ~AccessPathMgr() { }
+
+    int init(int64_t table_id) {
+        _table_id = table_id;
+        return 0;
+    }
+
+    void add_access_path(const SmartPath& access_path) {
+        //如果使用倒排索引，则不使用代价进行索引选择
+        if ((access_path->index_type == pb::I_FULLTEXT) 
+            && access_path->is_possible) {
+            _use_fulltext = true;
+        }
+
+        if (access_path->index_info_ptr->index_hint_status == pb::IHS_DISABLE 
+            && access_path->is_possible) {
+            _has_disable_index = true;
+        }
+
+        if (access_path->hint == AccessPath::FORCE_INDEX 
+            && access_path->is_possible) {
+            _use_force_index = true;
+        }
+
+        if (access_path->is_possible) {
+            _possible_indexs.insert(access_path->index_id);
+        }
+
+        _paths[access_path->index_id] = access_path;
+    }
+
+    void delete_possible_index(int64_t index_id) {
+        _possible_indexs.erase(index_id);
+    }
+
+    void reset() {
+        _use_fulltext = false;
+        _has_disable_index = false;
+        _use_force_index = false;
+        // 重置is_possible状态，只有此状态会在预处理时修改
+        for (auto& pair : _paths) {
+            auto& path = pair.second;
+            path->is_possible = false;
+            if (_possible_indexs.count(path->index_id) > 0) {
+                path->is_possible = true;
+            }
+
+            if ((path->index_type == pb::I_FULLTEXT) 
+                && path->is_possible) {
+                _use_fulltext = true;
+            }
+
+            if (path->index_info_ptr->index_hint_status == pb::IHS_DISABLE 
+                && path->is_possible) {
+                _has_disable_index = true;
+            }
+
+            if (path->hint == AccessPath::FORCE_INDEX 
+                && path->is_possible) {
+                _use_force_index = true;
+            }
+        }
+        _multi_reverse_index.clear();
+        _possible_index_cnt = 0;
+        _cover_index_cnt = 0;
+        _fulltext_use_arrow = false;
+    }
+
+    void clear() {
+        _possible_indexs.clear();
+        _paths.clear();
+        _multi_reverse_index.clear();
+        _use_fulltext = false;
+        _possible_index_cnt = 0;
+        _cover_index_cnt = 0;
+        _fulltext_use_arrow = false;
+    }
+
+    std::map<int64_t, SmartPath>& paths() {
+        return _paths;
+    }
+
+    SmartPath path(int64_t index_id) {
+        return _paths[index_id];
+    }
+
+    std::vector<int64_t> multi_reverse_index() {
+        return _multi_reverse_index;
+    }
+
+    bool fulltext_use_arrow() const {
+        return _fulltext_use_arrow;
+    }
+
+    bool has_disable_index() const {
+        return _has_disable_index;
+    }
+
+    void show_cost(std::vector<std::map<std::string, std::string>>& path_infos);
+
+    int64_t select_index(); 
+private:
+    int compare_two_path(SmartPath& outer_path, SmartPath& inner_path);
+    void inner_loop_and_compare(std::map<int64_t, SmartPath>::iterator outer_loop_iter);
+    // 两两比较，根据一些简单规则干掉次优索引
+    int64_t pre_process_select_index();
+
+    int choose_arrow_pb_reverse_index();
+
+    int64_t select_index_common(); 
+    int64_t select_index_by_cost();
+private:
+    std::set<int64_t> _possible_indexs; // reset时，重置possible的index
+    std::map<int64_t, SmartPath> _paths;
+    std::vector<int64_t> _multi_reverse_index;
+    std::map<int32_t, double> _filed_selectiy; //缓存，避免重复的filed_id多次调用代价接口
+    int64_t _table_id = 0;
+    bool _use_fulltext = false;
+    bool _has_disable_index = false;
+    bool _use_force_index = false;
+    int32_t _possible_index_cnt = 0;
+    int32_t _cover_index_cnt = 0;
+    bool _fulltext_use_arrow = false;
+};
+
+struct ScanIndexInfo {
+    enum IndexUseFor {
+        U_INIT = 0,
+        U_GLOBAL_LEARNER, // 
+        U_LOCAL_LEARNER
+    };
+    bool covering_index = false;
+    IndexUseFor use_for = U_INIT;
+    int64_t router_index_id = 0;
+    int64_t index_id = 0;
+    pb::PossibleIndex* router_index = nullptr;
+    std::string raw_index;
+    std::map<int64_t, pb::RegionInfo> region_infos;
+    std::map<int64_t, std::string> region_primary;
+};
+
 class ScanNode : public ExecNode {
 public:
     ScanNode() {
@@ -64,20 +208,9 @@ public:
     int32_t tuple_id() const {
         return _tuple_id;
     }
-    void set_router_index_id(int64_t router_index_id) {
-        _router_index_id = router_index_id;
-    }
-    int64_t router_index_id() const {
-        return _router_index_id;
-    }
+
     void set_covering_index(bool covering_index) {
         _is_covering_index = covering_index;
-    }
-    bool covering_index() const {
-        return _is_covering_index;
-    }
-    pb::PossibleIndex* router_index() const {
-        return _router_index;
     }
 
     void set_router_policy(RouterPolicy rp) {
@@ -88,9 +221,6 @@ public:
         return _router_policy;
     }
 
-    void set_router_index(pb::PossibleIndex* router_index) {
-        _router_index = router_index;
-    }
     const google::protobuf::RepeatedPtrField<pb::RegionInfo>& old_region_infos() {
         return _old_region_infos;
     }
@@ -100,25 +230,68 @@ public:
     pb::Engine engine() {
         return _engine;
     }
-    bool has_index() {
-        for (auto& pos_index : _pb_node.derive_node().scan_node().indexes()) {
-            for (auto& range : pos_index.ranges()) {
-                if (range.left_field_cnt() > 0) {
-                    return true;
-                }
-                if (range.right_field_cnt() > 0) {
-                    return true;
-                }
-                if (pos_index.has_sort_index()) {
-                    return true;
-                }
+
+    bool has_index() const {
+        return _has_index;
+    }
+
+    std::vector<ScanIndexInfo>& scan_indexs() {
+        return _scan_indexs;
+    }
+
+    ScanIndexInfo* main_scan_index() {
+        if (_scan_indexs.empty()) {
+            return nullptr;
+        }
+        return &_scan_indexs[0];
+    }
+
+    ScanIndexInfo* backup_scan_index() {
+        if (_scan_indexs.empty()) {
+            return nullptr;
+        }
+        for (auto& scan_index_info : _scan_indexs) {
+            if (scan_index_info.use_for == ScanIndexInfo::U_GLOBAL_LEARNER) {
+                return &scan_index_info;
             }
         }
-        return false;
+        return nullptr;
     }
+
+    void serialize_index_and_set_router_index(const pb::PossibleIndex& pos_index, pb::PossibleIndex* router_index, bool covering_index,
+                ScanIndexInfo::IndexUseFor use_for = ScanIndexInfo::U_INIT) {
+        ScanIndexInfo index;
+        pos_index.SerializeToString(&index.raw_index);
+        index.covering_index = covering_index;
+        index.router_index_id = router_index->index_id();
+        index.router_index = router_index;
+        index.index_id = pos_index.index_id();
+        index.use_for = use_for;
+        _scan_indexs.emplace_back(std::move(index));
+        bool has_index = false;
+        for (auto& range : pos_index.ranges()) {
+            if (range.left_field_cnt() > 0) {
+                has_index = true;
+                break;
+            }
+            if (range.right_field_cnt() > 0) {
+                has_index = true;
+                break;
+            }
+            if (pos_index.has_sort_index()) {
+                has_index = true;
+                break;
+            }
+        }
+        _has_index = _has_index || has_index;
+    }
+
     void clear_possible_indexes() {
-        _paths.clear();
+        _main_path.clear();
+        _learner_path.clear();
+        _scan_indexs.clear();
         _pb_node.mutable_derive_node()->mutable_scan_node()->clear_indexes();
+        _pb_node.mutable_derive_node()->mutable_scan_node()->clear_learner_index();
     }
     bool need_copy(MemRow* row, std::vector<ExprNode*>& conjuncts) {
         for (auto conjunct : conjuncts) {
@@ -133,37 +306,23 @@ public:
         ExecNode::find_place_holder(placeholders);
     }
 
-    void show_cost(std::vector<std::map<std::string, std::string>>& path_infos);
-    int64_t select_index(); 
-    int64_t select_index_by_cost(); 
-    int64_t select_index_in_baikaldb(const std::string& sample_sql);
-    int choose_arrow_pb_reverse_index();
-    virtual void show_explain(std::vector<std::map<std::string, std::string>>& output);
+    void show_cost(std::vector<std::map<std::string, std::string>>& path_infos) {
+        _main_path.show_cost(path_infos);
+    }
 
     void add_access_path(const SmartPath& access_path) {
-        //如果使用倒排索引，则不使用代价进行索引选择
-        if ((access_path->index_type == pb::I_FULLTEXT) 
-            && access_path->is_possible) {
-            _use_fulltext = true;
+        if (access_path->index_info_ptr->index_hint_status != pb::IHS_DISABLE) {
+            //disable之后不用于主集群选索引
+            _main_path.add_access_path(access_path);
         }
-        if (access_path->is_virtual) {
-            _use_virtual_index =  true;
+        if (access_path->need_add_to_learner_paths()) {
+            _learner_path.add_access_path(access_path);
         }
-        if (access_path->hint == AccessPath::FORCE_INDEX) {
-            _use_force_index =  true;
-        }
-        _paths[access_path->index_id] = access_path;
     }
 
-    size_t access_path_size() const {
-        return _paths.size();
-    }
-
-    bool full_coverage(const std::unordered_set<int32_t>& smaller, const std::unordered_set<int32_t>& bigger);
-
-    int compare_two_path(const SmartPath& outer_path, const SmartPath& inner_path);
-
-    void inner_loop_and_compare(std::map<int64_t, SmartPath>::iterator outer_loop_iter);
+    int64_t select_index_in_baikaldb(const std::string& sample_sql);
+    
+    virtual void show_explain(std::vector<std::map<std::string, std::string>>& output);
 
     void set_fulltext_index_tree(const FulltextInfoTree& tree) {
         _fulltext_index_tree = tree;
@@ -171,32 +330,52 @@ public:
 
     int create_fulltext_index_tree(FulltextInfoNode* node, pb::FulltextIndex* root);
     int create_fulltext_index_tree();
+    bool learner_use_diff_index() const {
+        return _learner_use_diff_index;
+    }
 
-// 两两比较，根据一些简单规则干掉次优索引
-    int64_t pre_process_select_index();
+    void set_index_useage_and_lock(bool use_global_backup) {
+        // 只有在存在global backup的时候才加锁
+        for (auto& scan_index_info : _scan_indexs) {
+            if (scan_index_info.use_for == ScanIndexInfo::U_GLOBAL_LEARNER) {
+                _current_index_mutex.lock();
+                _current_global_backup = use_global_backup;
+                break;
+            }
+        }
+    }
+
+    void current_index_unlock() {
+        for (auto& scan_index_info : _scan_indexs) {
+            if (scan_index_info.use_for == ScanIndexInfo::U_GLOBAL_LEARNER) {
+                _current_index_mutex.unlock();
+                break;
+            }
+        }
+    }
+
+    bool current_use_global_backup() const {
+        return _current_global_backup;
+    }
     
 protected:
     pb::Engine _engine = pb::ROCKSDB;
     int32_t _tuple_id = 0;
     int64_t _table_id = -1;
-    int64_t _router_index_id = -1;
-    std::map<int64_t, SmartPath> _paths;
-    std::vector<int64_t> _multi_reverse_index;
+    AccessPathMgr _main_path;    //主集群索引选择
+    AccessPathMgr _learner_path; //learner集群索引选择
+    bool _learner_use_diff_index = false;
     pb::TupleDescriptor* _tuple_desc = nullptr;
-    pb::PossibleIndex* _router_index = nullptr;
-    bool _is_covering_index = true;
-    bool _use_fulltext = false;
-    bool _use_virtual_index = false;
-    bool _use_force_index = false;
-    int32_t _possible_index_cnt = 0;
-    int32_t _cover_index_cnt = 0;
-    std::map<int32_t, double> _filed_selectiy; //缓存，避免重复的filed_id多次调用代价接口
+    bool _is_covering_index = true; // 只有store会用
+    bool _has_index = false;
     pb::LockCmdType _lock = pb::LOCK_NO;
     RouterPolicy _router_policy = RouterPolicy::RP_RANGE;
     google::protobuf::RepeatedPtrField<pb::RegionInfo> _old_region_infos;
     FulltextInfoTree _fulltext_index_tree; //目前只有两层，第一层为and，第二层为or。
     std::unique_ptr<pb::FulltextIndex> _fulltext_index_pb;
-    bool _fulltext_use_arrow = false;
+    std::vector<ScanIndexInfo> _scan_indexs;
+    bthread::Mutex _current_index_mutex;
+    bool _current_global_backup = false;
 };
 }
 

--- a/include/expr/agg_fn_call.h
+++ b/include/expr/agg_fn_call.h
@@ -60,7 +60,7 @@ public:
     bool is_initialize(const std::string& key, MemRow* dst);
     // 聚合函数逻辑
     // 初始化分配内存
-    int initialize(const std::string& key, int64_t& used_size, MemRow* dst);
+    int initialize(const std::string& key, MemRow* dst);
     // update每次更新一行
     int update(const std::string& key, MemRow* src, MemRow* dst);
     // merge表示store预聚合后，最终merge到一起
@@ -81,10 +81,9 @@ public:
 
     static void initialize_all(std::vector<AggFnCall*>& agg_calls,
             const std::string& key,
-            int64_t& used_size,
             MemRow* dst) {
         for (auto call : agg_calls) {
-            call->initialize(key, used_size, dst);
+            call->initialize(key, dst);
         }
     }
     static void update_all(std::vector<AggFnCall*>& agg_calls, const std::string& key, MemRow* src, MemRow* dst) {

--- a/include/expr/internal_functions.h
+++ b/include/expr/internal_functions.h
@@ -153,6 +153,8 @@ ExprValue tdigest_location(const std::vector<ExprValue>& input);
 // other
 ExprValue version(const std::vector<ExprValue>& input);
 ExprValue last_insert_id(const std::vector<ExprValue>& input);
+//transfer (latitude A, longitude A), (latitude B, longitude B) to distance of A to B (m)
+ExprValue point_distance(const std::vector<ExprValue>& input);
 ExprValue cast_to_date(const std::vector<ExprValue>& inpt);
 ExprValue cast_to_time(const std::vector<ExprValue>& inpt);
 ExprValue cast_to_datetime(const std::vector<ExprValue>& inpt);

--- a/include/expr/literal.h
+++ b/include/expr/literal.h
@@ -124,6 +124,10 @@ public:
         return 0;
     }
 
+    int64_t used_size() override {
+        return sizeof(*this) + _value.size();
+    }
+
     virtual bool is_place_holder() {
         return _is_place_holder;
     }

--- a/include/expr/scalar_fn_call.h
+++ b/include/expr/scalar_fn_call.h
@@ -113,7 +113,6 @@ private:
         }
         return ExprValue::True();
     }
-
 protected:
     pb::Function _fn;
     bool _is_row_expr = false;

--- a/include/logical_plan/ddl_planner.h
+++ b/include/logical_plan/ddl_planner.h
@@ -41,7 +41,19 @@ private:
     int add_constraint_def(pb::SchemaInfo& table, parser::Constraint* constraint,parser::AlterTableSpec* spec);
     bool is_fulltext_type_constraint(pb::StorageType pb_storage_type, bool& has_arrow_type, bool& has_pb_type) const;
     pb::PrimitiveType to_baikal_type(parser::FieldType* field_type);
-
+    int parse_pre_split_keys(std::string split_start_key,
+                             std::string split_end_key,
+                             std::string global_start_key,
+                             std::string global_end_key,
+                             int32_t split_region_num, pb::SchemaInfo& table);
+    int pre_split_index(const std::string& start_key,
+                        const std::string& end_key,
+                        int32_t region_num,
+                        pb::SchemaInfo& table,
+                        const pb::IndexInfo* pk_index,
+                        const pb::IndexInfo* index,
+                        const std::vector<const pb::FieldInfo*>& pk_fields,
+                        const std::vector<const pb::FieldInfo*>& index_fields);
     std::map<std::string, bool> _column_can_null;
 };
 } //namespace baikal

--- a/include/logical_plan/ddl_work_planner.h
+++ b/include/logical_plan/ddl_work_planner.h
@@ -66,6 +66,7 @@ private:
     int64_t _table_id = 0;
     int64_t _index_id = 0;
     QueryContext* _ctx = nullptr;
+    bool    _ddl_pk_key_is_full = true;
     std::string _start_key;
     std::string _end_key;
     std::string _router_start_key;
@@ -77,6 +78,7 @@ private:
     int64_t _partition_id = 0;
     std::string _task_id;
     int32_t _field_num = 0;
+    pb::PossibleIndex _pos_index;
 };
     
 } // namespace baikaldb

--- a/include/logical_plan/logical_planner.h
+++ b/include/logical_plan/logical_planner.h
@@ -271,6 +271,8 @@ protected:
     void plan_commit_and_begin_txn();
     void plan_rollback_and_begin_txn();
 
+    int generate_sql_sign(const pb::Plan& plan, QueryStat* stat_info, parser::StmtNode* stmt, bool* need_learner_backup);
+
 private:
     int create_n_ary_predicate(const parser::FuncExpr* item, 
             pb::Expr& expr,
@@ -279,7 +281,7 @@ private:
     int create_in_predicate(const parser::FuncExpr* func_item, 
             pb::Expr& expr,
             const CreateExprOptions& options);
-    int exec_subquery_expr(QueryContext* sub_ctx);
+    int exec_subquery_expr(QueryContext* sub_ctx, QueryContext* ctx);
     int create_common_subquery_expr(const parser::SubqueryExpr* item, pb::Expr& expr,
             const CreateExprOptions& options, bool& is_correlate);
     int handle_in_subquery(const parser::FuncExpr* func_item,
@@ -304,6 +306,7 @@ private:
 
 protected:
     QueryContext*       _ctx = nullptr;
+    std::shared_ptr<QueryContext> _cur_sub_ctx = nullptr;
     SmartPlanTableCtx      _plan_table_ctx;
     SchemaFactory*      _factory = nullptr;
 

--- a/include/mem_row/mem_row.h
+++ b/include/mem_row/mem_row.h
@@ -70,7 +70,9 @@ public:
 
     void clear() {
         for (auto& t : _tuples) {
-            t->Clear();
+            if (t != nullptr) {
+                t->Clear();
+            }
         }
         std::fill(_tuples_assignd.begin(), _tuples_assignd.end(), false);
         _used_size = 0;
@@ -134,7 +136,7 @@ public:
     }
 
     int64_t byte_size_long() {
-        int64_t used_size = 9 * _tuples.size() + sizeof(MemRow);
+        int64_t used_size = 9 * _tuples.size() + sizeof(*this);
         for (auto& t : _tuples) {
             if (t != nullptr) {
                 used_size += t->ByteSizeLong();
@@ -148,7 +150,8 @@ public:
     }
 
     int64_t used_size() const {
-        return _used_size + 9 * _tuples.size() + sizeof(MemRow);
+        // 1.5系数为内存消耗估值，MemRow与string转换消耗
+        return _used_size * 1.5 + 9 * _tuples.size() + sizeof(*this);
     }
 
 private:

--- a/include/meta_server/query_region_manager.h
+++ b/include/meta_server/query_region_manager.h
@@ -39,6 +39,7 @@ public:
     void send_transfer_leader(const pb::QueryRequest* request, pb::QueryResponse* response);
     void send_set_peer(const pb::QueryRequest* request, pb::QueryResponse* response);
     void get_region_peer_status(const pb::QueryRequest* request, pb::QueryResponse* response);
+    void get_region_learner_status(const pb::QueryRequest* request, pb::QueryResponse* response);
     void send_remove_region_request(std::string instance_address, int64_t region_id);
     void check_region_and_update(
             const std::unordered_map<int64_t, pb::RegionHeartBeat>&  

--- a/include/meta_server/region_manager.h
+++ b/include/meta_server/region_manager.h
@@ -69,7 +69,7 @@ public:
     // default for DEAD
     void delete_all_region_for_store(const std::string& instance, InstanceStateInfo status);
 
-    void remove_all_learner_for_store(const std::string& instance, const std::vector<int64_t>& learner_ids);
+    void add_all_learner_for_store(const std::string& instance, const std::vector<int64_t>& learner_ids);
     void pre_process_remove_peer_for_store(const std::string& instance,
                                                 pb::Status status, std::vector<pb::RaftControlRequest>& requests); 
     void pre_process_add_peer_for_store(const std::string& instance, pb::Status status,
@@ -252,9 +252,11 @@ public:
     }
 
     void remove_error_peer(const int64_t region_id,
+                                const std::set<std::string>& resource_tags,
                                 std::set<std::string> peers,
                                 std::vector<pb::PeerStateInfo>& recover_region_way);
     void remove_illegal_peer(const int64_t region_id,
+                                const std::set<std::string>& resource_tags,
                                 std::set<std::string> peers,
                                 std::vector<pb::PeerStateInfo>& recover_region_way);
     void recovery_single_region_by_set_peer(const int64_t region_id,
@@ -488,6 +490,7 @@ public:
                          pb::BaikalHeartBeatResponse* response, int64_t applied_index); 
     
     void send_add_learner_request(const std::vector<std::pair<std::string, pb::InitRegion>>& requests);
+    bool check_table_in_resource_tags(int64_t table_id, const std::set<std::string>& resource_tags);
     
 private:
     RegionManager(): _max_region_id(0) {

--- a/include/physical_plan/separate.h
+++ b/include/physical_plan/separate.h
@@ -82,6 +82,8 @@ private:
             const std::vector<int64_t>& local_affected_indexs, 
             ExecNode* manager_node);
 
+    int create_full_export_node(ExecNode* plan);
+
     SelectManagerNode* create_select_manager_node();
     bool need_separate_single_txn(QueryContext* ctx, const int64_t main_table_id);
     bool need_separate_plan(QueryContext* ctx, const int64_t main_table_id); 

--- a/include/protocol/show_helper.h
+++ b/include/protocol/show_helper.h
@@ -51,6 +51,7 @@ const std::string SQL_SHOW_DIFF_REGION_SIZE      = "diff_region_size";      // s
 const std::string SQL_SHOW_NETWORK_SEGMENT       = "network_segment";       // show network_segment resourceTag;
 const std::string SQL_SHOW_SWITCH                = "switch";                // show switch
 const std::string SQL_SHOW_ALL_TABLES            = "all_tables";            // show all_tables [ttl/binlog/...]
+const std::string SQL_SHOW_INSTANCE_PARAM        = "instance_param";        // show instance_param [resource_tag/instance]
 
 namespace baikaldb {
 typedef std::shared_ptr<NetworkSocket> SmartSocket;
@@ -128,6 +129,8 @@ private:
     bool _show_network_segment(const SmartSocket& client, const std::vector<std::string>& split_vec);
     // sql: show switch
     bool _show_switch(const SmartSocket& client, const std::vector<std::string>& split_vec);
+    // sql: show instance_param ResourceTag / Instance
+    bool _show_instance_param(const SmartSocket& client, const std::vector<std::string>& split_vec);
     bool _handle_client_query_template_dispatch(const SmartSocket& client, const std::vector<std::string>& split_vec);
     int _make_common_resultset_packet(const SmartSocket& sock, 
             std::vector<ResultField>& fields,

--- a/include/sqlparser/ddl.h
+++ b/include/sqlparser/ddl.h
@@ -110,6 +110,12 @@ enum ConstraintType : unsigned char {
     CONSTRAINT_FULLTEXT
 };
 
+enum IndexDistibuteType : unsigned char {
+    INDEX_DIST_DEFAULT = 0,
+    INDEX_DIST_LOCAL,
+    INDEX_DIST_GLOBAL
+};
+
 enum TableOptionType : unsigned char {
     TABLE_OPT_NONE = 0,
     TABLE_OPT_ENGINE,
@@ -142,7 +148,7 @@ enum DatabaseOptionType : unsigned char {
 // https://dev.mysql.com/doc/refman/8.0/en/alter-table.html
 enum AlterSpecType : unsigned char {
     ALTER_SPEC_ADD_COLUMN = 0,   // only support add column at the tail
-    ALTER_SPEC_ADD_INDEX,        // not supported yet
+    ALTER_SPEC_ADD_INDEX,        
     ALTER_SPEC_ADD_CONSTRAINT,
     ALTER_SPEC_ADD_FULLTEXT,
 
@@ -262,7 +268,7 @@ struct Constraint : public Node {
     Vector<ColumnName*> columns;  // Used for PRIMARY KEY, KEY, UNIQUE, FULLTEXT
     // ReferenceDef*   refer = nullptr;    // Used for foreign key.
     IndexOption* index_option = nullptr;
-    bool            global = false;
+    IndexDistibuteType index_dist = INDEX_DIST_DEFAULT;
 
     Constraint() {
         node_type = NT_CONSTRAINT;

--- a/include/store/backup.h
+++ b/include/store/backup.h
@@ -114,7 +114,8 @@ private:
 
     int upload_sst_info_streaming(
         brpc::StreamId sd, std::shared_ptr<StreamReceiver> receiver, 
-        bool ingest_store_latest_sst, const BackupInfo& backup_info, SmartRegion region_ptr);
+        bool ingest_store_latest_sst, int64_t data_sst_to_process_size,
+        const BackupInfo& backup_info, SmartRegion region_ptr, brpc::StreamId client_sd = 0);
 
     template<typename WritePolicy>
     int send_file(BackupInfo& backup_info, WritePolicy* pa, int64_t log_index) {

--- a/include/store/rpc_sender.h
+++ b/include/store/rpc_sender.h
@@ -24,7 +24,7 @@ public:
                             int64_t recevie_region_id,
                             int64_t request_version);
 
-    static void get_peer_applied_index(const std::string& peer, int64_t region_id,
+    static int get_peer_applied_index(const std::string& peer, int64_t region_id,
                             int64_t& applied_index, int64_t& dml_latency);
     static void get_peer_snapshot_size(const std::string& peer, int64_t region_id, 
             uint64_t* data_size, uint64_t* meta_size, int64_t* snapshot_index);

--- a/include/store/store.h
+++ b/include/store/store.h
@@ -141,8 +141,12 @@ public:
     virtual void backup(google::protobuf::RpcController* controller,
         const pb::BackupRequest* request,
         pb::BackupResponse* response,
-        google::protobuf::Closure* done); 
+        google::protobuf::Closure* done);
 
+    virtual void get_rocks_statistic(google::protobuf::RpcController* controller,
+                                     const pb::RocksStatisticReq* request,
+                                     pb::RocksStatisticRes* response,
+                                     google::protobuf::Closure* done);
     //上报心跳
     void heart_beat_thread();
 

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -35,6 +35,8 @@ enum ErrCode {
     RETRY_LATER  = 28;
     LESS_THAN_OLDEST_TS  = 29;
     IN_PROCESS   = 30;
+    STORE_BUSY   = 31;
+    LEARNER_NOT_READY = 32;
 };
 
 enum PrimitiveType {
@@ -81,6 +83,13 @@ enum BackupTable {
     BT_LEARNER = 4;
 };
 
+enum StreamState {
+    SS_INIT = 0;
+    SS_PROCESSING = 1;
+    SS_SUCCESS = 2;
+    SS_FAIL = 3;
+};
+
 message SchemaConf {
     optional bool need_merge                = 1;
     optional bool storage_compute_separate  = 2; 
@@ -90,6 +99,7 @@ message SchemaConf {
     optional float filter_ratio             = 6;
     optional BackupTable backup_table       = 7;
     optional int32 pk_prefix_balance        = 8;
+    optional bool in_fast_import            = 9;  // 快速导入中，不调度，不分裂
 };
 
 enum Engine {
@@ -112,7 +122,7 @@ message SlotDescriptor {
 
 //tuple可以与table对应，也可以是中间表达式和聚合结果
 message TupleDescriptor {
-    required int32 tuple_id = 1;
+    required int32 tuple_id = 1; //从0开始
     optional int64 table_id = 2; //与表映射才填
     repeated SlotDescriptor slots = 3; 
 };

--- a/proto/meta.interface.proto
+++ b/proto/meta.interface.proto
@@ -36,6 +36,7 @@ enum Status {
     MIGRATE= 4; // 迁移状态，该状态不能被改变，后续只能删除该实例
     FULL   = 5;
     SLOW   = 6; // 同集群比其他实例慢很多
+    BUSY   = 7;
 };
 enum RegionStatus {
     IDLE = 1;
@@ -291,7 +292,7 @@ message PhysicalRoom {
 };
 
 message InstanceInfo {
-    required string address         = 1;
+    optional string address         = 1;
     optional int64 capacity         = 2;
     //第一次上报心跳的时候需要填该参数
     //实际该参数并不需要存储
@@ -402,10 +403,11 @@ message ParamDesc {
     optional string key     = 1;
     optional string value   = 2; // 为通用，使用string，如果使用其他类型需要自己转成string
     optional bool is_meta_param = 3; //true则meta使用，store不需要更新本地配置
+    optional bool need_delete   = 4; //需要删除
 };
 
 message InstanceParam {
-    optional string          resource_tag_or_address    = 1;
+    optional string          resource_tag_or_address    = 1; // 警告！！！db和store共用这个存储结构，后续如果db也使用resource_tag需要确保和store resource_tag不同
     repeated ParamDesc       params                     = 2;
 };
 
@@ -583,14 +585,13 @@ message BaikalSchemaHeartBeat {
     required int64 table_id             = 1;
     required int64 version              = 2;
     repeated RegionHeartBeat regions    = 3;
-    optional int64 statis_version       = 4;
 };
 
 message BaikalHeartBeatRequest {
     //物理机房和逻辑机房对应关系
     repeated BaikalSchemaHeartBeat schema_infos    = 1;
     optional int64        last_updated_index       = 2;
-    optional bool         not_need_statistics      = 3; // meta能识别到时，说明baikaldb已经升级，不再通过该心跳更新统计信息
+    // optional bool         not_need_statistics      = 3; // meta能识别到时，说明baikaldb已经升级，不再通过该心跳更新统计信息
     repeated RegionDdlWork region_ddl_works        = 4;
     repeated DdlWorkInfo  ddl_works                = 5;
     optional bool can_do_ddlwork                   = 6;
@@ -605,6 +606,7 @@ message BaikalOtherHeartBeat {
 
 message BaikalOtherHeartBeatRequest {
     repeated BaikalOtherHeartBeat schema_infos    = 1;
+    optional string baikaldb_resource_tag         = 2;
 };
 
 message BaikalOtherHeartBeatResponse {
@@ -612,6 +614,7 @@ message BaikalOtherHeartBeatResponse {
     optional string errmsg                        = 2;
     optional string leader                        = 3;
     repeated Statistics   statistics              = 4;
+    optional InstanceParam instance_param         = 5; // baikaldb动态参数
 };
 
 message IdcInfo {
@@ -661,6 +664,7 @@ enum QueryOpType {
     QUERY_NETWORK_SEGMENT                         = 307;
     QUERY_RESOURCE_TAG_SWITCH                     = 308;
     QUERY_SHOW_VIRINDX_INFO_SQL                   = 309;//展示虚拟索引的影响   
+    QUERY_REGION_LEARNER_STATUS                   = 310;
 };
 
 message PhysicalInstance {

--- a/proto/plan.proto
+++ b/proto/plan.proto
@@ -84,6 +84,10 @@ message PossibleIndex {
         optional bool right_open = 8;
         optional bool like_prefix = 9;
         optional MatchMode match_mode = 10;
+        optional bytes left_key = 11;
+        optional bytes right_key = 12;
+        optional bool  left_full = 13;
+        optional bool  right_full = 14;
     };
 
     message SortIndex {
@@ -99,6 +103,7 @@ message PossibleIndex {
     optional SortIndex sort_index = 4;
     optional bool bool_and = 5;
     optional bool is_covering_index = 6;
+    optional bool use_for_learner = 7;
 };
 
 enum FulltextNodeType {
@@ -116,7 +121,7 @@ message FulltextIndex {
 message ScanNode {
     required int32 tuple_id = 1;  //tuple中记录有读取列信息与table信息
     required int64 table_id = 2;
-    repeated PossibleIndex indexes = 3; //baikal列举可能的index，region自己决定用哪个
+    repeated bytes indexes = 3; //baikal列举可能的index，region自己决定用哪个
     repeated int64 use_indexes = 4;
     optional Engine engine = 5;
     repeated int64 ignore_indexes = 6;
@@ -125,6 +130,7 @@ message ScanNode {
     optional bool is_ddl_work = 9;
     optional int64 ddl_index_id = 10;
     repeated int64 force_indexes = 11;
+    optional bytes learner_index = 12;
 };
 
 message LimitNode {
@@ -149,6 +155,7 @@ message AggNode {
 
 message FilterNode {
     repeated Expr conjuncts = 1; //and分开的条件
+    repeated Expr conjuncts_learner = 2; //and分开的条件，learner集群可能和主集群使用索引不同
 };
 
 enum JoinType {
@@ -303,7 +310,7 @@ message DerivePlanNode {
     optional ScanNode scan_node = 1;
     optional SortNode sort_node = 2;
     optional AggNode agg_node = 3;
-    optional FilterNode filter_node = 4;
+    optional bytes filter_node = 4;
     optional JoinNode join_node = 5;
     optional InsertNode insert_node = 6;
     optional DeleteNode delete_node = 7;
@@ -319,6 +326,7 @@ message DerivePlanNode {
     optional UnionNode union_node = 17;
     optional ApplyNode apply_node = 18;
     optional LoadNode  load_node = 19;
+    optional FilterNode raw_filter_node = 20;
 };
 
 message PlanNode {

--- a/proto/store.interface.proto
+++ b/proto/store.interface.proto
@@ -148,6 +148,18 @@ message RegionRaftStat {
     optional int64  dml_latency         = 5;
 };
 
+message RocksStatisticReq {
+    repeated bytes keys                 = 1;
+};
+
+message RocksStatisticRes {
+    required ErrCode errcode              = 1;
+    optional uint64 level0_sst_num        = 2;
+    optional uint64 compaction_data_size  = 3;
+    repeated bytes  key                   = 4;
+    repeated bytes  value                 = 5;
+}
+
 message StoreRes {
     required ErrCode errcode        = 1;
     optional bytes errmsg           = 2;
@@ -209,6 +221,8 @@ message BackUpRes {};
 enum BackupOp {
     BACKUP_DOWNLOAD = 0;
     BACKUP_UPLOAD = 1;
+    BACKUP_QUERY_PEERS = 2;
+    BACKUP_QUERY_STREAMING = 3;
 };
 
 message BackupRequest {
@@ -216,11 +230,19 @@ message BackupRequest {
     optional int64 log_index   = 2;
     optional BackupOp backup_op = 3;
     optional bool ingest_store_latest_sst = 4;
+    optional int64 data_sst_to_process_size = 5;
+    optional int64 row_size = 6;
+    optional uint64 streaming_id = 7;
 };
 
 message BackupResponse {
-    optional int64 log_index   = 1;
-    optional ErrCode errcode        = 2;
+    optional int64 log_index             = 1;
+    optional ErrCode errcode             = 2;
+    optional string leader               = 3;
+    repeated string peers                = 4;
+    repeated string unstable_followers   = 5;
+    optional uint64 streaming_id         = 6;
+    optional StreamState streaming_state = 7;
 };
 
 message HealthCheck {
@@ -276,4 +298,6 @@ service StoreService {
     rpc backup_region(BackUpReq) returns (BackUpRes);
 
     rpc backup(BackupRequest) returns (BackupResponse);
+
+    rpc get_rocks_statistic(RocksStatisticReq) returns (RocksStatisticRes);
 };

--- a/src/common/backup_stream.cpp
+++ b/src/common/backup_stream.cpp
@@ -83,8 +83,8 @@ int StreamReceiver::on_received_messages(brpc::StreamId id,
             if (_file_num == 1) {
                 _meta_file_streaming.flush();
                 _data_file_streaming.flush();
-                _status = (!_meta_file_streaming.bad() && !_data_file_streaming.bad()) ? 
-                    StreamState::SS_SUCCESS : StreamState::SS_FAIL;
+                _status = (!_meta_file_streaming.bad() && !_data_file_streaming.bad()) ?
+                          pb::StreamState::SS_SUCCESS : pb::StreamState::SS_FAIL;
             }
         } else {
             break;
@@ -122,7 +122,7 @@ int StreamReceiver::on_received_messages(brpc::StreamId id,
             _meta_file_streaming.flush();
             _data_file_streaming.flush();
             _status = (!_meta_file_streaming.bad() && !_data_file_streaming.bad()) ?
-                StreamState::SS_SUCCESS : StreamState::SS_FAIL;
+                      pb::StreamState::SS_SUCCESS : pb::StreamState::SS_FAIL;
         }
         break;
     }

--- a/src/common/baikal_heartbeat.cpp
+++ b/src/common/baikal_heartbeat.cpp
@@ -29,7 +29,6 @@ void BaikalHeartBeat::construct_heart_beat_request(pb::BaikalHeartBeatRequest& r
     }
 
     auto schema_read_recallback = [&request, factory](const SchemaMapping& schema){
-        auto& table_statistics_mapping = schema.table_statistics_mapping;
         for (auto& info_pair : schema.table_info_mapping) {
             if (info_pair.second->engine != pb::ROCKSDB &&
                     info_pair.second->engine != pb::ROCKSDB_CSTORE && 
@@ -50,12 +49,6 @@ void BaikalHeartBeat::construct_heart_beat_request(pb::BaikalHeartBeatRequest& r
                 auto req_info = request.add_schema_infos();
                 req_info->set_table_id(index_id);
                 req_info->set_version(1);
-                int64_t version = 0;
-                auto iter = table_statistics_mapping.find(index_id);
-                if (iter != table_statistics_mapping.end()) {
-                    version = iter->second->version();
-                }
-                req_info->set_statis_version(version);
 
                 if (index_id == info_pair.second->id) {
                     req_info->set_version(info_pair.second->version);

--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -19,6 +19,10 @@
 
 namespace baikaldb {
 std::string timestamp_to_str(time_t timestamp) {
+    // 内部存储采用了uint32，因此小于0的都不合法
+    if (timestamp <= 0) {
+        return "0000-00-00 00:00:00";
+    }
     char str_time[21] = {0};
     struct tm tm;
     localtime_r(&timestamp, &tm);  
@@ -185,6 +189,9 @@ uint64_t bin_date_to_datetime(DateTime time_struct) {
 }
 
 time_t datetime_to_timestamp(uint64_t datetime) {
+    if (datetime == 0) {
+        return 0;
+    }
     struct tm tm;
     memset(&tm, 0, sizeof(tm));
 
@@ -200,10 +207,14 @@ time_t datetime_to_timestamp(uint64_t datetime) {
 
     tm.tm_year -= 1900;
     tm.tm_mon--;
-    return mktime(&tm);
+    time_t t = mktime(&tm);
+    return t <= 0 ? 0 : t;
 }
 
 uint64_t timestamp_to_datetime(time_t timestamp) {
+    if (timestamp == 0) {
+        return 0;
+    }
     uint64_t datetime = 0;
 
     struct tm tm;

--- a/src/common/tuple_record.cpp
+++ b/src/common/tuple_record.cpp
@@ -45,7 +45,7 @@ int TupleRecord::verification_fields(int32_t max_field_id) {
         wired_type = field_key & 0x07;
         
         if (_offset >= _size) {
-            DB_WARNING("error: %lu, %lu", _offset, _size);
+            DB_DEBUG("error: %lu, %lu", _offset, _size);
             return -1;
         }
 
@@ -53,7 +53,7 @@ int TupleRecord::verification_fields(int32_t max_field_id) {
             field_num, wired_type, max_field_id, _offset);
 
         if (field_num > max_field_id || field_num == 0) {
-            DB_WARNING("error: field_num: %lu, wired_type: %d, max_field_id: %d", 
+            DB_DEBUG("error: field_num: %lu, wired_type: %d, max_field_id: %d", 
                 field_num, wired_type, max_field_id);
             return -1;
         }
@@ -72,7 +72,7 @@ int TupleRecord::verification_fields(int32_t max_field_id) {
                 skip_fixed<float>();
                 break;
             default:
-                DB_WARNING("invalid wired_type: %d, offset: %lu,%lu", wired_type, _offset, _size);
+                DB_DEBUG("invalid wired_type: %d, offset: %lu,%lu", wired_type, _offset, _size);
                 return -1;
         }
     }

--- a/src/engine/table_iterator.cpp
+++ b/src/engine/table_iterator.cpp
@@ -112,6 +112,7 @@ int Iterator::open(const IndexRange& range, std::map<int32_t, FieldInfo*>& field
     int right_primary_field_cnt = -1;
 
     if (_idx_type == pb::I_KEY) {
+        // region_id+index_id+索引字段+主键字段，这里考虑了把主键字段编码进来的情况，baikaldb侧目前未实现
         left_primary_field_cnt = std::max(0, (range.left_field_cnt - col_cnt));
         right_primary_field_cnt = std::max(0, (range.right_field_cnt - col_cnt));
     }
@@ -131,8 +132,8 @@ int Iterator::open(const IndexRange& range, std::map<int32_t, FieldInfo*>& field
                 return -1;
             }
         }
-    } else if (range.left_key) {
-        _start.append_index(*range.left_key);
+    } else if (range.left_key.size() > 0) {
+        _start.append_index(range.left_key);
     } else {
         //没有指定left bound时，forward遍历从seek region+table开始，backward遍历到左边界停止
         _left_open = false;
@@ -154,8 +155,8 @@ int Iterator::open(const IndexRange& range, std::map<int32_t, FieldInfo*>& field
                 return -1;
             }
         }
-    } else if (range.right_key) {
-        _end.append_index(*range.right_key);
+    } else if (range.right_key.size() > 0) {
+        _end.append_index(range.right_key);
     } else {
         _right_open = false;
     }

--- a/src/exec/apply_node.cpp
+++ b/src/exec/apply_node.cpp
@@ -373,6 +373,7 @@ int ApplyNode::loop_hash_apply(RuntimeState* state) {
     _outer_iter = _outer_tuple_data.begin();
 
     std::vector<MemRow*> outer_tuple_data;
+    outer_tuple_data.reserve(get_loop_num());
     while (_outer_iter != _outer_tuple_data.end() && outer_tuple_data.size() < get_loop_num()) {
         outer_tuple_data.emplace_back(*_outer_iter);
         _outer_iter++;
@@ -520,7 +521,7 @@ int ApplyNode::fetcher_inner_table_data(RuntimeState* state,
     _inner_node->close(state);
 
     _loops++;
-    DB_WARNING("fetcher_inner_table_data, loops:%d, outer:%ld, inner:%ld, time_cost:%ld",
+    DB_WARNING("fetcher_inner_table_data, loops:%lu, outer:%ld, inner:%ld, time_cost:%ld",
                _loops,  outer_tuple_data.size(), inner_tuple_data.size(), time_cost.get_time());
     return 0;
 }
@@ -732,11 +733,12 @@ int ApplyNode::get_next_via_loop_outer_hash_map(RuntimeState* state, RowBatch* b
 
         // construct outer
         if (_outer_iter == _outer_tuple_data.end()) {
-            DB_WARNING("when join, outer iter is end, loops:%d", _loops);
+            DB_WARNING("when join, outer iter is end, loops:%lu", _loops);
             *eos = true;
             return 0;
         }
         std::vector<MemRow*> outer_tuple_data;
+        outer_tuple_data.reserve(get_loop_num());
         while (_outer_iter != _outer_tuple_data.end() && outer_tuple_data.size() < get_loop_num()) {
             outer_tuple_data.emplace_back(*_outer_iter);
             _outer_iter++;

--- a/src/exec/dml_node.cpp
+++ b/src/exec/dml_node.cpp
@@ -283,12 +283,12 @@ int DMLNode::insert_row(RuntimeState* state, SmartRecord record, bool is_update)
 
         if (!_ddl_need_write && (index_state != pb::IS_PUBLIC && index_state != pb::IS_WRITE_ONLY &&
             index_state != pb::IS_WRITE_LOCAL)) {
-            DB_DEBUG("DDL_LOG index_selector skip index [%ld] state [%s] ", 
+            DB_DEBUG("DDL_LOG skip index [%ld] state [%s] ", 
                 info.id, pb::IndexState_Name(index_state).c_str());
             continue;
         } else if (_ddl_need_write && info_ptr->id != _ddl_index_id && (index_state == pb::IS_WRITE_ONLY &&
             index_state == pb::IS_WRITE_LOCAL)) {
-            DB_DEBUG("DDL_LOG index_selector skip stale index [%ld] state [%s] ", 
+            DB_DEBUG("DDL_LOG skip stale index [%ld] state [%s] ", 
                 info.id, pb::IndexState_Name(index_state).c_str());
             continue;
         }
@@ -361,12 +361,12 @@ int DMLNode::insert_row(RuntimeState* state, SmartRecord record, bool is_update)
         auto index_state = info.state;
         if (!_ddl_need_write && (index_state != pb::IS_PUBLIC && index_state != pb::IS_WRITE_ONLY &&
             index_state != pb::IS_WRITE_LOCAL)) {
-            DB_DEBUG("DDL_LOG index_selector skip index [%ld] state [%s] ", 
+            DB_DEBUG("DDL_LOG skip index [%ld] state [%s] ", 
                 info.id, pb::IndexState_Name(index_state).c_str());
             continue;
         } else if (_ddl_need_write && info_ptr->id != _ddl_index_id && (index_state == pb::IS_WRITE_ONLY &&
             index_state == pb::IS_WRITE_LOCAL)) {
-            DB_DEBUG("DDL_LOG index_selector skip stale index [%ld] state [%s] ", 
+            DB_DEBUG("DDL_LOG skip stale index [%ld] state [%s] ", 
                 info.id, pb::IndexState_Name(index_state).c_str());
             continue;
         }
@@ -455,7 +455,7 @@ int DMLNode::remove_row(RuntimeState* state, SmartRecord record,
         }
         auto index_state = info.state;
         if (index_state == pb::IS_NONE) {
-            DB_DEBUG("DDL_LOG index_selector skip index [%ld] state [%s] ", 
+            DB_DEBUG("DDL_LOG skip index [%ld] state [%s] ", 
                 index_id, pb::IndexState_Name(index_state).c_str());
             continue;
         }

--- a/src/exec/exec_node.cpp
+++ b/src/exec/exec_node.cpp
@@ -42,7 +42,6 @@
 namespace baikaldb {
 int ExecNode::init(const pb::PlanNode& node) {
     _pb_node = node;
-    //_id = node.node_id();
     _limit = node.limit();
     _num_rows_returned = 0;
     _node_type = node.node_type();

--- a/src/exec/fetcher_store.cpp
+++ b/src/exec/fetcher_store.cpp
@@ -24,13 +24,8 @@
 #include "binlog_context.h"
 #include "query_context.h"
 #include "dml_node.h"
+#include "scan_node.h"
 #include "trace_state.h"
-#ifdef BAIDU_INTERNAL
-#include "baidu/rpc/reloadable_flags.h"
-#else
-#include "brpc/reloadable_flags.h"
-#endif
-
 namespace baikaldb {
 
 DEFINE_int64(retry_interval_us, 500 * 1000, "retry interval ");
@@ -38,200 +33,174 @@ DEFINE_int32(single_store_concurrency, 20, "max request for one store");
 DEFINE_int64(max_select_rows, 10000000, "query will be fail when select too much rows");
 DEFINE_int64(print_time_us, 10000, "print log when time_cost > print_time_us(us)");
 DEFINE_int64(binlog_alarm_time_s, 30, "alarm, > binlog_alarm_time_s from prewrite to commit");
-#ifdef BAIDU_INTERNAL
-BAIDU_RPC_VALIDATE_GFLAG(print_time_us, brpc::NonNegativeInteger);
-#else
+DEFINE_int64(baikaldb_alive_time_s, 10 * 60, "obervation time length in baikaldb, default:10 min");
 BRPC_VALIDATE_GFLAG(print_time_us, brpc::NonNegativeInteger);
-#endif
 DEFINE_int32(fetcher_request_timeout, 100000,
                     "store as server request timeout, default:10000ms");
 DEFINE_int32(fetcher_connect_timeout, 1000,
                     "store as server connect timeout, default:1000ms");
-DEFINE_int64(db_row_number_to_check_memory, 10240, "do memory limit when row number more than #, default: 10240");
 DEFINE_bool(fetcher_follower_read, true, "where allow follower read for fether");
 DEFINE_bool(fetcher_learner_read, false, "where allow learner read for fether");
 DECLARE_int32(transaction_clear_delay_ms);
 DEFINE_bool(use_dynamic_timeout, false, "whether use dynamic_timeout");
-#ifdef BAIDU_INTERNAL
-BAIDU_RPC_VALIDATE_GFLAG(use_dynamic_timeout, brpc::PassValidate);
-#else
 BRPC_VALIDATE_GFLAG(use_dynamic_timeout, brpc::PassValidate);
-#endif
-                    
-ErrorType FetcherStore::send_request(
-        RuntimeState* state,
-        ExecNode* store_request,
-        pb::RegionInfo& info,
-        pb::TraceNode* trace_node,
-        int64_t old_region_id,
-        int64_t region_id,
-        uint64_t log_id,
-        int retry_times,
-        int start_seq_id,
-        int current_seq_id,
-        pb::OpType op_type) {
-    pb::StoreReq req;
-    pb::StoreRes res;
-    TimeCost total_cost;
-    if (trace_node != nullptr) {
-        req.set_is_trace(true);
-    }
+bvar::Adder<int64_t> OnRPCDone::async_rpc_region_count {"async_rpc_region_count"};
+bvar::LatencyRecorder OnRPCDone::total_send_request {"total_send_request"};
+bvar::LatencyRecorder OnRPCDone::add_backup_send_request {"add_backup_send_request"};
+bvar::LatencyRecorder OnRPCDone::has_backup_send_request {"has_backup_send_request"};
 
-    if (state->explain_type == ANALYZE_STATISTICS) {
-        if (state->cmsketch != nullptr) {
-            pb::AnalyzeInfo* info = req.mutable_analyze_info();
-            info->set_depth(state->cmsketch->get_depth());
-            info->set_width(state->cmsketch->get_width());
-            info->set_sample_rows(state->cmsketch->get_sample_rows());
-            info->set_table_rows(state->cmsketch->get_table_rows());
-        }
+OnRPCDone::OnRPCDone(FetcherStore* fetcher_store, RuntimeState* state, ExecNode* store_request, pb::RegionInfo* info_ptr, 
+    int64_t old_region_id, int64_t region_id, int start_seq_id, int current_seq_id, pb::OpType op_type) : 
+    _fetcher_store(fetcher_store), _state(state), _store_request(store_request), _info(*info_ptr),
+    _old_region_id(old_region_id), _region_id(region_id), 
+    _start_seq_id(start_seq_id),  _current_seq_id(current_seq_id), _op_type(op_type) {
+    _client_conn = _state->client_conn();
+    if (_store_request->get_trace() != nullptr) {
+        _trace_node = std::make_shared<pb::TraceNode>();
     }
-    ScopeGuard auto_update_trace([&]() {
-        if (trace_node != nullptr) {
-            std::string desc = "baikalDB FetcherStore send_request "
-                               + pb::ErrCode_Name(res.errcode());
-            trace_node->set_description(trace_node->description() + " " + desc);
-            trace_node->set_total_time(total_cost.get_time());
-            trace_node->set_affect_rows(res.affected_rows());
-            pb::TraceNode* local_trace = trace_node->add_child_nodes();
-            if (res.has_errmsg() && res.errcode() == pb::SUCCESS) {
-                pb::TraceNode trace;
-                if (!trace.ParseFromString(res.errmsg())) {
-                    DB_FATAL("parse from pb fail");
-                } else {
-                    (*local_trace) = trace;
-                }
-            }
-        }
-    });
-    if (error != E_OK) {
-        DB_WARNING("recieve error, need not requeset to region_id: %ld, log_id: %lu", region_id, log_id);
-        return E_WARNING;
+    if (_info.leader() == "0.0.0.0:0" || _info.leader() == "") {
+        _store_addr = rand_peer(_info);
+    } else {
+        _store_addr = _info.leader();
     }
-    if (state->is_cancelled()) {
-        DB_FATAL("region_id: %ld is cancelled, log_id: %lu op_type:%s", 
-                region_id, log_id, pb::OpType_Name(op_type).c_str());
-        return E_OK;
-    }
-    //DB_WARNING("region_info; txn: %ld, %s, %lu", _txn_id, info.ShortDebugString().c_str(), records.size());
-    if (retry_times >= 5) {
-        DB_WARNING("region_id: %ld, txn_id: %lu, log_id:%lu, op_type:%s rpc error; retry:%d",
-            region_id, state->txn_id, log_id, pb::OpType_Name(op_type).c_str(), retry_times);
+    async_rpc_region_count << 1;
+    DB_DONE(DEBUG, "OnRPCDone");
+}
+OnRPCDone::~OnRPCDone() {
+    async_rpc_region_count << -1;
+}
+// 检查状态，判断是否需要继续执行
+ErrorType OnRPCDone::check_status() {
+    if (_fetcher_store->error != E_OK) {
+        DB_DONE(WARNING, "recieve error");
         return E_FATAL;
     }
-    // for exec next_statement_after_begin, begin must be added
-    if (current_seq_id == 2 && state->single_sql_autocommit() == false) {
-        //DB_WARNING("start seq id is reset to 1, region_id: %ld", region_id);
-        start_seq_id = 1;
+
+    if (_state->is_cancelled() || _fetcher_store->is_cancelled) {
+        DB_DONE(FATAL, "cancelled, state cancel: %d, fetcher_store cancel: %d", 
+                _state->is_cancelled(), _fetcher_store->is_cancelled);
+        return E_FATAL;
     }
-    bool need_copy_cache_plan = true;
-    if (state->txn_id != 0) {
-        BAIDU_SCOPED_LOCK(state->client_conn()->region_lock);
-        if (state->client_conn()->region_infos.count(region_id) == 0) {
-            //DB_WARNING("start seq id is reset to 1, region_id: %ld", region_id);
-            start_seq_id = 1;
-            no_copy_cache_plan_set.emplace(region_id);
+
+    if (_retry_times >= 5) {
+        DB_DONE(WARNING, "too many retries");
+        return E_FATAL;
+    }
+
+    return E_OK;
+}
+
+ErrorType OnRPCDone::fill_request() {
+    if (_trace_node != nullptr) {
+        _request.set_is_trace(true);
+    }
+    if (_state->explain_type == ANALYZE_STATISTICS) {
+        if (_state->cmsketch != nullptr) {
+            pb::AnalyzeInfo* info = _request.mutable_analyze_info();
+            info->set_depth(_state->cmsketch->get_depth());
+            info->set_width(_state->cmsketch->get_width());
+            info->set_sample_rows(_state->cmsketch->get_sample_rows());
+            info->set_table_rows(_state->cmsketch->get_table_rows());
         }
-        if (no_copy_cache_plan_set.count(region_id) != 0) {
+    }
+    // for exec next_statement_after_begin, begin must be added
+    if (_current_seq_id == 2 && !_state->single_sql_autocommit()) {
+        _start_seq_id = 1;
+    }
+    
+    bool need_copy_cache_plan = true;
+    if (_state->txn_id != 0) {
+        BAIDU_SCOPED_LOCK(_client_conn->region_lock);
+        if (_client_conn->region_infos.count(_region_id) == 0) {
+            _start_seq_id = 1;
+            _fetcher_store->no_copy_cache_plan_set.emplace(_region_id);
+        }
+        if (_fetcher_store->no_copy_cache_plan_set.count(_region_id) != 0) {
             need_copy_cache_plan = false;
         }
     }
-    TimeCost cost;
-    auto client_conn = state->client_conn();
-    SchemaFactory* schema_factory = SchemaFactory::get_instance();
-    brpc::Controller cntl;
-    cntl.set_log_id(log_id);
-    if (info.leader() == "0.0.0.0:0" || info.leader() == "") {
-        info.set_leader(rand_peer(info));
+    
+    if (_info.leader() == "0.0.0.0:0" || _info.leader() == "") {
+        _info.set_leader(rand_peer(_info));
     }
-    req.set_db_conn_id(client_conn->get_global_conn_id());
-    req.set_op_type(op_type);
-    req.set_region_id(region_id);
-    req.set_region_version(info.version());
-    req.set_log_id(log_id);
-    req.set_sql_sign(state->sign);
-    for (auto& desc : state->tuple_descs()) {
+    _request.set_db_conn_id(_client_conn->get_global_conn_id());
+    _request.set_op_type(_op_type);
+    _request.set_region_id(_region_id);
+    _request.set_region_version(_info.version());
+    _request.set_log_id(_state->log_id());
+    _request.set_sql_sign(_state->sign);
+    for (auto& desc : _state->tuple_descs()) {
         if (desc.has_tuple_id()){
-            req.add_tuples()->CopyFrom(desc);
+            _request.add_tuples()->CopyFrom(desc);
         }
     }
-    pb::TransactionInfo* txn_info = req.add_txn_infos();
-    txn_info->set_txn_id(state->txn_id);
-    txn_info->set_seq_id(current_seq_id);
-    txn_info->set_autocommit(state->single_sql_autocommit());
+    pb::TransactionInfo* txn_info = _request.add_txn_infos();
+    txn_info->set_txn_id(_state->txn_id);
+    txn_info->set_seq_id(_current_seq_id);
+    txn_info->set_autocommit(_state->single_sql_autocommit());
     // 全局二级索引online ddl 设置超时时间 40 s
-    if (client_conn->txn_timeout > 0) {
-        txn_info->set_txn_timeout(client_conn->txn_timeout);
+    if (_client_conn->txn_timeout > 0) {
+        txn_info->set_txn_timeout(_client_conn->txn_timeout);
     }
-    for (int id : client_conn->need_rollback_seq) {
+    for (int id : _client_conn->need_rollback_seq) {
         txn_info->add_need_rollback_seq(id);
     }
-    txn_info->set_start_seq_id(start_seq_id);
-    txn_info->set_optimize_1pc(state->optimize_1pc());
-    if (state->txn_id != 0) {
-        txn_info->set_primary_region_id(client_conn->primary_region_id.load());
-        if (need_process_binlog(state, op_type)) {
-            auto binlog_ctx = client_conn->get_binlog_ctx();
+    txn_info->set_start_seq_id(_start_seq_id);
+    txn_info->set_optimize_1pc(_state->optimize_1pc());
+    if (_state->txn_id != 0) {
+        txn_info->set_primary_region_id(_client_conn->primary_region_id.load());
+        if (_fetcher_store->need_process_binlog(_state, _op_type)) {
+            auto binlog_ctx = _client_conn->get_binlog_ctx();
             txn_info->set_commit_ts(binlog_ctx->commit_ts());
             txn_info->set_open_binlog(true);
         }
-        if (client_conn->primary_region_id != -1
-            && client_conn->primary_region_id != region_id
-            && !primary_timestamp_updated) {
-            if (butil::gettimeofday_us() - client_conn->txn_pri_region_last_exec_time > (FLAGS_transaction_clear_delay_ms / 2) * 1000LL) {
-                primary_timestamp_updated = true;
+        if (_client_conn->primary_region_id != -1
+            && _client_conn->primary_region_id != _region_id
+            && !_fetcher_store->primary_timestamp_updated) {
+            if (butil::gettimeofday_us() - _client_conn->txn_pri_region_last_exec_time > (FLAGS_transaction_clear_delay_ms / 2) * 1000LL) {
+                _fetcher_store->primary_timestamp_updated = true;
                 txn_info->set_need_update_primary_timestamp(true);
-                client_conn->txn_pri_region_last_exec_time = butil::gettimeofday_us();
+                _client_conn->txn_pri_region_last_exec_time = butil::gettimeofday_us();
             }
-        } else if (client_conn->primary_region_id == region_id) {
-            client_conn->txn_pri_region_last_exec_time = butil::gettimeofday_us();
+        } else if (_client_conn->primary_region_id == _region_id) {
+            _client_conn->txn_pri_region_last_exec_time = butil::gettimeofday_us();
         }
     }
 
-    // DB_WARNING("txn_id: %lu, start_seq_id: %d, autocommit:%d", _txn_id, start_seq_id, state->autocommit());
     // 将缓存的plan中seq_id >= start_seq_id的部分追加到request中
     // rollback cmd does not need to send cache
-    //DB_WARNING("op_type: %d, start_seq_id:%d, cache_plans_size: %d",
-    //            op_type, start_seq_id, client_conn->cache_plans.size());
-    if (start_seq_id >= 0 && op_type != pb::OP_COMMIT) {
-        for (auto& pair : client_conn->cache_plans) {
+    if (_start_seq_id >= 0 && _op_type != pb::OP_COMMIT) {
+        for (auto& pair : _client_conn->cache_plans) {
             //DB_WARNING("op_type: %d, pair.first:%d, start_seq_id:%d", op_type, pair.first, start_seq_id);
             auto& plan_item = pair.second;
             if ((plan_item.op_type != pb::OP_BEGIN)
-                && (pair.first < start_seq_id || pair.first >= current_seq_id)) {
+                && (pair.first < _start_seq_id || pair.first >= _current_seq_id)) {
                 continue;
             }
-            if (op_type == pb::OP_PREPARE && plan_item.op_type == pb::OP_PREPARE) {
+            if (_op_type == pb::OP_PREPARE && plan_item.op_type == pb::OP_PREPARE) {
                 continue;
             }
             if (!need_copy_cache_plan && plan_item.op_type != pb::OP_BEGIN
-                && !state->single_txn_cached()) {
-                DB_DEBUG("not copy cache region_id: %ld, log_id:%lu txn_id:%lu", region_id, log_id, state->txn_id);
+                && !_state->single_txn_cached()) {
+                DB_DONE(DEBUG, "not copy cache");
                 continue;
             }
             // rollback只带上begin
-            if (op_type == pb::OP_ROLLBACK && plan_item.op_type != pb::OP_BEGIN) {
+            if (_op_type == pb::OP_ROLLBACK && plan_item.op_type != pb::OP_BEGIN) {
                 continue;
             }
             if (plan_item.tuple_descs.size() > 0 &&
                 plan_item.op_type != pb::OP_BEGIN &&
-                static_cast<DMLNode*>(plan_item.root)->global_index_id() != info.table_id()
+                static_cast<DMLNode*>(plan_item.root)->global_index_id() != _info.table_id()
                 ) {
-                /*DB_WARNING("TransactionNote: cache_item table_id mismatch,"
-                    " cache global_index_id: %ld, region_info index_id : %ld",
-                    static_cast<DMLNode*>(plan_item.root)->global_index_id(), info.table_id());
-                */
                 continue;
             }
             pb::CachePlan* pb_cache_plan = txn_info->add_cache_plans();
             pb_cache_plan->set_op_type(plan_item.op_type);
             pb_cache_plan->set_seq_id(plan_item.sql_id);
-            ExecNode::create_pb_plan(old_region_id, pb_cache_plan->mutable_plan(), plan_item.root);
-            if (plan_item.op_type != pb::OP_BEGIN && !state->single_txn_cached()) {
-                DB_WARNING("TranstationNote: copy cache region_id: %ld, old_region_id:%ld log_id:%lu txn_id:%lu "
-                "start_seq_id:%d current_seq_id:%d cache_plan:%s", 
-                    region_id, old_region_id, log_id, state->txn_id, start_seq_id, current_seq_id,
-                    pb_cache_plan->ShortDebugString().c_str());
+            ExecNode::create_pb_plan(_old_region_id, pb_cache_plan->mutable_plan(), plan_item.root);
+            if (plan_item.op_type != pb::OP_BEGIN && !_state->single_txn_cached()) {
+                DB_DONE(WARNING, "TranstationNote: copy cache, cache_plan:%s", pb_cache_plan->ShortDebugString().c_str());
             }
             for (auto& desc : plan_item.tuple_descs) {
                 if (desc.has_tuple_id()){
@@ -241,79 +210,132 @@ ErrorType FetcherStore::send_request(
         }
     }
     // save region id for txn commit/rollback
-    int64_t client_lock_tm = 0;
-    if (state->txn_id != 0) {
-        TimeCost cost;
-        BAIDU_SCOPED_LOCK(client_conn->region_lock);
-        if (client_conn->region_infos.count(region_id) == 0) {
-            client_conn->region_infos.insert(std::make_pair(region_id, info));
+    if (_state->txn_id != 0) {
+        BAIDU_SCOPED_LOCK(_client_conn->region_lock);
+        if (_client_conn->region_infos.count(_region_id) == 0) {
+            _client_conn->region_infos.insert(std::make_pair(_region_id, _info));
         }
-        client_lock_tm = cost.get_time();
     }
-    ExecNode::create_pb_plan(old_region_id, req.mutable_plan(), store_request);
 
-    std::string addr = info.leader();
-    std::string backup;
+    std::vector<ExecNode*> scan_nodes;
+    ScanNode* scan_node = nullptr;
+    _store_request->get_node(pb::SCAN_NODE, scan_nodes);
+    if (scan_nodes.size() == 1) {
+        scan_node = static_cast<ScanNode*>(scan_nodes[0]);
+    }
+
+    // 需要对当前使用的router index id 加锁，可能由于存在全局二级索引backup，store_request在不同索引之间并发使用，需要区分当前处理的req属于哪个router index
+    if (scan_node != nullptr) {
+        bool use_global_backup = _fetcher_store->global_backup_type == GBT_LEARNER;
+        scan_node->set_index_useage_and_lock(use_global_backup);
+    }
+
+    ExecNode::create_pb_plan(_old_region_id, _request.mutable_plan(), _store_request);
+
+    if (scan_node != nullptr) {
+        scan_node->current_index_unlock();
+    }
+
+    return E_OK;
+}   
+
+void OnRPCDone::select_addr() {
+    _addr = _info.leader();
+    _access_learner = false;
     // 事务读也读leader
-    if (op_type == pb::OP_SELECT && state->txn_id == 0 && 
-        info.learners_size() > 0 && (FLAGS_fetcher_learner_read || state->need_learner_backup())) {
+    if (_op_type == pb::OP_SELECT && _state->txn_id == 0 && _info.learners_size() > 0 && 
+        (FLAGS_fetcher_learner_read || _state->need_learner_backup() || _fetcher_store->global_backup_type == GBT_LEARNER/*全局索引降级，强制访问learner*/)) {
         // 多机房优化
-        if (retry_times == 0) {
-            choose_opt_instance(info.region_id(), info.learners(), addr, nullptr);
-        }
-        req.set_select_without_leader(true);
-    } else if (op_type == pb::OP_SELECT && state->txn_id == 0 && FLAGS_fetcher_follower_read) {
-        // 多机房优化
-        if (info.learners_size() > 0) {
-            choose_opt_instance(info.region_id(), info.peers(), addr, nullptr);
-            choose_opt_instance(info.region_id(), info.learners(), backup, nullptr);
-        } else {
-            if (retry_times == 0) {
-                choose_opt_instance(info.region_id(), info.peers(), addr, &backup);
+        std::vector<std::string> learners;
+        for (auto& learner_peer : _info.learners()) {
+            if (_fetcher_store->learner_status.can_learner_access(_info.region_id(), learner_peer)) {
+                learners.emplace_back(learner_peer);
             }
         }
-        req.set_select_without_leader(true);
-    } else if (retry_times == 0) {
+        // 临时方案，后续重构
+        if (!learners.empty()) {
+            _addr = learners[0];
+            pb::Status addr_status = pb::NORMAL;
+            FetcherStore::choose_opt_instance(_info.region_id(), learners, _addr, addr_status, nullptr);
+            _access_learner = true;
+        } else {
+            pb::Status addr_status = pb::NORMAL;
+            FetcherStore::choose_opt_instance(_info.region_id(), _info.peers(), _addr, addr_status, nullptr);
+        }
+
+        _request.set_select_without_leader(true);
+    } else if (_op_type == pb::OP_SELECT && _state->txn_id == 0 && FLAGS_fetcher_follower_read) {
+        // 多机房优化
+        if (_info.learners_size() > 0) {
+            pb::Status addr_status = pb::NORMAL;
+            FetcherStore::choose_opt_instance(_info.region_id(), _info.peers(), _addr, addr_status, nullptr);
+            pb::Status backup_status = pb::NORMAL;
+            FetcherStore::choose_opt_instance(_info.region_id(), _info.learners(), _backup, backup_status, nullptr);
+            bool backup_can_access = (!_backup.empty()) && (backup_status == pb::NORMAL) && 
+                                        _fetcher_store->learner_status.can_learner_access(_info.region_id(), _backup);
+            if (addr_status != pb::NORMAL && backup_can_access && 
+                    _fetcher_store->global_backup_type != GBT_MAIN/*全局索引降级，强制访问主集群不可以只访问learner*/) {
+                _addr = _backup;
+                _backup.clear();
+                _state->need_statistics = false;
+            } else if (!backup_can_access) {
+                _backup.clear();
+            }
+        } else {
+            if (_retry_times == 0) {
+                pb::Status addr_status = pb::NORMAL;
+                FetcherStore::choose_opt_instance(_info.region_id(), _info.peers(), _addr, addr_status, &_backup);
+            }
+        }
+        _request.set_select_without_leader(true);
+    } else if (_retry_times == 0) {
         // 重试前已经选择了normal的实例
         // 或者store返回了正确的leader
-        choose_other_if_faulty(info, addr);
+        FetcherStore::choose_other_if_faulty(_info, _addr);
     }
+
+    // 存在全局索引降级的情况，强制访问主集群的情况下不要backup
+    if (_fetcher_store->global_backup_type == GBT_MAIN) {
+        _backup.clear();
+    }
+}
+
+ErrorType OnRPCDone::send_async() {
+    _cntl.Reset();
+    _cntl.set_log_id(_state->log_id());
+    _response.Clear();
     brpc::ChannelOptions option;
     option.max_retry = 1;
     option.connect_timeout_ms = FLAGS_fetcher_connect_timeout;
     option.timeout_ms = FLAGS_fetcher_request_timeout;
-    if (dynamic_timeout_ms > 0 && !backup.empty() && backup != addr) {
-        option.backup_request_ms = dynamic_timeout_ms;
+    if (_fetcher_store->dynamic_timeout_ms > 0 && !_backup.empty() && _backup != _addr) {
+        option.backup_request_ms = _fetcher_store->dynamic_timeout_ms;
     }
     brpc::SelectiveChannel channel;
-    int ret = 0;
-    ret = channel.Init("rr", &option);
+    int ret = channel.Init("rr", &option);
     if (ret != 0) {
-        DB_WARNING("SelectiveChannel init failed, addr:%s, ret:%d, region_id: %ld, log_id:%lu",
-                addr.c_str(), ret, region_id, log_id);
+        DB_DONE(WARNING, "SelectiveChannel init failed, ret:%d", ret);
         return E_FATAL;
     }
     // sub_channel do not need backup_request_ms
     option.backup_request_ms = -1;
     option.max_retry = 0;
     brpc::Channel* sub_channel1 = new brpc::Channel;
-    ret = sub_channel1->Init(addr.c_str(), &option);
+    ret = sub_channel1->Init(_addr.c_str(), &option);
     if (ret != 0) {
-        DB_WARNING("channel init failed, addr:%s, ret:%d, region_id: %ld, log_id:%lu",
-                addr.c_str(), ret, region_id, log_id);
+        DB_DONE(WARNING, "channel init failed, ret:%d", ret);
         delete sub_channel1;
         return E_FATAL;
     }
     channel.AddChannel(sub_channel1, NULL);
-    if (dynamic_timeout_ms > 0 && !backup.empty() && backup != addr) {
+    if (_fetcher_store->dynamic_timeout_ms > 0 && !_backup.empty() && _backup != _addr) {
 #ifdef BAIDU_INTERNAL
         //开源版brpc和内部不大一样
         brpc::SocketId sub_id2;
         brpc::Channel* sub_channel2 = new brpc::Channel;
-        ret = sub_channel2->Init(backup.c_str(), &option);
+        ret = sub_channel2->Init(_backup.c_str(), &option);
         if (ret != 0) {
-            DB_WARNING("channel init failed, backup:%s, ret:%d, region_id: %ld, log_id:%lu",
-                    backup.c_str(), ret, region_id, log_id);
+            DB_DONE(WARNING, "sub_channel init failed, ret:%d", ret);
             delete sub_channel2;
             return E_FATAL;
         }
@@ -322,251 +344,299 @@ ErrorType FetcherStore::send_request(
         // 保证第一次请求必定走addr，并且这个ExcludedServers不影响backup_request
         brpc::ExcludedServers* exclude = brpc::ExcludedServers::Create(1);
         exclude->Add(sub_id2);
-        cntl.set_excluded_servers(exclude);
+        _cntl.set_excluded_servers(exclude);
 #endif
     } else {
         //命中backup可以不cancel
-        client_conn->insert_callid(addr, region_id, cntl.call_id());
+        _client_conn->insert_callid(_addr, _region_id, _cntl.call_id());
     }
+    _fetcher_store->insert_callid(_cntl.call_id());
+    _query_time.reset();
+    pb::StoreService_Stub(&channel).query(&_cntl, &_request, &_response, this);
+    return E_ASYNC;
+}
 
-    TimeCost query_time;
-    pb::StoreService_Stub(&channel).query(&cntl, &req, &res, NULL);
-
-    DB_DEBUG("fetch store req: %s", req.ShortDebugString().c_str());
-    DB_DEBUG("fetch store res: %s", res.ShortDebugString().c_str());
-    if (cost.get_time() > FLAGS_print_time_us || retry_times > 0) {
-        DB_WARNING("op_type:%s, lock:%ld, wait region_id: %ld retry_times:%d "
-                "version:%ld time:%ld rpc_time: %ld log_id:%lu txn_id: %lu, ip:%s, addr:%s backup:%s",
-                pb::OpType_Name(op_type).c_str(), client_lock_tm, region_id, retry_times,
-                info.version(), cost.get_time(), query_time.get_time(), log_id, state->txn_id,
-                butil::endpoint2str(cntl.remote_side()).c_str(), addr.c_str(), backup.c_str());
+void OnRPCDone::Run() {
+    DB_DONE(DEBUG, "fetch store req: %s", _request.ShortDebugString().c_str());
+    DB_DONE(DEBUG, "fetch store res: %s", _response.ShortDebugString().c_str());
+    std::string remote_side = butil::endpoint2str(_cntl.remote_side()).c_str();
+    int64_t query_cost = _query_time.get_time();
+    if (query_cost > FLAGS_print_time_us || _retry_times > 0) {
+        DB_DONE(WARNING, "version:%ld time:%ld rpc_time:%ld ip:%s",
+                 _info.version(), _total_cost.get_time(), query_cost, remote_side.c_str());
     }
-    if (cntl.Failed()) {
-        DB_WARNING("call failed region_id: %ld, errcode:%d, error:%s, log_id:%lu, op_type:%s",
-                region_id, cntl.ErrorCode(), cntl.ErrorText().c_str(), log_id, pb::OpType_Name(op_type).c_str());
+    total_send_request << query_cost;
+    if (!_backup.empty() && _backup != _addr) {
+        add_backup_send_request << query_cost;
+    }
+    SchemaFactory* schema_factory = SchemaFactory::get_instance();
+    if (_cntl.Failed()) {
+        DB_DONE(WARNING, "call failed, errcode:%d, error:%s", _cntl.ErrorCode(), _cntl.ErrorText().c_str());
+        schema_factory->update_instance(remote_side, pb::FAULTY, false, false);
         // 只有网络相关错误码才重试
-        if (cntl.ErrorCode() != ETIMEDOUT &&
-                cntl.ErrorCode() != ECONNREFUSED &&
-                cntl.ErrorCode() != EHOSTDOWN &&
-                cntl.ErrorCode() != ECANCELED) {
-            return E_FATAL;
+        if (_cntl.ErrorCode() != ETIMEDOUT &&
+                _cntl.ErrorCode() != ECONNREFUSED &&
+                _cntl.ErrorCode() != EHOSTDOWN &&
+                _cntl.ErrorCode() != ECANCELED) {
+            _fetcher_store->error = E_FATAL;
+            _rpc_ctrl->task_finish(this);
+            return;
         }
-        if (op_type != pb::OP_SELECT && cntl.ErrorCode() == ECANCELED) {
-            return E_FATAL;
+        if (_op_type != pb::OP_SELECT && _cntl.ErrorCode() == ECANCELED) {
+            _fetcher_store->error = E_FATAL;
+            _rpc_ctrl->task_finish(this);
+            return;
         }
-        other_normal_peer_to_leader(info, addr);
-        bthread_usleep(retry_times * FLAGS_retry_interval_us);
-        return send_request(state, store_request, info, trace_node, old_region_id, region_id, log_id,
-                  retry_times + 1, start_seq_id, current_seq_id, op_type);
-    }
-    if (cntl.has_backup_request()) {
-        DB_WARNING("has_backup_request region_id: %ld, addr:%s, backup:%s, log_id:%lu",
-                region_id, addr.c_str(), backup.c_str(), log_id);
-        SchemaFactory* factory = SchemaFactory::get_instance();
-        //业务快速置状态
-        factory->update_instance(addr, pb::FAULTY, true);
-    }
-    if (res.errcode() == pb::NOT_LEADER) {
-        DB_WARNING("NOT_LEADER, region_id: %ld, addr:%s retry:%d, new_leader:%s, log_id:%lu",
-                region_id, addr.c_str(), retry_times, res.leader().c_str(), log_id);
 
-        if (res.leader() != "0.0.0.0:0") {
-            // store返回了leader，则相信store，不判断normal
-            info.set_leader(res.leader());
-            schema_factory->update_leader(info);
+        _fetcher_store->learner_status.set_learner_cannot_access(_info.region_id(), remote_side);
+        FetcherStore::other_normal_peer_to_leader(_info, _addr);
+        bthread_usleep(_retry_times * FLAGS_retry_interval_us);
+        _rpc_ctrl->task_retry(this);
+        return;
+    }
+
+    // 如果已经失败或取消则不再处理
+    if (_fetcher_store->error != E_OK) {
+        _rpc_ctrl->task_finish(this);
+        return;
+    } 
+
+    if (_state->is_cancelled() || _fetcher_store->is_cancelled) {
+        DB_DONE(WARNING, "rpc cancelled, state cancel: %d, fetcher store cancel: %d", 
+            _state->is_cancelled(), _fetcher_store->is_cancelled);
+        _fetcher_store->error = E_FATAL;
+        _rpc_ctrl->task_finish(this);
+        return;
+    }
+
+    auto err = handle_response(remote_side);
+    if (err == E_RETRY) {
+        _rpc_ctrl->task_retry(this);
+    } else {
+        if (err != E_OK) {
+            _fetcher_store->error = err;
+        }
+        _rpc_ctrl->task_finish(this);
+    }
+    return;
+}
+
+ErrorType OnRPCDone::handle_version_old() {
+    SchemaFactory* schema_factory = SchemaFactory::get_instance();
+    DB_DONE(WARNING, "VERSION_OLD, now:%s", _info.ShortDebugString().c_str());
+    if (_response.regions_size() >= 2) {
+        auto regions = _response.regions();
+        regions.Clear();
+        if (!_response.is_merge()) {
+            for (auto r : _response.regions()) {
+                DB_WARNING("version region:%s", r.ShortDebugString().c_str());
+                if (end_key_compare(r.end_key(), _info.end_key()) > 0) {
+                    DB_WARNING("region:%ld r.end_key:%s > info.end_key:%s",
+                                r.region_id(),
+                                str_to_hex(r.end_key()).c_str(),
+                                str_to_hex(_info.end_key()).c_str());
+                    continue;
+                }
+                *regions.Add() = r;
+            }
         } else {
-            other_normal_peer_to_leader(info, addr);
-           
-        }
-        if (state->txn_id != 0 ) {
-            BAIDU_SCOPED_LOCK(client_conn->region_lock);
-            client_conn->region_infos[region_id].set_leader(info.leader());
-        }
-        // leader切换在秒级
-        bthread_usleep(retry_times * FLAGS_retry_interval_us);
-        return send_request(state, store_request, info, trace_node, old_region_id, region_id, log_id,
-             retry_times + 1, start_seq_id, current_seq_id, op_type);
-    }
-    if (res.errcode() == pb::DISABLE_WRITE_TIMEOUT) {
-        // region正在分裂, 处于禁写状态
-        DB_WARNING("DISABLE_WRITE_TIMEOUT, region_id: %ld, addr:%s retry:%d, log_id:%lu",
-                   region_id, addr.c_str(), retry_times, log_id);
-        bthread_usleep(retry_times * FLAGS_retry_interval_us);
-        return send_request(state, store_request, info, trace_node, old_region_id, region_id, log_id,
-                            retry_times + 1, start_seq_id, current_seq_id, op_type);
-    }
-    if (res.errcode() == pb::RETRY_LATER) {
-        DB_WARNING("RETRY_LATER, region_id: %ld, retry:%d, log_id:%lu, op:%d, start_seq_id:%d current_seq_id:%d",
-                region_id, retry_times, log_id, op_type, start_seq_id, current_seq_id);
-        bthread_usleep(retry_times * FLAGS_retry_interval_us);
-        return send_request(state, store_request, info, trace_node, old_region_id, region_id, log_id,
-                  retry_times + 1, start_seq_id, current_seq_id,  op_type);
-    }
-    if (res.errcode() == pb::IN_PROCESS) {
-        DB_WARNING("txn IN_PROCESS, region_id: %ld, retry:%d, log_id:%lu, op:%d, start_seq_id:%d current_seq_id:%d",
-                region_id, retry_times, log_id, op_type, start_seq_id, current_seq_id);
-        bthread_usleep(retry_times * FLAGS_retry_interval_us);
-        return send_request(state, store_request, info, trace_node, old_region_id, region_id, log_id,
-                  retry_times + 1, start_seq_id, current_seq_id,  op_type);
-    }
-    //todo 需要处理分裂情况
-    if (res.errcode() == pb::VERSION_OLD) {
-        DB_WARNING("VERSION_OLD, region_id: %ld, start_seq_id:%d retry:%d, now:%s, log_id:%lu",
-                region_id, start_seq_id, retry_times, info.ShortDebugString().c_str(), log_id);
-        if (res.regions_size() >= 2) {
-            auto regions = res.regions();
-            regions.Clear();
-            if (!res.is_merge()) {
-                for (auto r : res.regions()) {
-                    DB_WARNING("version region:%s", r.ShortDebugString().c_str());
-                    if (end_key_compare(r.end_key(), info.end_key()) > 0) {
-                        DB_WARNING("region:%ld r.end_key:%s > info.end_key:%s",
-                                   r.region_id(),
-                                   str_to_hex(r.end_key()).c_str(),
-                                   str_to_hex(info.end_key()).c_str());
-                        continue;
-                    }
-                    *regions.Add() = r;
-                }
-            } else {
-                //merge场景，踢除当前region，继续走下面流程
-                for (auto r : res.regions()) {
-                    if (r.region_id() == region_id) {
-                        DB_WARNING("merge can`t add this region:%s",
-                                   r.ShortDebugString().c_str());
-                        continue;
-                    }
-                    DB_WARNING("version region:%s", r.ShortDebugString().c_str());
-                    *regions.Add() = r;
-                }
-            }
-            schema_factory->update_regions(regions);
-            //auto orgin_info = res.regions(0);
-            //auto new_info = res.regions(1);
-            // 为了方便，串行执行
-            // 靠store自己过滤数据
-            //bthread_usleep(retry_times * FLAGS_retry_interval_us);
-            if (op_type == pb::OP_PREPARE && client_conn->transaction_has_write()) {
-                state->set_optimize_1pc(false);
-                DB_WARNING("TransactionNote: disable optimize_1pc due to split: txn_id: %lu, seq_id: %d, region_id: %ld",
-                state->txn_id, current_seq_id, region_id);
-            }
-            for (auto& r : regions) {
-                if (r.region_id() != region_id) {
-                    BAIDU_SCOPED_LOCK(client_conn->region_lock);
-                    client_conn->region_infos[r.region_id()] = r;
-                    skip_region_set.insert(r.region_id());
-                    state->region_count++;
-                } else {
-                    if (res.leader() != "0.0.0.0:0") {
-                        DB_WARNING("region_id: %ld set new_leader: %s when old_version", region_id, r.leader().c_str());
-                        r.set_leader(res.leader());
-                    }
-                    BAIDU_SCOPED_LOCK(client_conn->region_lock);
-                    client_conn->region_infos[region_id].set_end_key(r.start_key());
-                    client_conn->region_infos[region_id].set_end_key(r.end_key());
-                    client_conn->region_infos[region_id].set_version(r.version());
-                    if (r.leader() != "0.0.0.0:0") {
-                        client_conn->region_infos[region_id].set_leader(r.leader());
-                    }
-                }
-            }
-            int last_seq_id = res.has_last_seq_id()? res.last_seq_id() : start_seq_id;
-            for (auto& r : regions) {
-                ErrorType ret;
-                ret = send_request(state, store_request, r, trace_node, old_region_id, r.region_id(),
-                         log_id, retry_times, last_seq_id, current_seq_id, op_type);
-                if (ret != E_OK) {
-                    DB_WARNING("retry failed, region_id: %ld, log_id:%lu, txn_id: %lu",
-                            r.region_id(), log_id, state->txn_id);
-                    return ret;
-                }
-            }
-            return E_OK;
-        } else if (res.regions_size() == 1) {
-            auto regions = res.regions();
-            regions.Clear();
-            for (auto r : res.regions()) {
-                if (r.region_id() != region_id) {
-                    DB_WARNING("not the same region:%s",
-                               r.ShortDebugString().c_str());
-                    return E_FATAL;
-                }
-                if (!(r.start_key() <= info.start_key() &&
-                        end_key_compare(r.end_key(), info.end_key()) >= 0)) {
-                    DB_FATAL("store region not overlap local region, region_id:%ld",
-                            region_id);
-                    return E_FATAL;
+            //merge场景，踢除当前region，继续走下面流程
+            for (auto r : _response.regions()) {
+                if (r.region_id() == _region_id) {
+                    DB_WARNING("merge can`t add this region:%s",
+                                r.ShortDebugString().c_str());
+                    continue;
                 }
                 DB_WARNING("version region:%s", r.ShortDebugString().c_str());
                 *regions.Add() = r;
             }
-            int last_seq_id = res.has_last_seq_id()? res.last_seq_id() : start_seq_id;
-            for (auto& r : regions) {
-                auto r_copy = r;
-                {
-                    BAIDU_SCOPED_LOCK(client_conn->region_lock);
-                    client_conn->region_infos[region_id].set_start_key(r_copy.start_key());
-                    client_conn->region_infos[region_id].set_end_key(r_copy.end_key());
-                    client_conn->region_infos[region_id].set_version(r_copy.version());
-                    if (r_copy.leader() != "0.0.0.0:0") {
-                        client_conn->region_infos[region_id].set_leader(r_copy.leader());
-                    }
+        }
+        schema_factory->update_regions(regions);
+        if (_op_type == pb::OP_PREPARE && _client_conn->transaction_has_write()) {
+            _state->set_optimize_1pc(false);
+            DB_DONE(WARNING, "TransactionNote: disable optimize_1pc due to split");
+        }
+        for (auto& r : regions) {
+            if (r.region_id() != _region_id) {
+                BAIDU_SCOPED_LOCK(_client_conn->region_lock);
+                _client_conn->region_infos[r.region_id()] = r;
+                _fetcher_store->skip_region_set.insert(r.region_id());
+                _fetcher_store->region_count++;
+            } else {
+                if (_response.leader() != "0.0.0.0:0") {
+                    DB_WARNING("region_id: %ld set new_leader: %s when old_version", _region_id, r.leader().c_str());
+                    r.set_leader(_response.leader());
                 }
-                ret = send_request(state, store_request, r_copy, trace_node, old_region_id, r_copy.region_id(),
-                                   log_id, retry_times + 1, last_seq_id, current_seq_id, op_type);
-                if (ret != E_OK) {
-                    DB_WARNING("retry failed, region_id: %ld, log_id:%lu, txn_id: %lu",
-                               r_copy.region_id(), log_id, state->txn_id);
-                    return E_FATAL;
+                BAIDU_SCOPED_LOCK(_client_conn->region_lock);
+                _client_conn->region_infos[_region_id].set_end_key(r.start_key());
+                _client_conn->region_infos[_region_id].set_end_key(r.end_key());
+                _client_conn->region_infos[_region_id].set_version(r.version());
+                if (r.leader() != "0.0.0.0:0") {
+                    _client_conn->region_infos[_region_id].set_leader(r.leader());
                 }
             }
-            return E_OK;
         }
-        return E_FATAL;
+        int last_seq_id = _response.has_last_seq_id()? _response.last_seq_id() : _start_seq_id;
+        for (auto& r : regions) {
+            pb::RegionInfo* info = nullptr;
+            {       
+                BAIDU_SCOPED_LOCK(_client_conn->region_lock);
+                info = &(_client_conn->region_infos[r.region_id()]);
+            }
+            auto task = new OnRPCDone(_fetcher_store, _state, _store_request, info, 
+                    _old_region_id, info->region_id(), last_seq_id, _current_seq_id, _op_type);
+            _rpc_ctrl->add_new_task(task);
+        }
+        return E_OK;
+    } else if (_response.regions_size() == 1) {
+        auto regions = _response.regions();
+        regions.Clear();
+        for (auto r : _response.regions()) {
+            if (r.region_id() != _region_id) {
+                DB_WARNING("not the same region:%s",
+                            r.ShortDebugString().c_str());
+                return E_FATAL;
+            }
+            if (!(r.start_key() <= _info.start_key() &&
+                    end_key_compare(r.end_key(), _info.end_key()) >= 0)) {
+                DB_FATAL("store region not overlap local region, region_id:%ld",
+                        _region_id);
+                return E_FATAL;
+            }
+            DB_WARNING("version region:%s", r.ShortDebugString().c_str());
+            *regions.Add() = r;
+        }
+        int last_seq_id = _response.has_last_seq_id()? _response.last_seq_id() : _start_seq_id;
+        for (auto& r : regions) {
+            auto r_copy = r;
+            pb::RegionInfo* info = nullptr;
+            {
+                BAIDU_SCOPED_LOCK(_client_conn->region_lock);
+                _client_conn->region_infos[_region_id].set_start_key(r_copy.start_key());
+                _client_conn->region_infos[_region_id].set_end_key(r_copy.end_key());
+                _client_conn->region_infos[_region_id].set_version(r_copy.version());
+                if (r_copy.leader() != "0.0.0.0:0") {
+                    _client_conn->region_infos[_region_id].set_leader(r_copy.leader());
+                }
+                info = &(_client_conn->region_infos[r.region_id()]);
+            }
+            auto task = new OnRPCDone(_fetcher_store, _state, _store_request, info, 
+                        _old_region_id, info->region_id(), last_seq_id, _current_seq_id, _op_type);
+            _rpc_ctrl->add_new_task(task);
+        }
+        return E_OK;
     }
-    if (res.errcode() == pb::TXN_IS_ROLLBACK) {
-        DB_WARNING("TXN_IS_ROLLBACK, region_id:%ld, txn_id:%lu, new_leader:%s, log_id:%lu op_type:%s",
-                region_id, state->txn_id, res.leader().c_str(), log_id, pb::OpType_Name(op_type).c_str());
+    return E_FATAL;
+}
+
+ErrorType OnRPCDone::handle_response(const std::string& remote_side) {
+    SchemaFactory* schema_factory = SchemaFactory::get_instance();
+    if (_cntl.has_backup_request()) {
+        DB_DONE(WARNING, "has_backup_request");
+        has_backup_send_request << _query_time.get_time();
+        // backup先回，整体时延包含dynamic_timeout_ms，不做统计
+        // remote_side != _addr 说明backup先回
+        if (remote_side != _addr) {
+            //业务快速置状态
+            schema_factory->update_instance(_addr, pb::BUSY, true, false);
+            _state->need_statistics = false;
+        }
+    } else {
+        if (_response.errcode() != pb::SUCCESS) {
+            // 失败请求会重试，可能统计的时延不准，不做统计
+            _state->need_statistics = false;
+        } else {
+            // 请求结束再次判断请求的实例状态，非NORMAL则时延不可控，不做统计
+            if (_state->need_statistics) {
+                auto status = SchemaFactory::get_instance()->get_instance_status(_addr);
+                if (status.status != pb::NORMAL) {
+                    _state->need_statistics = false;
+                }
+            }
+        }
+    }
+    if (_access_learner && (_response.errcode() == pb::REGION_NOT_EXIST || _response.errcode() == pb::LEARNER_NOT_READY)) {
+        DB_DONE(WARNING, "learner not ready, errcode: %s", pb::ErrCode_Name(_response.errcode()).c_str());
+        _fetcher_store->learner_status.set_learner_cannot_access(_info.region_id(), _addr);
+        bthread_usleep(_retry_times * FLAGS_retry_interval_us);
+        return E_RETRY;
+    }
+    if (_response.errcode() == pb::NOT_LEADER) {
+        // 兼容not leader报警，匹配规则 NOT_LEADER.*retry:4
+        DB_DONE(WARNING, "NOT_LEADER, new_leader:%s, retry:%d", _response.leader().c_str(), _retry_times);
+        if (_response.leader() != "0.0.0.0:0") {
+            // store返回了leader，则相信store，不判断normal
+            _info.set_leader(_response.leader());
+            schema_factory->update_leader(_info);
+        } else {
+            FetcherStore::other_normal_peer_to_leader(_info, _addr);
+           
+        }
+        if (_state->txn_id != 0 ) {
+            BAIDU_SCOPED_LOCK(_client_conn->region_lock);
+            _client_conn->region_infos[_region_id].set_leader(_info.leader());
+        }
+        // leader切换在秒级
+        bthread_usleep(_retry_times * FLAGS_retry_interval_us);
+        return E_RETRY;
+    }
+    if (_response.errcode() == pb::DISABLE_WRITE_TIMEOUT || _response.errcode() == pb::RETRY_LATER || _response.errcode() == pb::IN_PROCESS) {
+        DB_DONE(WARNING, "request failed, errcode: %s", pb::ErrCode_Name(_response.errcode()).c_str());
+        bthread_usleep(_retry_times * FLAGS_retry_interval_us);
+        return E_RETRY;
+    }
+
+    if (_response.errcode() == pb::VERSION_OLD) {
+        return handle_version_old();
+    }
+    if (_response.errcode() == pb::TXN_IS_ROLLBACK) {
+        DB_DONE(WARNING, "TXN_IS_ROLLBACK, new_leader:%s", _response.leader().c_str());
         return E_RETURN;
     }
-    if (res.errcode() == pb::REGION_NOT_EXIST || res.errcode() == pb::INTERNAL_ERROR) {
-        DB_WARNING("REGION_NOT_EXIST, region_id:%ld, retry:%d, new_leader:%s, log_id:%lu",
-                region_id, retry_times, res.leader().c_str(), log_id);
-        other_normal_peer_to_leader(info, addr);
-        //bthread_usleep(retry_times * FLAGS_retry_interval_us);
-        return send_request(state, store_request, info, trace_node, old_region_id, region_id, log_id,
-                   retry_times + 1, start_seq_id, current_seq_id, op_type);
-    }
-    if (res.errcode() != pb::SUCCESS) {
-        if (res.has_mysql_errcode()) {
-            BAIDU_SCOPED_LOCK(region_lock);
-            state->error_code = (MysqlErrCode)res.mysql_errcode();
-            state->error_msg.str(res.errmsg());
+    if (_response.errcode() == pb::REGION_NOT_EXIST || _response.errcode() == pb::INTERNAL_ERROR) {
+        DB_DONE(WARNING, "new_leader:%s，errcode: %s", _response.leader().c_str(), pb::ErrCode_Name(_response.errcode()).c_str());
+        if (_response.errcode() == pb::REGION_NOT_EXIST) {
+            pb::RegionInfo tmp_info;
+            // 已经被merge了并且store已经删掉了，按正常处理
+            int ret = schema_factory->get_region_info(_info.table_id(), _region_id, tmp_info);
+            if (ret != 0) {
+                DB_DONE(WARNING, "REGION_NOT_EXIST, region merge, new_leader:%s", _response.leader().c_str());
+                return E_OK;
+            }
         }
-        DB_WARNING("errcode:%d, mysql_errcode:%d, msg:%s, failed, instance:%s region_id:%ld, log_id:%lu",
-                res.errcode(), res.mysql_errcode(), res.errmsg().c_str(), addr.c_str(), region_id, log_id);
-        if (state->error_code == ER_DUP_ENTRY) {
+        schema_factory->update_instance(remote_side, pb::FAULTY, false, false);
+        FetcherStore::other_normal_peer_to_leader(_info, _addr);
+        return E_RETRY;
+    }
+    if (_response.errcode() != pb::SUCCESS) {
+        if (_response.has_mysql_errcode()) {
+            BAIDU_SCOPED_LOCK(_fetcher_store->region_lock);
+            _fetcher_store->error_code = (MysqlErrCode)_response.mysql_errcode();
+            _fetcher_store->error_msg.str(_response.errmsg());
+        }
+        DB_DONE(WARNING, "errcode:%s, mysql_errcode:%d, msg:%s, failed",
+                pb::ErrCode_Name(_response.errcode()).c_str(), _response.mysql_errcode(), _response.errmsg().c_str());
+        if (_fetcher_store->error_code == ER_DUP_ENTRY) {
             return E_WARNING;
         }
         return E_FATAL;
     }
 
-    if (res.records_size() > 0) {
-        int64_t main_table_id = info.has_main_table_id() ? info.main_table_id() : info.table_id();
+    if (_response.records_size() > 0) {
+        int64_t main_table_id = _info.has_main_table_id() ? _info.main_table_id() : _info.table_id();
         if (main_table_id <= 0) {
-            DB_FATAL("impossible branch region_id:%ld, log_id:%lu", region_id, log_id);
+            DB_DONE(FATAL, "impossible branch");
             return E_FATAL;
         }
         std::map<int64_t, std::vector<SmartRecord>> result_records;
         SmartRecord record_template = schema_factory->new_record(main_table_id);
-        for (auto& records_pair : res.records()) {
+        for (auto& records_pair : _response.records()) {
             int64_t index_id = records_pair.index_id();
             for (auto& str_record : records_pair.records()) {
                 SmartRecord record = record_template->clone(false);
                 auto ret = record->decode(str_record);
                 if (ret < 0) {
-                    DB_FATAL("decode to record fail, region_id:%ld, log_id:%lu", region_id, log_id);
+                    DB_DONE(FATAL, "decode to record fail");
                     return E_FATAL;
                 }
                 //DB_WARNING("record: %s", record->debug_string().c_str());
@@ -574,111 +644,148 @@ ErrorType FetcherStore::send_request(
             }
         }
         {
-            BAIDU_SCOPED_LOCK(region_lock);
+            BAIDU_SCOPED_LOCK(_fetcher_store->region_lock);
             for (auto& result_record : result_records) {
                 int64_t index_id = result_record.first;
-                index_records[index_id].insert(index_records[index_id].end(), result_record.second.begin(), result_record.second.end());
+                _fetcher_store->index_records[index_id].insert(_fetcher_store->index_records[index_id].end(), result_record.second.begin(), result_record.second.end());
             }
         }
     }
-    if (res.has_scan_rows()) {
-        scan_rows += res.scan_rows();
+    if (_response.has_scan_rows()) {
+        _fetcher_store->scan_rows += _response.scan_rows();
     }
-    if (res.has_filter_rows()) {
-        filter_rows += res.filter_rows();
+    if (_response.has_filter_rows()) {
+        _fetcher_store->filter_rows += _response.filter_rows();
     }
-    if (res.has_last_insert_id()) {
-        client_conn->last_insert_id = res.last_insert_id();
+    if (_response.has_last_insert_id()) {
+        _client_conn->last_insert_id = _response.last_insert_id();
     }
-    if (op_type != pb::OP_SELECT && op_type != pb::OP_SELECT_FOR_UPDATE) {
-        affected_rows += res.affected_rows();
+    if (_op_type != pb::OP_SELECT && _op_type != pb::OP_SELECT_FOR_UPDATE) {
+        _fetcher_store->affected_rows += _response.affected_rows();
         return E_OK;
     }
-    if (!res.leader().empty() && res.leader() != "0.0.0.0:0" && res.leader() != info.leader()) {
-        info.set_leader(res.leader());
-        schema_factory->update_leader(info);
-        if (state->txn_id != 0) {
-            BAIDU_SCOPED_LOCK(client_conn->region_lock);
-            client_conn->region_infos[region_id].set_leader(res.leader());
+    if (!_response.leader().empty() && _response.leader() != "0.0.0.0:0" && _response.leader() != _info.leader()) {
+        _info.set_leader(_response.leader());
+        schema_factory->update_leader(_info);
+        if (_state->txn_id != 0) {
+            BAIDU_SCOPED_LOCK(_client_conn->region_lock);
+            _client_conn->region_infos[_region_id].set_leader(_response.leader());
         }
     }
-    cost.reset();
-    if (res.row_values_size() > 0) {
-        row_cnt += res.row_values_size();
+    TimeCost cost;
+    if (_response.row_values_size() > 0) {
+        _fetcher_store->row_cnt += _response.row_values_size();
     }
     // TODO reduce mem used by streaming
-    if ((!state->is_full_export) && (row_cnt > FLAGS_max_select_rows)) {
-        DB_FATAL("_row_cnt:%ld > %ld max_select_rows", row_cnt.load(), FLAGS_max_select_rows);
+    if ((!_state->is_full_export) && (_fetcher_store->row_cnt > FLAGS_max_select_rows)) {
+        DB_DONE(FATAL, "_row_cnt:%ld > %ld max_select_rows", _fetcher_store->row_cnt.load(), FLAGS_max_select_rows);
         return E_BIG_SQL;
     }
     std::shared_ptr<RowBatch> batch = std::make_shared<RowBatch>();
     std::vector<int64_t> ttl_batch;
     ttl_batch.reserve(100);
-    bool global_ddl_with_ttl = (res.row_values_size() > 0 && res.row_values_size() == res.ttl_timestamp_size()) ? true : false;
+    bool global_ddl_with_ttl = (_response.row_values_size() > 0 && _response.row_values_size() == _response.ttl_timestamp_size()) ? true : false;
     int ttl_idx = 0;
-    for (auto& pb_row : res.row_values()) {
-        if (pb_row.tuple_values_size() != res.tuple_ids_size()) {
+    for (auto& pb_row : _response.row_values()) {
+        if (pb_row.tuple_values_size() != _response.tuple_ids_size()) {
             // brpc SelectiveChannel+backup_request有bug，pb的repeated字段merge到一起了
             SQL_TRACE("backup_request size diff, tuple_values_size:%d tuple_ids_size:%d rows:%d", 
-                    pb_row.tuple_values_size(), res.tuple_ids_size(), res.row_values_size());
-            for (auto id : res.tuple_ids()) {
+                    pb_row.tuple_values_size(), _response.tuple_ids_size(), _response.row_values_size());
+            for (auto id : _response.tuple_ids()) {
                 SQL_TRACE("tuple_id:%d  ", id);
             }
-            return send_request(state, store_request, info, trace_node, old_region_id, region_id, log_id,
-                    retry_times + 1, start_seq_id, current_seq_id, op_type);
+            return E_RETRY;
         }
-        std::unique_ptr<MemRow> row = state->mem_row_desc()->fetch_mem_row();
-        for (int i = 0; i < res.tuple_ids_size(); i++) {
-            int32_t tuple_id = res.tuple_ids(i);
+        std::unique_ptr<MemRow> row = _state->mem_row_desc()->fetch_mem_row();
+        for (int i = 0; i < _response.tuple_ids_size(); i++) {
+            int32_t tuple_id = _response.tuple_ids(i);
             row->from_string(tuple_id, pb_row.tuple_values(i));
-            //DB_WARNING("row:%s", row->debug_string(tuple_id).c_str());
         }
-        if (0 != memory_limit_exceeded(state, row.get())) {
+        if (0 != _state->memory_limit_exceeded(_fetcher_store->row_cnt, row->used_size())) {
+            BAIDU_SCOPED_LOCK(_fetcher_store->region_lock);
+            _state->error_code = ER_TOO_BIG_SELECT;
+            _state->error_msg.str("select reach memory limit");
             return E_FATAL;
         }
         batch->move_row(std::move(row));
         if (global_ddl_with_ttl) {
-            int64_t time_us = res.ttl_timestamp(ttl_idx++);
+            int64_t time_us = _response.ttl_timestamp(ttl_idx++);
             ttl_batch.emplace_back(time_us);
-            DB_DEBUG("region_id: %ld, ttl_timestamp: %ld", region_id, time_us);
+            DB_DEBUG("region_id: %ld, ttl_timestamp: %ld", _region_id, time_us);
         }
     }
     if (global_ddl_with_ttl) {
-        BAIDU_SCOPED_LOCK(ttl_timestamp_mutex);
-        region_id_ttl_timestamp_batch[region_id] = ttl_batch;
-        DB_DEBUG("region_id: %ld, ttl_timestamp_size: %ld", region_id, ttl_batch.size());
+        BAIDU_SCOPED_LOCK(_fetcher_store->region_lock);
+        _fetcher_store->region_id_ttl_timestamp_batch[_region_id] = ttl_batch;
+        DB_DEBUG("_region_id: %ld, ttl_timestamp_size: %ld", _region_id, ttl_batch.size());
     }
-    if (res.has_cmsketch() && state->cmsketch != nullptr) {
-        state->cmsketch->add_proto(res.cmsketch());
-        DB_WARNING("region_id:%ld, cmsketch:%s", region_id, res.cmsketch().ShortDebugString().c_str());
+    if (_response.has_cmsketch() && _state->cmsketch != nullptr) {
+        _state->cmsketch->add_proto(_response.cmsketch());
+        DB_DONE(WARNING, "cmsketch:%s", _response.cmsketch().ShortDebugString().c_str());
     }
     // 减少锁冲突
-    if (region_batch.count(region_id) == 1) {
-        region_batch[region_id] = batch;
+    if (_fetcher_store->region_batch.count(_region_id) == 1) {
+        _fetcher_store->region_batch[_region_id] = batch;
     } else {
         //分裂单独处理
-        BAIDU_SCOPED_LOCK(region_lock);
-        split_start_key_sort.emplace(info.start_key(), region_id);
-        split_region_batch[region_id] = batch;
+        BAIDU_SCOPED_LOCK(_fetcher_store->region_lock);
+        _fetcher_store->split_start_key_sort.emplace(_info.start_key(), _region_id);
+        _fetcher_store->split_region_batch[_region_id] = batch;
+    }
+
+    if (_trace_node != nullptr) {
+        std::string desc = "baikalDB FetcherStore send_request "
+                            + pb::ErrCode_Name(_response.errcode());
+        _trace_node->set_description(_trace_node->description() + " " + desc);
+        _trace_node->set_total_time(_total_cost.get_time());
+        _trace_node->set_affect_rows(_response.affected_rows());
+        pb::TraceNode* local_trace = _trace_node->add_child_nodes();
+        if (_response.has_errmsg() && _response.errcode() == pb::SUCCESS) {
+            pb::TraceNode trace;
+            if (!trace.ParseFromString(_response.errmsg())) {
+                DB_FATAL("parse from pb fail");
+            } else {
+                (*local_trace) = trace;
+            }
+        }
     }
     if (cost.get_time() > FLAGS_print_time_us) {
-        DB_WARNING("parse region:%ld time:%ld rows:%lu log_id:%lu ",
-                region_id, cost.get_time(), batch->size(), log_id);
+        DB_DONE(WARNING, "parse time:%ld rows:%lu", cost.get_time(), batch->size());
     }
     return E_OK;
 }
 
-int FetcherStore::memory_limit_exceeded(RuntimeState* state, MemRow* row) {
-    if (row_cnt > FLAGS_db_row_number_to_check_memory) {
-        if (0 != state->memory_limit_exceeded(row->used_size())) {
-            BAIDU_SCOPED_LOCK(region_lock);
-            state->error_code = ER_TOO_BIG_SELECT;
-            state->error_msg.str("select reach memory limit");
-            return -1;
-        }
+void OnRPCDone::send_request() {
+    auto err = check_status();
+    if (err != E_OK) {
+        _fetcher_store->error = err;
+        _rpc_ctrl->task_finish(this);
+        return;
     }
-    used_bytes += row->used_size();
-    return 0;
+
+    // 处理request，重试时不用再填充req
+    if (!_has_fill_request) {
+        err = fill_request();
+        if (err != E_OK) {
+            _fetcher_store->error = err;
+            _rpc_ctrl->task_finish(this);
+            return;
+        }
+        _has_fill_request = true;
+    }
+
+    // 选择请求的store地址
+    select_addr();
+
+    err = send_async();
+    if (err == E_RETRY) {
+        _rpc_ctrl->task_retry(this);
+    } else if (err != E_ASYNC) {
+        if (err != E_OK) {
+            _fetcher_store->error = err;
+        }
+        _rpc_ctrl->task_finish(this);
+    }
 }
 
 void FetcherStore::choose_other_if_faulty(pb::RegionInfo& info, std::string& addr) {
@@ -879,9 +986,12 @@ ErrorType FetcherStore::write_binlog(RuntimeState* state,
             }
             req.set_region_id(info.region_id());
             req.set_region_version(info.version());
+        } else if (res.errcode() == pb::REGION_NOT_EXIST) {
+            other_normal_peer_to_leader(info, addr);
+            retry_times++;
         } else if (res.errcode() != pb::SUCCESS) {
-            DB_WARNING("errcode:%d, failed, instance:%s region_id:%ld retry:%d log_id:%lu",
-                    res.errcode(), addr.c_str(), region_id, retry_times, log_id);
+            DB_WARNING("errcode:%s, write_binlog failed, instance:%s region_id:%ld retry:%d log_id:%lu",
+                    pb::ErrCode_Name(res.errcode()).c_str(), addr.c_str(), region_id, retry_times, log_id);
             return E_FATAL;
         } else {
             // success
@@ -909,14 +1019,42 @@ ErrorType FetcherStore::write_binlog(RuntimeState* state,
     }
 }
 
-int FetcherStore::run(RuntimeState* state,
+int64_t FetcherStore::get_dynamic_timeout_ms(ExecNode* store_request, pb::OpType op_type, uint64_t sign) {
+    int64_t dynamic_timeout_ms = -1;
+
+    if (FLAGS_use_dynamic_timeout && op_type == pb::OP_SELECT) {
+        SchemaFactory* factory = SchemaFactory::get_instance();
+        std::shared_ptr<SqlStatistics> sql_info = factory->get_sql_stat(sign);
+        if (sql_info != nullptr) {
+            dynamic_timeout_ms = sql_info->dynamic_timeout_ms();
+        }
+
+        std::vector<ExecNode*> scan_nodes;
+        store_request->get_node(pb::SCAN_NODE, scan_nodes);
+        if (sql_info != nullptr && scan_nodes.size() == 1) {
+            ScanNode* scan_node = static_cast<ScanNode*>(scan_nodes[0]);
+            int64_t heap_top = sql_info->latency_heap_top();
+            if (scan_node->learner_use_diff_index() && heap_top > 0) {
+                DB_WARNING("dynamic_timeout_ms: %ld, heap_top: %ld", dynamic_timeout_ms, heap_top);
+                if (dynamic_timeout_ms <= 0 ) {
+                    dynamic_timeout_ms = heap_top;
+                } else {
+                    dynamic_timeout_ms = std::min(dynamic_timeout_ms, heap_top);
+                }
+            }
+        }
+    }
+
+    return dynamic_timeout_ms;
+}
+
+int FetcherStore::run_not_set_state(RuntimeState* state,
                     std::map<int64_t, pb::RegionInfo>& region_infos,
                     ExecNode* store_request,
                     int start_seq_id,
                     int current_seq_id,
-                    pb::OpType op_type) {
-    //DB_WARNING("start_seq_id: %d, current_seq_id: %d op_type: %s", start_seq_id,
-    //        current_seq_id, pb::OpType_Name(op_type).c_str());
+                    pb::OpType op_type, 
+                    GlobalBackupType backup_type) {
     region_batch.clear();
     split_region_batch.clear();
     index_records.clear();
@@ -925,43 +1063,35 @@ int FetcherStore::run(RuntimeState* state,
     no_copy_cache_plan_set.clear();
     error = E_OK;
     skip_region_set.clear();
+    callids.clear();
     primary_timestamp_updated = false;
     affected_rows = 0;
     scan_rows = 0;
     filter_rows = 0;
     row_cnt = 0;
     client_conn = state->client_conn();
-    state->region_count += region_infos.size();
-    analyze_fail_cnt = 0;
-    //TimeCost cost;
+    region_count += region_infos.size();
+    global_backup_type = backup_type;
     if (region_infos.size() == 0) {
         DB_WARNING("region_infos size == 0, op_type:%s", pb::OpType_Name(op_type).c_str());
         return E_OK;
     }
-    if (FLAGS_use_dynamic_timeout && op_type == pb::OP_SELECT) {
-        SchemaFactory* factory = SchemaFactory::get_instance();
-        std::shared_ptr<SqlStatistics> sql_info = factory->get_sql_stat(state->sign);
-        if (sql_info != nullptr) {
-            dynamic_timeout_ms = sql_info->dynamic_timeout_ms();
-        }
-    }
+
+    dynamic_timeout_ms = get_dynamic_timeout_ms(store_request, op_type, state->sign);
+
     // 预分配空洞
     for (auto& pair : region_infos) {
         start_key_sort.emplace(pair.second.start_key(), pair.first);
         region_batch[pair.first] = nullptr;
     }
     uint64_t log_id = state->log_id();
-    ErrorType ret = E_OK;
     // 选择primary region同时保证第一次请求primary region成功
     if ((state->txn_id != 0) && (client_conn->primary_region_id == -1) && op_type != pb::OP_SELECT) {
         auto info_iter = region_infos.begin();
         client_conn->primary_region_id = info_iter->first;
         client_conn->txn_pri_region_last_exec_time = butil::gettimeofday_us();
-        //DB_WARNING("select primary_region_id:%ld txn_id:%lu op_type:%s",
-        //       client_conn->primary_region_id.load(), state->txn_id, pb::OpType_Name(op_type).c_str());
-        ret = send_request(state, store_request, info_iter->second, info_iter->first, info_iter->first, log_id,
-                0, start_seq_id, current_seq_id, op_type);
-        if (ret == E_RETURN) {
+        send_request(state, store_request, &info_iter->second, start_seq_id, current_seq_id, op_type);
+        if (error == E_RETURN) {
             DB_WARNING("primary_region_id:%ld rollbacked, log_id:%lu op_type:%s",
                 client_conn->primary_region_id.load(), log_id, pb::OpType_Name(op_type).c_str());
             if (op_type == pb::OP_COMMIT || op_type == pb::OP_ROLLBACK) {
@@ -971,10 +1101,10 @@ int FetcherStore::run(RuntimeState* state,
                 return -1;
             }
         }
-        if (ret != E_OK) {
+        if (error != E_OK) {
             DB_WARNING("rpc error, primary_region_id:%ld, log_id:%lu op_type:%s",
                             client_conn->primary_region_id.load(), log_id, pb::OpType_Name(op_type).c_str());
-            if (ret != E_WARNING) {
+            if (error != E_WARNING) {
                 client_conn->state = STATE_ERROR;
             }
             return -1;
@@ -991,7 +1121,6 @@ int FetcherStore::run(RuntimeState* state,
             DB_FATAL("something wrong primary_region_id: %ld", primary_region_id);
             return E_OK;
         }
-        ErrorType ret = E_OK;
         // commit命令获取commit_ts需要发送给store
         if (op_type == pb::OP_COMMIT && need_process_binlog(state, op_type)) {
             int64_t commit_ts = get_commit_ts();
@@ -1004,14 +1133,14 @@ int FetcherStore::run(RuntimeState* state,
         }
         int retry_times = 0;
         do {
-            ret = send_request(state, store_request, iter->second, primary_region_id, primary_region_id, log_id,
-                0, start_seq_id, current_seq_id, op_type);
-            if (ret == E_RETURN) {
+            error = E_OK; // 每次重试前将error设置为E_OK
+            send_request(state, store_request, &iter->second, start_seq_id, current_seq_id, op_type);
+            if (error == E_RETURN) {
                 DB_WARNING("primary_region_id:%ld rollbacked, log_id:%lu op_type:%s",
                     primary_region_id, log_id, pb::OpType_Name(op_type).c_str());
                 return E_OK;
             }
-            if (ret != E_OK) {
+            if (error != E_OK) {
                 DB_FATAL("send optype:%s to region_id:%ld txn_id:%lu failed, log_id:%lu ", pb::OpType_Name(op_type).c_str(),
                     primary_region_id, state->txn_id, log_id);
                 if (retry_times < 5) {
@@ -1020,11 +1149,11 @@ int FetcherStore::run(RuntimeState* state,
                 // 每次多延迟5s重试，leader切换耗时评估后考虑去掉无限重试
                 bthread_usleep(retry_times * FLAGS_retry_interval_us * 10L);
             }
-        } while (ret != E_OK);
+        } while (error != E_OK);
         skip_region_set.insert(primary_region_id);
     }
 
-    ret = process_binlog_start(state, op_type);
+    auto ret = process_binlog_start(state, op_type);
     if (ret != E_OK) {
         DB_FATAL("process binlog op_type:%s txn_id:%lu failed, log_id:%lu ", pb::OpType_Name(op_type).c_str(),
              state->txn_id, log_id);
@@ -1032,120 +1161,25 @@ int FetcherStore::run(RuntimeState* state,
     }
 
     // 构造并发送请求
-    std::map<std::string, std::set<std::shared_ptr<TraceDesc>>> send_region_ids_map; // leader ip => region_ids
-    int send_region_count = 0;
+    std::vector<pb::RegionInfo*> infos;
+    infos.reserve(region_infos.size());
     for (auto& pair : region_infos) {
-        if (skip_region_set.count(pair.first) > 0) {
+        int64_t region_id = pair.first;
+        if (skip_region_set.count(region_id) > 0) {
             continue;
         }
-        ++send_region_count;
-        std::shared_ptr<TraceDesc> trace = std::make_shared<TraceDesc>();
-        trace->region_id = pair.first;
-        if (store_request->get_trace() != nullptr) {
-            std::shared_ptr<pb::TraceNode> child_trace = std::make_shared<pb::TraceNode>();
-            trace->trace_node = child_trace;
-        }
-        send_region_ids_map[pair.second.leader()].insert(trace);
-    }
-    if (send_region_count == 1) {
-        auto& trace = *send_region_ids_map.begin()->second.begin();
-        int64_t region_id = trace->region_id;
-        // 这两个资源后续不会分配新的，因此不需要加锁
+
         pb::RegionInfo* info = nullptr;
         if (region_infos.count(region_id) != 0) {
             info = &region_infos[region_id];
         } else if (state->txn_id != 0) {
-            BAIDU_SCOPED_LOCK(state->client_conn()->region_lock);
-            info = &(state->client_conn()->region_infos[region_id]);
+            BAIDU_SCOPED_LOCK(client_conn->region_lock);
+            info = &(client_conn->region_infos[region_id]);
         }
-        auto ret = send_request(state, store_request, *info, trace->trace_node.get(), region_id, region_id, log_id,
-                0, start_seq_id, current_seq_id, op_type);
-        if (ret != E_OK) {
-            DB_WARNING("rpc error, region_id:%ld, log_id:%lu op_type:%s",
-                    region_id, log_id, pb::OpType_Name(op_type).c_str());
-            error = ret;
-        }
-    } else if (send_region_count <= FLAGS_single_store_concurrency) {
-        ConcurrencyBthread con_bth(send_region_count, &BTHREAD_ATTR_SMALL);
-        for (auto& pair : send_region_ids_map) {
-            for (auto& trace : pair.second) {
-                int64_t region_id = trace->region_id;
-                // 这两个资源后续不会分配新的，因此不需要加锁
-                pb::RegionInfo* info = nullptr;
-                if (region_infos.count(region_id) != 0) {
-                    info = &region_infos[region_id];
-                } else if (state->txn_id != 0) {
-                    BAIDU_SCOPED_LOCK(state->client_conn()->region_lock);
-                    info = &(state->client_conn()->region_infos[region_id]);
-                }
-
-                auto req_thread = [this, state, store_request, info, trace, region_id, log_id, current_seq_id,
-                     start_seq_id, op_type]() {
-                         auto ret = send_request(state, store_request, *info, trace->trace_node.get(), region_id, region_id, log_id,
-                                 0, start_seq_id, current_seq_id, op_type);
-                         if (ret != E_OK) {
-                             DB_WARNING("rpc error, region_id:%ld, log_id:%lu op_type:%s",
-                                     region_id, log_id, pb::OpType_Name(op_type).c_str());
-                             error = ret;
-                         }
-                     };
-                con_bth.run(req_thread);
-            }
-        }
-        con_bth.join();
-    } else {
-        BthreadCond store_cond; // 不同store并发
-        for (auto& pair : send_region_ids_map) {
-            store_cond.increase();
-            auto store_thread = [this, state, store_request, pair, log_id, start_seq_id, current_seq_id,
-                 &region_infos, &store_cond, op_type, send_region_count]() {
-                     ON_SCOPE_EXIT([&store_cond]{store_cond.decrease_signal();});
-                     BthreadCond cond(-FLAGS_single_store_concurrency); // 单store内并发数
-                     for (auto& trace : pair.second) {
-                         int64_t region_id = trace->region_id;
-                         // 这两个资源后续不会分配新的，因此不需要加锁
-                         pb::RegionInfo* info = nullptr;
-                         if (region_infos.count(region_id) != 0) {
-                             info = &region_infos[region_id];
-                         } else if (state->txn_id != 0) {
-                             BAIDU_SCOPED_LOCK(state->client_conn()->region_lock);
-                             info = &(state->client_conn()->region_infos[region_id]);
-                         }
-                         cond.increase();
-                         cond.wait();
-                         auto req_thread = [this, state, store_request, info, trace, region_id, log_id, current_seq_id,
-                              start_seq_id, &cond, op_type, send_region_count]() {
-                                  ON_SCOPE_EXIT([&cond]{cond.decrease_signal();});
-                                  auto ret = send_request(state, store_request, *info, trace->trace_node.get(), region_id, region_id, log_id,
-                                          0, start_seq_id, current_seq_id, op_type);
-                                  if (ret != E_OK) {
-                                      DB_WARNING("rpc error, region_id:%ld, log_id:%lu op_type:%s",
-                                              region_id, log_id, pb::OpType_Name(op_type).c_str());
-                                        if (state->explain_type == ANALYZE_STATISTICS) {
-                                            // 代价采样时，个别region报错可以继续
-                                            analyze_fail_cnt++;
-                                            //超过10%报错则退出
-                                            if (analyze_fail_cnt.load()*1.0/send_region_count > 0.1) {
-                                                error = ret;
-                                            }
-                                        } else {
-                                            error = ret;
-                                        }
-                                  }
-                              };
-                         // 怀疑栈溢出
-                         Bthread bth(&BTHREAD_ATTR_SMALL);
-                         bth.run(req_thread);
-                     }
-                     cond.wait(-FLAGS_single_store_concurrency);
-                 };
-            Bthread bth(&BTHREAD_ATTR_SMALL);
-            bth.run(store_thread);
-        }
-
-        // commit/rollback请求后续可以考虑异步执行，不等待
-        store_cond.wait();
+        infos.emplace_back(info);
     }
+
+    send_request(state, store_request, infos, start_seq_id, current_seq_id, op_type);
 
     process_binlog_done(state, op_type);
 
@@ -1154,14 +1188,15 @@ int FetcherStore::run(RuntimeState* state,
         client_conn->primary_region_id = -1;
         return E_OK;
     }
+
     if (error != E_OK) {
         if (error == E_FATAL
                 || error == E_BIG_SQL) {
             DB_FATAL("fetcher node open fail, log_id:%lu, txn_id: %lu, seq_id: %d op_type: %s",
                     log_id, state->txn_id, current_seq_id, pb::OpType_Name(op_type).c_str());
             if (error == E_BIG_SQL) {
-                state->error_code = ER_SQL_TOO_BIG;
-                state->error_msg.str("sql too big");
+                error_code = ER_SQL_TOO_BIG;
+                error_msg.str("sql too big");
             }
         } else {
             DB_WARNING("fetcher node open fail, log_id:%lu, txn_id: %lu, seq_id: %d op_type: %s",
@@ -1175,40 +1210,7 @@ int FetcherStore::run(RuntimeState* state,
     for (auto& pair : split_region_batch) {
         region_batch.emplace(pair.first, pair.second);
     }
-    std::map<uint64_t, std::shared_ptr<pb::TraceNode>> cost_trace_map;
-    if (store_request->get_trace() != nullptr) {
-        for (auto& pair : send_region_ids_map) {
-            for (auto& trace : pair.second) {
-                cost_trace_map[trace->trace_node->total_time()] = trace->trace_node;
-            }
-        }
-        int region_cnt = cost_trace_map.size();
-        if (region_cnt > 10 && state->explain_type == SHOW_TRACE) {
-            for (auto& pair : cost_trace_map) {
-                if (region_cnt > 10) {
-                    pb::LocalTraceNode* local_node = store_request->get_trace()->mutable_store_agg();
-                    int64_t scan_rows = TraceLocalNode::get_scan_rows(pair.second.get());
-                    int64_t affect_rows = pair.second->affect_rows();
-                    local_node->set_scan_rows(scan_rows + local_node->scan_rows());
-                    local_node->set_affect_rows(affect_rows + local_node->affect_rows());
-                } else {
-                    pb::TraceNode* trace = store_request->get_trace()->add_child_nodes();
-                    (*trace) = (*pair.second);
-                }
-                --region_cnt;
-            }
-        } else {
-            for (auto& pair : send_region_ids_map) {
-                for (auto& trace : pair.second) {
-                    (*store_request->get_trace()->add_child_nodes()) = *trace->trace_node;
-                }
-            }
-        }
-    }
-    state->set_num_scan_rows(state->num_scan_rows() + scan_rows.load());
-    state->set_num_filter_rows(state->num_filter_rows() + filter_rows.load());
-    //DB_WARNING("fetcher time:%ld, txn_id: %lu, log_id:%lu, batch_size:%lu",
-    //        cost.get_time(), state->txn_id, log_id, region_batch.size());
+
     return affected_rows.load();
 }
 }

--- a/src/exec/insert_manager_node.cpp
+++ b/src/exec/insert_manager_node.cpp
@@ -489,7 +489,7 @@ int InsertManagerNode::insert_on_dup_key_update(RuntimeState* state) {
             // 移除冲突行
             for (auto id : ids_set) {
                 if (_record_ids.erase(id)) {
-                    update_record(_on_dup_key_update_records[index_id][key]);
+                    update_record(_on_dup_key_update_records[index_id][key], _origin_records[id]);
                 }
             }
         }
@@ -501,10 +501,10 @@ int InsertManagerNode::insert_on_dup_key_update(RuntimeState* state) {
                 for (auto it = std::next(min); it != ids_set.end(); ++it) {
                     if (_record_ids.erase(*it)) {
                         dup_record_ids.insert(*it);
-                        update_record(_origin_records[*min]);
+                        update_record(_origin_records[*min], _origin_records[*it]);
                     }
                 }
-                _record_ids.insert(*min);
+                //_record_ids.insert(*min);
             }
         }
     }
@@ -576,14 +576,14 @@ int InsertManagerNode::insert_on_dup_key_update(RuntimeState* state) {
     return _affected_rows;
 }
 
-void InsertManagerNode::update_record(SmartRecord record) {
+void InsertManagerNode::update_record(const SmartRecord& record, const SmartRecord& origin_record) {
     // 处理values函数
     _dup_update_row->clear();
     if (_values_tuple_desc != nullptr) {
         for (auto slot : _values_tuple_desc->slots()) {
-            auto field = record->get_field_by_tag(slot.field_id());
+            auto field = origin_record->get_field_by_tag(slot.field_id());
             _dup_update_row->set_value(slot.tuple_id(), slot.slot_id(),
-                    record->get_value(field));
+                    origin_record->get_value(field));
         }
     }
     // 更新数据

--- a/src/exec/redis_scan_node.cpp
+++ b/src/exec/redis_scan_node.cpp
@@ -51,7 +51,8 @@ int RedisScanNode::open(RuntimeState* state) {
     }
     // 简单kv只有primary
     // 如果数据源支持各种索引，可以在这边做处理
-    const pb::PossibleIndex& pos_index = _pb_node.derive_node().scan_node().indexes(0);
+    pb::PossibleIndex pos_index;
+    pos_index.ParseFromString(_pb_node.derive_node().scan_node().indexes(0));
     _index_id = pos_index.index_id();
     SchemaFactory* factory = SchemaFactory::get_instance();
     auto index_info_ptr = factory->get_index_info_ptr(_index_id);

--- a/src/exec/sort_node.cpp
+++ b/src/exec/sort_node.cpp
@@ -45,7 +45,7 @@ int SortNode::init(const pb::PlanNode& node) {
             node->set_col_type(expr.nodes(0).col_type());
             node->set_num_children(0);
             node->mutable_derive_node()->set_tuple_id(_tuple_id);
-            node->mutable_derive_node()->set_slot_id(slot_id);
+            node->mutable_derive_node()->set_slot_id(slot_id++);
             ret = ExprNode::create_tree(slot_expr, &order_expr);
             if (ret < 0) {
                 //如何释放资源

--- a/src/exec/union_node.cpp
+++ b/src/exec/union_node.cpp
@@ -95,7 +95,12 @@ int UnionNode::open(RuntimeState* state) {
             if (batch_ptr->size() != 0) {
                 _sorter->add_batch(batch_ptr);
             }
+            runtime_state->inc_num_returned_rows(batch_ptr->size());
         } while (!eos);
+        state->set_num_affected_rows(state->num_affected_rows() + runtime_state->num_affected_rows());
+        state->set_num_scan_rows(state->num_scan_rows() + runtime_state->num_scan_rows());
+        state->set_num_filter_rows(state->num_filter_rows() + runtime_state->num_filter_rows());
+        state->region_count += runtime_state->region_count;
     }
     return 0;
 }

--- a/src/expr/agg_fn_call.cpp
+++ b/src/expr/agg_fn_call.cpp
@@ -264,7 +264,7 @@ bool AggFnCall::is_initialize(const std::string& key, MemRow* dst) {
 }
 
 // 聚合函数逻辑
-int AggFnCall::initialize(const std::string& key, int64_t& used_size, MemRow* dst) {
+int AggFnCall::initialize(const std::string& key, MemRow* dst) {
     ExprValue dst_val = dst->get_value(_tuple_id, _intermediate_slot_id);
     switch (_agg_type) {
         case COUNT_STAR:
@@ -310,7 +310,6 @@ int AggFnCall::initialize(const std::string& key, int64_t& used_size, MemRow* ds
                     dst->set_value(_tuple_id, _intermediate_slot_id, intermediate_val.val);
                 }
                 intermediate_val.is_assign = true;
-                used_size += intermediate_val.val.size();
             }
             return 0;
         }
@@ -335,7 +334,6 @@ int AggFnCall::initialize(const std::string& key, int64_t& used_size, MemRow* ds
                     // and第一次需要特殊处理
                     intermediate_val.is_assign = true;
                 }
-                used_size += intermediate_val.val.size();
             }
             return 0;
         }
@@ -353,7 +351,6 @@ int AggFnCall::initialize(const std::string& key, int64_t& used_size, MemRow* ds
                     dst->set_value(_tuple_id, _intermediate_slot_id, dst_val);
                 }
                 intermediate_val.is_assign = true;
-                used_size += intermediate_val.val.size();
             }
             return 0;
         }

--- a/src/expr/fn_manager.cpp
+++ b/src/expr/fn_manager.cpp
@@ -245,6 +245,8 @@ void FunctionManager::register_operators() {
 
     register_object_ret("version", version, pb::STRING);
     register_object_ret("last_insert_id", last_insert_id, pb::INT64);
+    //
+    register_object_ret("point_distance", point_distance, pb::INT64);
     register_object_ret("cast_to_date", cast_to_date, pb::DATE);
     register_object_ret("cast_to_time", cast_to_time, pb::TIME);
     register_object_ret("cast_to_datetime", cast_to_datetime, pb::DATETIME);
@@ -342,6 +344,9 @@ int FunctionManager::complete_fn(pb::Function& fn, std::vector<pb::PrimitiveType
             return 0;
         case parser::FT_COMMON:
             fn.set_return_type(return_type_map[fn.name()]);
+            complete_common_fn(fn, types);
+            return 0;
+        case parser::FT_MATCH_AGAINST:
             complete_common_fn(fn, types);
             return 0;
         default:
@@ -450,6 +455,8 @@ void FunctionManager::complete_common_fn(pb::Function& fn, std::vector<pb::Primi
         }
         DB_DEBUG("merge type : [%s]", pb::PrimitiveType_Name(ret_type).c_str());
         fn.set_return_type(ret_type);
+    } else if (fn.name() == "match_against") {
+        fn.set_return_type(pb::BOOL);
     }
 }
 }

--- a/src/expr/internal_functions.cpp
+++ b/src/expr/internal_functions.cpp
@@ -1175,7 +1175,7 @@ ExprValue week(const std::vector<ExprValue>& input) {
 }
 
 ExprValue datediff(const std::vector<ExprValue>& input) {
-    if (input.size() == 0 || input[0].is_null() || input[1].is_null()) {
+    if (input.size() != 2 || input[0].is_null() || input[1].is_null()) {
         return ExprValue::Null();
     }
     ExprValue left = input[0];
@@ -1873,6 +1873,24 @@ ExprValue last_insert_id(const std::vector<ExprValue>& input) {
     return tmp.cast_to(pb::INT64);
 }
 
+ExprValue point_distance(const std::vector<ExprValue>& input) {
+    if (input.size() < 4) {
+        return ExprValue::Null();
+    }
+    double latitude1 = input[0].get_numberic<double>();
+    double longitude1 = input[1].get_numberic<double>();
+    double latitude2 = input[2].get_numberic<double>();
+    double longitude2 = input[3].get_numberic<double>();
+    ExprValue result(pb::INT64);
+    double tmp_pow1 = std::pow(std::sin((latitude1 * M_PI / 180 - latitude2 * M_PI / 180) / 2),2);
+    double tmp_pow2 = std::pow(std::sin((longitude1  * M_PI / 180 - longitude2  * M_PI / 180) / 2),2);
+    double tmp_cos_multi = std::cos(latitude1  * M_PI / 180) * std::cos(latitude2  * M_PI / 180);
+    double tmp_sqrt = std::sqrt(tmp_pow1 + tmp_cos_multi * tmp_pow2);
+    double tmp_asin = std::asin(tmp_sqrt);
+    result._u.int64_val = std::round(1000 * 6378.138 * 2 * tmp_asin);
+    return result;
+}
+
 ExprValue cast_to_date(const std::vector<ExprValue>& input) {
     if (input.size() != 1) {
         return ExprValue::Null();
@@ -1920,6 +1938,7 @@ ExprValue cast_to_unsigned(const std::vector<ExprValue>& input) {
     ExprValue tmp = input[0];
     return tmp.cast_to(pb::UINT64);
 }
+
 }
 
 /* vim: set ts=4 sw=4 sts=4 tw=100 */

--- a/src/logical_plan/kill_planner.cpp
+++ b/src/logical_plan/kill_planner.cpp
@@ -45,7 +45,7 @@ int KillPlanner::plan() {
         if (sock->conn_id == k->conn_id) {
             DB_WARNING("conn_id equal %ld is_query:%d", k->conn_id, k->is_query);
             _ctx->kill_ctx = sock->query_ctx;
-            _ctx->kill_ctx->get_runtime_state()->cancel();
+            _ctx->kill_ctx->kill_all_ctx();
             // kill xxx 复用client_free,会导致被kill的sock的DataBuffer被继续占用，导致下一次建立连接失败
             // 但是kill指令用的很少，后续再考虑优化
             // kill query xx没问题

--- a/src/logical_plan/select_planner.cpp
+++ b/src/logical_plan/select_planner.cpp
@@ -116,7 +116,7 @@ int SelectPlanner::plan() {
     if (0 != create_agg_node()) {
         return -1;
     }
-    // greate_filter_node
+    // create_filter_node
     if (0 != create_filter_node(_where_filters, pb::WHERE_FILTER_NODE)) {
         return -1;
     }
@@ -215,7 +215,6 @@ bool SelectPlanner::check_conjuncts(std::vector<ExprNode*>& conjuncts) {
 bool SelectPlanner::check_single_conjunct(ExprNode* conjunct) {
     //conjunct的size为1同时含有limit节点
     auto& expr_head_node = conjunct;
-    auto expr_node_about_primary = expr_head_node->children(0);
     if (!is_range_compare(expr_head_node)) {
         return false;
     }
@@ -226,7 +225,11 @@ bool SelectPlanner::check_single_conjunct(ExprNode* conjunct) {
         return false;
     }
     auto& pk_fields_info = pk_field_info_ptr->fields;
+    if (expr_head_node->children_size() == 0) {
+        return false;
+    }
     //判断row_expr情况下的主键情况
+    auto expr_node_about_primary = expr_head_node->children(0);
     if (expr_node_about_primary->is_row_expr()) {
         RowExpr* row_expr = static_cast<RowExpr*>(expr_node_about_primary);
         std::map<size_t, SlotRef*> slots;

--- a/src/logical_plan/union_planner.cpp
+++ b/src/logical_plan/union_planner.cpp
@@ -72,17 +72,17 @@ int UnionPlanner::gen_select_stmts_plan() {
         if (ret < 0) {
             return -1;
         }
-        auto sub_ctx = _ctx->sub_query_plans.back();
         if (stmt_idx == 0) {
             final_select_names = _select_names;
         }
         // union的每个select的column个数必须一样
-        if (final_select_names.size() != sub_ctx->expr_params.row_filed_number) {
+        if (final_select_names.size() != _cur_sub_ctx->expr_params.row_filed_number) {
             _ctx->stat_info.error_code = ER_WRONG_NUMBER_OF_COLUMNS_IN_SELECT;
             _ctx->stat_info.error_msg << "The used SELECT statements have a different number of columns";
-            DB_WARNING("have a different number of columns %zu %d", final_select_names.size(), sub_ctx->expr_params.row_filed_number);
+            DB_WARNING("have a different number of columns %zu %d", final_select_names.size(), _cur_sub_ctx->expr_params.row_filed_number);
             return -1;
         }
+        _ctx->add_sub_ctx(_cur_sub_ctx);
     }
     _select_names.swap(final_select_names);
     return 0;

--- a/src/mem_row/mem_row_descriptor.cpp
+++ b/src/mem_row/mem_row_descriptor.cpp
@@ -18,6 +18,9 @@
 namespace baikaldb {
 
 int32_t MemRowDescriptor::init(std::vector<pb::TupleDescriptor>& tuple_desc) {
+    if (tuple_desc.size() == 0) {
+        return 0;
+    }
     if (nullptr == (_factory 
             = new (std::nothrow)google::protobuf::DynamicMessageFactory(&_pool))) {
         return -1;

--- a/src/meta_server/meta_state_machine.cpp
+++ b/src/meta_server/meta_state_machine.cpp
@@ -191,7 +191,10 @@ void MetaStateMachine::baikal_other_heartbeat(google::protobuf::RpcController* c
     response->set_errcode(pb::SUCCESS);
     response->set_errmsg("success");
     TableManager::get_instance()->check_update_statistics(request, response);
+    ClusterManager::get_instance()->process_instance_param_heartbeat_for_baikal(request, response);
     int64_t schema_time = step_time_cost.get_time();
+
+
     DB_NOTICE("baikaldb:%s heart beat, wait time: %ld, update_cost: %ld, log_id: %lu", 
                 butil::endpoint2str(cntl->remote_side()).c_str(),
                 wait_time, schema_time, log_id);

--- a/src/meta_server/namespace_manager.cpp
+++ b/src/meta_server/namespace_manager.cpp
@@ -106,7 +106,7 @@ void NamespaceManager::modify_namespace(const pb::MetaManagerRequest& request, b
     int64_t namespace_id = _namespace_id_map[namespace_name];
     pb::NameSpaceInfo tmp_info = _namespace_info_map[namespace_id];
     tmp_info.set_quota(namespace_info.quota());
-    if (tmp_info.has_resource_tag()) {
+    if (namespace_info.has_resource_tag()) {
         tmp_info.set_resource_tag(namespace_info.resource_tag());
     }
     tmp_info.set_version(tmp_info.version() + 1);

--- a/src/meta_server/query_table_manager.cpp
+++ b/src/meta_server/query_table_manager.cpp
@@ -39,7 +39,7 @@ void QueryTableManager::get_schema_info(const pb::QueryRequest* request,
             if (manager->_table_id_map.find(table_name) == manager->_table_id_map.end()) {
                 response->set_errmsg("table not exist");
                 response->set_errcode(pb::INPUT_PARAM_ERROR);
-                DB_FATAL("namespace: %s database: %s table_name: %s not exist", 
+                DB_WARNING("namespace: %s database: %s table_name: %s not exist",
                             namespace_name.c_str(), database.c_str(), table_name.c_str());
                 return;
             }

--- a/src/meta_server/schema_manager.cpp
+++ b/src/meta_server/schema_manager.cpp
@@ -383,7 +383,7 @@ void SchemaManager::process_baikal_heartbeat(const pb::BaikalHeartBeatRequest* r
         TableManager::get_instance()->check_update_or_drop_table(request, response); 
         //判断是否有新增的表没有下推给baikaldb
         std::vector<int64_t> new_add_region_ids;
-        TableManager::get_instance()->check_add_table(report_table_ids, new_add_region_ids, request->not_need_statistics(), response);
+        TableManager::get_instance()->check_add_table(report_table_ids, new_add_region_ids, response);
         RegionManager::get_instance()->add_region_info(new_add_region_ids, response);      
     }
     int64_t update_table_time = step_time_cost.get_time();
@@ -609,10 +609,14 @@ int SchemaManager::pre_process_for_create_table(const pb::MetaManagerRequest* re
     if (!table_info.has_resource_tag()) {
         std::string namespace_name = table_info.namespace_name();
         std::string database_name = namespace_name + "\001" + table_info.database();
+        int64_t namespace_id = NamespaceManager::get_instance()->get_namespace_id(namespace_name);
+        std::string namespace_resource_tag = NamespaceManager::get_instance()->get_resource_tag(namespace_id);
         int64_t database_id = DatabaseManager::get_instance()->get_database_id(database_name);
         std::string database_resource_tag = DatabaseManager::get_instance()->get_resource_tag(database_id);
         if (database_resource_tag != "") {
             resource_tag = database_resource_tag;
+        } else if (namespace_resource_tag != "") {
+            resource_tag = namespace_resource_tag;
         }
     }
 

--- a/src/protocol/main.cpp
+++ b/src/protocol/main.cpp
@@ -31,8 +31,6 @@
 
 namespace baikaldb {
 
-DEFINE_int64(db_sql_memory_bytes_limit, 8589934592, "minimum memory use size , default: 8G");
-
 // Signal handlers.
 void handle_exit_signal() {
     NetworkServer::get_instance()->graceful_shutdown();
@@ -103,7 +101,7 @@ int main(int argc, char **argv) {
     baikaldb::HandleHelper::get_instance()->init();
     baikaldb::ShowHelper::get_instance()->init();
     baikaldb::MemoryGCHandler::get_instance()->init();
-    baikaldb::MemTrackerPool::get_instance()->init(baikaldb::FLAGS_db_sql_memory_bytes_limit);
+    baikaldb::MemTrackerPool::get_instance()->init();
     // Initail server.
     baikaldb::NetworkServer* server = baikaldb::NetworkServer::get_instance();
     if (!server->init()) {

--- a/src/runtime/runtime_state.cpp
+++ b/src/runtime/runtime_state.cpp
@@ -16,28 +16,55 @@
 #include "runtime_state_pool.h"
 #include "query_context.h"
 #include "network_socket.h"
-
+#include "packet_node.h"
 namespace baikaldb {
 DEFINE_int32(per_txn_max_num_locks, 1000000, "max num locks per txn default 100w");
-
+DEFINE_int64(row_number_to_check_memory, 4096, "do memory limit when row number more than #, default: 4096");
+DECLARE_int32(single_store_concurrency);
+DECLARE_int64(baikaldb_alive_time_s);
+DEFINE_int32(time_length_to_delete_message, 1, "hours length to delete mem_row_descriptor of sql : default one hour");
+DEFINE_bool(limit_unappropriate_sql, false, "limit concurrency as one when select sql is unappropriate");
 int RuntimeState::init(const pb::StoreReq& req,
         const pb::Plan& plan, 
         const RepeatedPtrField<pb::TupleDescriptor>& tuples,
         TransactionPool* pool,
         bool store_compute_separate, bool is_binlog_region) {
+    //thread_local map:线程局部变量map,保存签名,  tuple_sign => pair<TimeCost, std::shared_ptr<SmartDescriptor>>, 避免重复BuildFile
+    static thread_local MemRowDescriptorMap sql_sign_to_mem_row_descriptor;
     for (auto& tuple : tuples) {
         if (tuple.tuple_id() >= (int)_tuple_descs.size()) {
             _tuple_descs.resize(tuple.tuple_id() + 1);
         }
         _tuple_descs[tuple.tuple_id()] = tuple;
     }
-    if (_tuple_descs.size() > 0) {
-        int ret = _mem_row_desc.init(_tuple_descs);
+    sign = req.sql_sign();
+    uint64_t tuple_sign = tuple_descs_to_sign();
+
+    //取出缓存的动态编译结果(按照签名)
+    if (_tuple_descs.size() > 0 && sign != 0 && tuple_sign != 0) {
+        if (sql_sign_to_mem_row_descriptor.count(tuple_sign) == 1) {
+            _mem_row_desc = sql_sign_to_mem_row_descriptor[tuple_sign].second;
+            sql_sign_to_mem_row_descriptor[tuple_sign].first.reset();//更新tuple_sign对应的使用时间
+        } else {
+            _mem_row_desc = std::make_shared<MemRowDescriptor>();
+            int ret = _mem_row_desc->init(_tuple_descs);
+            if (ret < 0) {
+                DB_WARNING("_mem_row_desc init fail");
+                return -1;
+            }
+            TimeCost start_time;
+            sql_sign_to_mem_row_descriptor[tuple_sign] = {start_time, _mem_row_desc};
+        }
+    } else {
+        _mem_row_desc = std::make_shared<MemRowDescriptor>();
+        int ret = _mem_row_desc->init(_tuple_descs);
         if (ret < 0) {
             DB_WARNING("_mem_row_desc init fail");
             return -1;
         }
     }
+    clear_mem_row_descriptor(sql_sign_to_mem_row_descriptor);//定期清理过期sql的mem_row_descriptor
+
     _region_id = req.region_id();
     _region_version = req.region_version();
     if (req.has_not_check_region()) {
@@ -83,6 +110,8 @@ int RuntimeState::init(const pb::StoreReq& req,
 }
 
 int RuntimeState::init(QueryContext* ctx, DataBuffer* send_buf) {
+    //thread_local map:线程局部变量map,保存签名,  tuple_sign => pair<TimeCost, std::shared_ptr<SmartDescriptor>>, 避免重复BuildFile
+    static thread_local MemRowDescriptorMap sql_sign_to_mem_row_descriptor;
     _num_increase_rows = 0; 
     _num_affected_rows = 0; 
     _num_returned_rows = 0; 
@@ -103,18 +132,58 @@ int RuntimeState::init(QueryContext* ctx, DataBuffer* send_buf) {
     }
     _send_buf = send_buf;
     _tuple_descs = ctx->tuple_descs();
-    if (_tuple_descs.size() > 0) {
-        int ret = _mem_row_desc.init(_tuple_descs);
+    uint64_t tuple_sign = tuple_descs_to_sign();
+
+    //取出缓存的动态编译结果(按照签名)
+    if (_tuple_descs.size() > 0 && sign != 0 && tuple_sign != 0) {
+        if (sql_sign_to_mem_row_descriptor.count(tuple_sign) == 1) {
+            _mem_row_desc = sql_sign_to_mem_row_descriptor[tuple_sign].second;
+            sql_sign_to_mem_row_descriptor[tuple_sign].first.reset();//更新tuple_sign对应的使用时间   
+        } else {
+            _mem_row_desc = std::make_shared<MemRowDescriptor>();
+            int ret = _mem_row_desc->init(_tuple_descs);
+            if (ret < 0) {
+                DB_WARNING("_mem_row_desc init fail");
+                return -1;
+            }
+            TimeCost start_time;
+            sql_sign_to_mem_row_descriptor[tuple_sign] = {start_time, _mem_row_desc};
+        }
+    } else {
+        _mem_row_desc = std::make_shared<MemRowDescriptor>();
+        int ret = _mem_row_desc->init(_tuple_descs);
         if (ret < 0) {
             DB_WARNING("_mem_row_desc init fail");
             return -1;
         }
     }
+    clear_mem_row_descriptor(sql_sign_to_mem_row_descriptor);//定期清理过期sql的mem_row_descriptor
+
     if (ctx->open_binlog) {
         _open_binlog = true;
     }
     _is_inited = true;
     return 0;
+}
+
+void RuntimeState::set_single_store_concurrency() {
+    _single_store_concurrency = FLAGS_single_store_concurrency;//默认并发度为20
+    if (!FLAGS_limit_unappropriate_sql) {
+        return;
+    }
+    int64_t baikaldb_alive_time_us = SchemaFactory::get_instance()->get_baikaldb_alive_time_us();
+    if (baikaldb_alive_time_us < FLAGS_baikaldb_alive_time_s * 1000 * 1000LL) {
+        return;
+    }
+    if (sign == 0) {
+        return;
+    }
+    auto schema_factory = SchemaFactory::get_instance();
+    auto sql_stat_ptr = schema_factory->get_sql_stat(sign);
+    if (sql_stat_ptr == nullptr || sql_stat_ptr->counter < SqlStatistics::SQL_COUNTS_RANGE) {
+        _single_store_concurrency = 1;
+        DB_WARNING("select sql is unappropriate sql, need to limit concurrency as one, sql sign is [%lu]", sign);
+    }
 }
 /*
 int RuntimeState::init(const pb::CachePlan& commit_plan) {
@@ -138,18 +207,23 @@ void RuntimeState::conn_id_cancel(uint64_t db_conn_id) {
     }
 }
 
-int RuntimeState::memory_limit_exceeded(int64_t bytes) {
+int RuntimeState::memory_limit_exceeded(int64_t rows_to_check, int64_t bytes) {
+    if (rows_to_check < FLAGS_row_number_to_check_memory) {
+        return 0;
+    }
     if (_mem_tracker == nullptr) {
+        // db侧region并发执行
         BAIDU_SCOPED_LOCK(_mem_lock);
         if (_mem_tracker == nullptr) {
             _mem_tracker = baikaldb::MemTrackerPool::get_instance()->get_mem_tracker(_log_id);
         }
     }
     _mem_tracker->consume(bytes);
-    _used_bytes += bytes;
-    if (_mem_tracker->check_bytes_limit()) {
+    _used_bytes.fetch_add(bytes, std::memory_order_relaxed);
+    if (_mem_tracker->has_limit_exceeded() || _mem_tracker->any_limit_exceeded()) {
+        _mem_tracker->set_limit_exceeded();
         DB_WARNING("log_id:%lu memory limit Exceeded limit:%ld consumed:%ld used:%ld.", _log_id,
-            _mem_tracker->bytes_limit(), _mem_tracker->bytes_consumed(), _used_bytes);
+            _mem_tracker->bytes_limit(), _mem_tracker->bytes_consumed(), _used_bytes.load());
         error_code = ER_TOO_BIG_SELECT;
         error_msg.str("select reach memory limit");
         return -1;
@@ -157,18 +231,61 @@ int RuntimeState::memory_limit_exceeded(int64_t bytes) {
     return 0;
 }
 
-int RuntimeState::memory_limit_release(int64_t bytes) {
+int RuntimeState::memory_limit_release(int64_t rows, int64_t bytes) {
+    if (rows < FLAGS_row_number_to_check_memory) {
+        return 0;
+    }
     if (_mem_tracker != nullptr) {
         _mem_tracker->release(bytes);
-        DB_DEBUG("log_id:%lu mempry tracker release %ld bytes.", _log_id, bytes);
     }
-    _used_bytes -= bytes;
-    if (_used_bytes < 0) {
-        _used_bytes = 0;
-    }
+    _used_bytes.fetch_sub(bytes, std::memory_order_relaxed);
     return 0;
 }
 
+int RuntimeState::memory_limit_release_all() {
+    if (_mem_tracker != nullptr) {
+        _mem_tracker->release(_used_bytes);
+    }
+    _used_bytes = 0;
+    return 0;
+}
+
+void RuntimeState::clear_mem_row_descriptor(MemRowDescriptorMap& sql_sign_to_mem_row_descriptor) {
+    static thread_local TimeCost timecost; 
+    int64_t time_pass = timecost.get_time();
+    int64_t time_length_us = FLAGS_time_length_to_delete_message * 60 * 60 * 1000 * 1000LL; //transform hours to us 
+    if (time_pass > time_length_us) { //定时清理
+        timecost.reset();
+        auto iter = sql_sign_to_mem_row_descriptor.begin();
+        while (iter != sql_sign_to_mem_row_descriptor.end()) {
+            auto& sign = iter->first;
+            auto& time_cost = iter->second.first;
+            auto sql_not_used_time = time_cost.get_time();//sql截止目前未被使用的时长(us)
+            if (sql_not_used_time > time_length_us) {
+                DB_NOTICE("current sql sign [%lu] is to to be erased, current map_descriptor_size is [%lu]", sign, sql_sign_to_mem_row_descriptor.size());
+                iter = sql_sign_to_mem_row_descriptor.erase(iter);
+            } else {
+                iter++;
+            }
+        }
+    }
+}
+
+uint64_t RuntimeState::tuple_descs_to_sign() {
+    if (_tuple_descs.size() == 0) {
+        return 0;
+    }
+    std::string str;
+    str.reserve(100);
+    for (auto& tuple : _tuple_descs) {
+        std::string tmp;
+        tuple.SerializeToString(&tmp);
+        str += tmp;
+    }
+    uint64_t out[2];
+    butil::MurmurHash3_x64_128(str.c_str(), str.size(), 0x1234, out);
+    return out[0];
+}
 }
 
 /* vim: set ts=4 sw=4 sts=4 tw=100 */

--- a/src/store/main.cpp
+++ b/src/store/main.cpp
@@ -38,7 +38,6 @@ DECLARE_int32(store_port);
 DECLARE_bool(use_fulltext_wordweight_segment);
 DECLARE_bool(use_fulltext_wordseg_wordrank_segment);
 DEFINE_string(wordrank_conf, "./config/drpc_client.xml", "wordrank conf path");
-DEFINE_int64(store_sql_memory_bytes_limit, 17179869184, "minimum memory use size , default: 16G");
 } // namespace baikaldb
 DEFINE_bool(stop_server_before_core, true, "stop_server_before_core");
 
@@ -182,7 +181,7 @@ int main(int argc, char **argv) {
         return -1;
     }
     baikaldb::MemoryGCHandler::get_instance()->init();
-    baikaldb::MemTrackerPool::get_instance()->init(baikaldb::FLAGS_store_sql_memory_bytes_limit);
+    baikaldb::MemTrackerPool::get_instance()->init();
     //注册处理Store逻辑的service服务
     baikaldb::Store* store = baikaldb::Store::get_instance();
     std::vector<std::int64_t> init_region_ids;

--- a/src/store/region_control.cpp
+++ b/src/store/region_control.cpp
@@ -401,7 +401,11 @@ int RegionControl::transfer_leader(const pb::TransLeaderRequest& trans_leader_re
         if (region == nullptr) {
             return;
         }
-        RpcSender::get_peer_applied_index(new_leader, _region_id, peer_applied_index, peer_dml_latency);
+        int ret = RpcSender::get_peer_applied_index(new_leader, _region_id, peer_applied_index, peer_dml_latency);
+        if (ret != 0) {
+            DB_WARNING("get_peer_applied_index fail,region_id: %ld", region->get_region_id());
+            return;
+        }
         if ((region->_applied_index - peer_applied_index) * peer_dml_latency
                 > (FLAGS_transfer_leader_catchup_time_threshold)) {
             DB_WARNING("peer applied index: %ld is less than applied index: %ld, peer_dml_latency: %ld",
@@ -421,7 +425,7 @@ int RegionControl::transfer_leader(const pb::TransLeaderRequest& trans_leader_re
             DB_WARNING("region status to doning becase of transfer leader of heartbeat response,"
                     " region_id: %ld", _region_id);
         }
-        int ret = region->transfer_leader_to(new_leader);
+        ret = region->transfer_leader_to(new_leader);
         reset_region_status();
         if (ret != 0) {
             DB_WARNING("node:%s %s transfer leader fail",

--- a/src/store/rpc_sender.cpp
+++ b/src/store/rpc_sender.cpp
@@ -35,7 +35,7 @@ int RpcSender::send_no_op_request(const std::string& instance,
     return ret;
 }
 
-void RpcSender::get_peer_applied_index(const std::string& peer, int64_t region_id,
+int RpcSender::get_peer_applied_index(const std::string& peer, int64_t region_id,
                                        int64_t& applied_index, int64_t& dml_latency) {
     pb::GetAppliedIndex request;
     request.set_region_id(region_id);
@@ -50,6 +50,7 @@ void RpcSender::get_peer_applied_index(const std::string& peer, int64_t region_i
             dml_latency = 50000;
         }
     }
+    return ret;
 }
 
 void RpcSender::get_peer_snapshot_size(const std::string& peer, int64_t region_id,

--- a/test/test_common.cpp
+++ b/test/test_common.cpp
@@ -205,9 +205,13 @@ TEST(test_cond, wait) {
         Bthread bth;
         // increase一定要在主线程里
         cond.increase();
-        bth.run([&cond] () {
+        bth.run([&cond, i] () {
+            static thread_local int a;
+            int* b = &a;
+            *b = i;
+            DB_NOTICE("start cond test %d, %d, %p", i, *b, b);
             bthread_usleep(1000 * 1000);
-            DB_NOTICE("cond test");
+            DB_NOTICE("end cond test %d, %d, %p %p", i, *b, b, &a);
             cond.decrease_signal();
         });
     }

--- a/test/test_date_time.cpp
+++ b/test/test_date_time.cpp
@@ -53,6 +53,7 @@ TEST(test_stamp_to_str, case_all) {
     EXPECT_EQ(timestamp_to_str(1512300524), "2017-12-03 19:28:44");
     EXPECT_EQ(timestamp_to_str(1512300480), "2017-12-03 19:28:00");
     EXPECT_EQ(timestamp_to_str(1512230400), "2017-12-03 00:00:00");
+    std::cout << timestamp_to_str(-100) << std::endl;
 }
 /*
 TEST(test_str_to_stamp, case_all) {
@@ -101,6 +102,14 @@ TEST(test_datetime_str_other, case_all) {
     EXPECT_EQ(datetime_to_str(str_to_datetime("891203192844.111")), "1989-12-03 19:28:44.111000");
     EXPECT_EQ(datetime_to_str(str_to_datetime("19891203192844.111")), "1989-12-03 19:28:44.111000");
     std::cout << "tm:" << str_to_datetime("20111303") << std::endl;
+    std::cout << "tm2:" << str_to_datetime("0000-00-00 00:00:00") << std::endl;
+    std::cout << "tm3:" << datetime_to_timestamp(0) << std::endl;
+    std::cout << "tm4:" << str_to_datetime("1970-01-01 08:00:00") << std::endl;
+    std::cout << "tm5:" << str_to_datetime("1970-01-01 08:00:01") << std::endl;
+    std::cout << "tm5:" << str_to_datetime("1970-01-01 07:00:01") << std::endl;
+    std::cout << "tm4:" << datetime_to_timestamp(str_to_datetime("1970-01-01 08:00:00")) << std::endl;
+    std::cout << "tm5:" << datetime_to_timestamp(str_to_datetime("1970-01-01 08:00:01")) << std::endl;
+    std::cout << "tm5:" << datetime_to_timestamp(str_to_datetime("1970-01-01 07:00:01")) << std::endl;
 }
 int32_t str_to_time2(const char* str_time) {
     int hour = 0;
@@ -199,6 +208,12 @@ TEST(test_datetime_time, case_all) {
 
 TEST(test_datetime_timestamp, case_all) {
     EXPECT_EQ(timestamp_to_str(datetime_to_timestamp(str_to_datetime("2017-12-03 19:28:44.123456"))), "2017-12-03 19:28:44");
+    EXPECT_EQ(timestamp_to_str(datetime_to_timestamp(str_to_datetime("0000-00-00 00:00:00"))), "0000-00-00 00:00:00");
+    EXPECT_EQ(timestamp_to_str(datetime_to_timestamp(str_to_datetime("1970-01-01 08:00:00"))), "0000-00-00 00:00:00");
+    EXPECT_EQ(timestamp_to_str(datetime_to_timestamp(str_to_datetime("1970-01-01 08:00:01"))), "1970-01-01 08:00:01");
+    EXPECT_EQ(timestamp_to_str(datetime_to_timestamp(str_to_datetime("2040-01-01 08:00:01"))), "2040-01-01 08:00:01");
+    // < 1970-01-01 08:00:01非法，都当做0
+    EXPECT_EQ(timestamp_to_str(datetime_to_timestamp(str_to_datetime("1970-01-01 07:00:01"))), "0000-00-00 00:00:00");
     //EXPECT_EQ(datetime_to_str(timestamp_to_datetime(str_to_timestamp("2017-12-03 19:28:44"))), "2017-12-03 19:28:44");
 }
 

--- a/test/test_sqlparser_for_select.cpp
+++ b/test/test_sqlparser_for_select.cpp
@@ -91,7 +91,6 @@ TEST(test_parser, case_option) {
         ASSERT_FALSE(select_stmt->select_opt->straight_join);
         ASSERT_EQ(0, select_stmt->select_opt->priority);
         std::cout << select_stmt->to_string() << std::endl; 
-        exit(0);
     }
     //select
     {
@@ -109,15 +108,15 @@ TEST(test_parser, case_option) {
         ASSERT_FALSE(select_stmt->select_opt->straight_join);
         ASSERT_EQ(0, select_stmt->select_opt->priority);
         std::cout << select_stmt->to_string() << std::endl; 
-        ASSERT_STREQ(select_stmt->fields[0]->org_name.c_str(), "");
-        ASSERT_STREQ(select_stmt->fields[1]->org_name.c_str(), "");
+        ASSERT_STREQ(select_stmt->fields[0]->org_name.c_str(), NULL);
+        ASSERT_STREQ(select_stmt->fields[1]->org_name.c_str(), NULL);
         ASSERT_STREQ(select_stmt->fields[2]->org_name.c_str(), "1+1");
         ASSERT_STREQ(select_stmt->fields[3]->org_name.c_str(), "count(*)");
         ASSERT_STREQ(select_stmt->fields[4]->org_name.c_str(), "(select 1 +1)");
-        ASSERT_STREQ(select_stmt->fields[5]->org_name.c_str(), "");
+        ASSERT_STREQ(select_stmt->fields[5]->org_name.c_str(), NULL);
         ASSERT_STREQ(select_stmt->fields[6]->org_name.c_str(), "((1.1+1))");
-        ASSERT_STREQ(select_stmt->fields[7]->org_name.c_str(), "");
-        exit(0);
+        ASSERT_STREQ(select_stmt->fields[7]->org_name.c_str(), "count(*)");
+        ASSERT_STREQ(select_stmt->fields[7]->as_name.c_str(), "A");
     }
     {
         parser::SqlParser parser;


### PR DESCRIPTION
## New Features：
* 增加内存限制功能
* 建表使用unique index默认改成global的，可以通过unique index local来指定成local的，可以通过-unique_index_default_global=false改成默认是local的
* 建表使用普通索引index默认还是local的，可以通过index global指定成global的，可以通过-normal_index_default_global=true改成默认是global的
* 通过-open_nonboolean_sql_forbid=true可以禁止非bool表达式参与and/or计算，默认false
* 通过-open_non_where_sql_forbid=true可以禁止没有where条件的update/delete，默认false
* 通过-limit_unappropriate_sql=true可以限制手工sql（每个db执行次数少于3次）每个store并发到1，防止store被打挂，默认false
* 支持ingest sst方式的快速导入功能（暂未适配开源编译，将在后续开放）

## Bug Fixes：
* 修复order by超过1个表达式计算问题
* write binlog错误码修复
* 子查询kill问题修复
* datediff 问题修复
* 修复match against类型推导
* 修复全局索引+insert duplicate中values函数不生效问题

## Performance Improvements:
* 注释解析性能优化
* MemRowDescriptor缓存降低多列情况下开销
* 局部索引内存优化
* 索引key解析优化
* db到store改用异步请求，降低高并发下bthread数量