### PR TITLE
feat: add read concurrency control for new sql

### DIFF
--- a/include/common/concurrency.h
+++ b/include/common/concurrency.h
@@ -19,6 +19,7 @@ namespace baikaldb {
 DECLARE_int32(snapshot_load_num);
 DECLARE_int32(raft_write_concurrency);
 DECLARE_int32(service_write_concurrency);
+DECLARE_int32(new_sign_read_concurrency);
 DECLARE_int32(baikal_heartbeat_concurrency);
 DECLARE_int32(upload_sst_streaming_concurrency);
 
@@ -33,6 +34,7 @@ struct Concurrency {
     BthreadCond add_peer_concurrency;
     BthreadCond raft_write_concurrency;
     BthreadCond service_write_concurrency;
+    BthreadCond new_sign_read_concurrency; // 新sql读并发控制
     BthreadCond baikal_heartbeat_concurrency;
     BthreadCond upload_sst_streaming_concurrency;
 private:
@@ -41,6 +43,7 @@ private:
                    add_peer_concurrency(-FLAGS_snapshot_load_num), 
                    raft_write_concurrency(-FLAGS_raft_write_concurrency), 
                    service_write_concurrency(-FLAGS_service_write_concurrency),
+                   new_sign_read_concurrency(-FLAGS_new_sign_read_concurrency),
                    baikal_heartbeat_concurrency(-FLAGS_baikal_heartbeat_concurrency),
                    upload_sst_streaming_concurrency(-FLAGS_upload_sst_streaming_concurrency) {
                    }

--- a/include/store/store.h
+++ b/include/store/store.h
@@ -41,6 +41,7 @@ namespace baikaldb {
 DECLARE_int32(snapshot_load_num);
 DECLARE_int32(raft_write_concurrency);
 DECLARE_int32(service_write_concurrency);
+DECLARE_int32(new_sign_read_concurrency);
 const static uint64_t split_thresh = 100 * 1024 * 1024;
 const static int max_region_map_count = 23;
 inline int map_idx(int64_t region_id) {

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -65,6 +65,8 @@ DEFINE_bool(open_service_write_concurrency, true, "open service_write_concurrenc
 DEFINE_int32(baikal_heartbeat_interval_us, 10 * 1000 * 1000, "baikal_heartbeat_interval(us)");
 DEFINE_bool(schema_ignore_case, false, "whether ignore case when match db/table name");
 DEFINE_bool(disambiguate_select_name, false, "whether use the first when select name is ambiguous, default false");
+DEFINE_int32(new_sign_read_concurrency, 20, "new_sign_read concurrency, default:20");
+DEFINE_bool(open_new_sign_read_concurrency, false, "open new_sign_read concurrency, default: false");
 
 int64_t timestamp_diff(timeval _start, timeval _end) {
     return (_end.tv_sec - _start.tv_sec) * 1000000 

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -65,7 +65,7 @@ DEFINE_bool(open_service_write_concurrency, true, "open service_write_concurrenc
 DEFINE_int32(baikal_heartbeat_interval_us, 10 * 1000 * 1000, "baikal_heartbeat_interval(us)");
 DEFINE_bool(schema_ignore_case, false, "whether ignore case when match db/table name");
 DEFINE_bool(disambiguate_select_name, false, "whether use the first when select name is ambiguous, default false");
-DEFINE_int32(new_sign_read_concurrency, 20, "new_sign_read concurrency, default:20");
+DEFINE_int32(new_sign_read_concurrency, 10, "new_sign_read concurrency, default:20");
 DEFINE_bool(open_new_sign_read_concurrency, false, "open new_sign_read concurrency, default: false");
 
 int64_t timestamp_diff(timeval _start, timeval _end) {

--- a/src/engine/qos.cpp
+++ b/src/engine/qos.cpp
@@ -185,6 +185,13 @@ bool QosBthreadLocal::need_reject() {
     return false;
 }
 
+bool QosBthreadLocal::is_new_sign() {
+    if (_sqlqos_ptr != nullptr) {
+        return _sqlqos_ptr->is_new_sign();
+    }
+    return false;
+}
+
 void SqlQos::get_statistics_adder(int64_t count, int64_t statistics_count) {
     _get_real.adder(count);
     _get_statistics.adder(statistics_count);

--- a/src/store/region.cpp
+++ b/src/store/region.cpp
@@ -91,6 +91,7 @@ DECLARE_int64(min_split_lines);
 DECLARE_bool(use_approximate_size);
 DECLARE_bool(use_approximate_size_to_split);
 DECLARE_bool(open_service_write_concurrency);
+DECLARE_bool(open_new_sign_read_concurrency);
 DECLARE_bool(stop_ttl_data);
 //const size_t  Region::REGION_MIN_KEY_SIZE = sizeof(int64_t) * 2 + sizeof(uint8_t);
 const uint8_t Region::PRIMARY_INDEX_FLAG = 0x01;                                   
@@ -2284,6 +2285,27 @@ int Region::select(const pb::StoreReq& request, pb::StoreRes& response) {
         DB_WARNING("sign: %lu, reject", sign);
         return -1;
     }
+
+    TimeCost cost;
+    bool is_new_sign = false;
+    if (FLAGS_open_new_sign_read_concurrency && (StoreQos::get_instance()->is_new_sign())) {
+        is_new_sign = true;
+        Concurrency::get_instance()->new_sign_read_concurrency.increase_wait();
+    }
+    int64_t wait_cost = cost.get_time();
+    ON_SCOPE_EXIT([&]() {
+        if (FLAGS_open_new_sign_read_concurrency && is_new_sign) {
+            Concurrency::get_instance()->new_sign_read_concurrency.decrease_broadcast();
+            if (wait_cost > FLAGS_print_time_us) {
+                DB_NOTICE("select type: %s, region_id: %ld, "
+                        "time_cost: %ld, log_id: %lu, sign: %lu, rows: %ld, scan_rows: %ld",
+                        pb::OpType_Name(request.op_type()).c_str(), _region_id,
+                        cost.get_time(), request.log_id(), sign,
+                        response.affected_rows(), response.scan_rows());
+            }
+        }
+    });
+
 
     int ret = 0;
     if (_is_learner) {

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -1543,10 +1543,10 @@ void Store::start_db_statistics() {
         print_properties("rocksdb.block-cache-pinned-usage");
         auto& con = *Concurrency::get_instance();
         DB_WARNING("get properties cost: %ld, concurrency:"
-                "snapshot:%d, recieve_add_peer:%d, add_peer:%d, service_write:%d", 
+                "snapshot:%d, recieve_add_peer:%d, add_peer:%d, service_write:%d, new_sign_read:%d",
                 cost.get_time(), con.snapshot_load_concurrency.count(),
                 con.recieve_add_peer_concurrency.count(), con.add_peer_concurrency.count(),
-                con.service_write_concurrency.count());
+                con.service_write_concurrency.count(), con.new_sign_read_concurrency.count());
 
         // 获取和打印level0数量
         uint64_t level0_ssts = 0;


### PR DESCRIPTION
距离首次请求DB的时间不超过1个小时（FLAGS_qps_statistics_minutes_ago）的sql被定义为新sql，新sql会被限定有限的读并发度（默认10线程），因为新SQL很可能是不走索引未经优化的，限制并发可以避免抢占线上已在稳定运行的老sql的资源
-qps_statistics_minutes_ago= 1h（默认1h内认为是一个新SQL）
-new_sign_read_concurrency = 10（新SQL的并发度，建议配置为bthread_concurrency的1/10或1/20）