### PR TITLE
feat: predicate_rewrite, or转in, date_format去除

### DIFF
--- a/include/expr/expr_node.h
+++ b/include/expr/expr_node.h
@@ -41,6 +41,10 @@ public:
         return 0;
     }
     virtual void children_swap() {}
+    // 等价谓词变换
+    // Done: DATE_FORMAT(create_time, '%Y-%m-%d') < '2022-07-07' => create_time < '2022-07-07';
+    // TODO: id + 2 - 4 => id - 2;
+    virtual ExprNode* transfer() { return this; }
 
     bool is_literal() {
         switch (_node_type) {

--- a/include/expr/scalar_fn_call.h
+++ b/include/expr/scalar_fn_call.h
@@ -24,6 +24,7 @@ public:
     virtual int init(const pb::ExprNode& node);
     virtual int type_inferer();
     virtual void children_swap();
+    virtual ExprNode* transfer();
     virtual int open();
     virtual ExprValue get_value(MemRow* row);
     pb::Function fn() {
@@ -113,6 +114,8 @@ private:
         }
         return ExprValue::True();
     }
+    ExprNode* transfer_date_format();
+    ExprNode* transfer_from_or_to_in();
 protected:
     pb::Function _fn;
     bool _is_row_expr = false;


### PR DESCRIPTION
## 等价谓词变换
- 用途：等价谓词变换，是一种数据库查询计划优化手段，通过对原始SQL的等价改写，调整查询计划，提升性能
- 优化1：or 转 in， 例如 `where a="a1" or a="a2"` 改写为 `where a in （"a1", "a2"）`
- 优化2：date_format消除，例如 `date_format(create_time, "%Y-%M-%D") >= "2022-09-09"` 转`create_time >= "2022-09-09"` 