### PR TITLE
feat: update braft from v1.1.1 to v1.1.2

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -186,7 +186,7 @@ bind(
 git_repository(
     name = "com_github_brpc_braft",
     remote = "https://github.com/baidu/braft.git",
-    tag = "v1.1.1",
+    tag = "v1.1.2",
 )
 
 bind(


### PR DESCRIPTION
旧版本region分裂，add peer时会失败。