### PR TITLE
索引优化

### DIFF
--- a/include/exec/access_path.h
+++ b/include/exec/access_path.h
@@ -44,7 +44,9 @@ enum IndexHint {
         return true;
     }
 
-    void calc_index_range(Property& sort_property) {
+    void calc_index_range();
+
+    void calc_index_match(Property& sort_property) {
         fetch_field_ids();
         switch (index_type) {
             case pb::I_FULLTEXT:
@@ -60,7 +62,7 @@ enum IndexHint {
     bool need_select_learner_index();
     
     void calc_row_expr_range(std::vector<int32_t>& range_fields, ExprNode* expr, bool in_open,
-            std::vector<ExprValue>& values, SmartRecord record, size_t field_idx, bool* out_open, int* out_field_cnt);
+            std::vector<ExprValue>& values, SmartRecord record, size_t field_idx);
 
     bool check_sort_use_index(Property& sort_property);
 
@@ -193,6 +195,13 @@ public:
     SmartTable table_info_ptr;
     SmartIndex index_info_ptr;
     SmartIndex pri_info_ptr;
+    int _left_field_cnt = 0;
+    int _right_field_cnt = 0;
+    bool _left_open = false;
+    bool _right_open = false;
+    bool _like_prefix = false;
+    bool _in_pred = false;
+    bool _is_eq_or_in = true;
 };
 typedef std::shared_ptr<AccessPath> SmartPath;
 }

--- a/include/exec/access_path.h
+++ b/include/exec/access_path.h
@@ -108,14 +108,16 @@ enum IndexHint {
             }
         }
     }
-
-    void calc_is_covering_index(const pb::TupleDescriptor& desc) {
+    void calc_is_covering_index(const pb::TupleDescriptor& desc, std::set<int32_t>* slot_ids = nullptr) {
         for (auto& slot : desc.slots()) {
+            if ((slot_ids != nullptr) && (slot_ids->count(slot.slot_id()) == 0)) {
+                continue;
+            }
             if (cover_field_ids.count(slot.field_id()) == 0) {
                 // I_FULLTEXT; 获取不到索引的field信息
                 // 但是select count(*) from full like '%a%';是能够索引覆盖的
-                if (slot.ref_cnt() == 1 && 
-                        !need_cut_index_range_condition.empty() && 
+                if (slot.ref_cnt() == 1 &&
+                        !need_cut_index_range_condition.empty() &&
                         slot.field_id() == index_info_ptr->fields[0].id) {
                     continue;
                 } else {

--- a/include/exec/access_path.h
+++ b/include/exec/access_path.h
@@ -162,6 +162,10 @@ enum IndexHint {
 
         return false;
     }
+    bool need_filter() {
+        return _need_filter;
+    }
+
     
 public:
     //TODO 先mock一个，后面从schema读取
@@ -206,6 +210,7 @@ public:
     bool _like_prefix = false;
     bool _in_pred = false;
     bool _is_eq_or_in = true;
+    bool _need_filter = false;
 };
 typedef std::shared_ptr<AccessPath> SmartPath;
 }

--- a/include/exec/access_path.h
+++ b/include/exec/access_path.h
@@ -135,6 +135,7 @@ enum IndexHint {
 
     // 参考choose_index函数
     bool is_eq_or_in() {
+        return _is_eq_or_in;
         if (pos_index.ranges_size() > 0) {
             const auto& range = pos_index.ranges(0);
             bool is_eq = true;
@@ -194,6 +195,7 @@ public:
     bool is_possible = false;
     bool is_sort_index = false;
     bool is_virtual = false;
+    int index_other_condition_count = 0;
     SmartTable table_info_ptr;
     SmartIndex index_info_ptr;
     SmartIndex pri_info_ptr;

--- a/include/exec/access_path.h
+++ b/include/exec/access_path.h
@@ -136,31 +136,6 @@ enum IndexHint {
     // 参考choose_index函数
     bool is_eq_or_in() {
         return _is_eq_or_in;
-        if (pos_index.ranges_size() > 0) {
-            const auto& range = pos_index.ranges(0);
-            bool is_eq = true;
-            if (range.has_left_key()) {
-                if (range.left_key() != range.right_key()) {
-                    is_eq = false;
-                }
-            } else {
-                if (range.left_pb_record() != range.right_pb_record()) {
-                    is_eq = false;
-                }
-            }
-
-            if (range.left_field_cnt() != range.right_field_cnt()) {
-                is_eq = false;
-            }
-
-            if (range.left_open() || range.right_open()) {
-                is_eq = false;
-            }
-
-            return is_eq && !range.like_prefix();
-        }
-
-        return false;
     }
     bool need_filter() {
         return _need_filter;

--- a/include/exec/limit_node.h
+++ b/include/exec/limit_node.h
@@ -36,6 +36,18 @@ public:
     int64_t other_limit() {
         return _offset + _limit;
     }
+    int64_t get_offset() {
+	return _offset;
+    }
+    int64_t get_num_rows_skipped() {
+	return _num_rows_skipped;
+    }
+    int64_t add_num_rows_skipped(int64_t num) {
+	_num_rows_skipped += num;
+    }
+    int64_t get_limit() {
+	return _limit;
+    }
 private:
     int64_t _offset;
     int64_t _num_rows_skipped;

--- a/include/exec/scan_node.h
+++ b/include/exec/scan_node.h
@@ -368,7 +368,7 @@ public:
                 _main_path.path(_select_idx)->insert_no_cut_condition(*_expr_field_map);
             }
         }
-        if (_main_path.path(_select_idx)->index_info_ptr->is_global) {
+        if (!_main_path.path(_select_idx)->index_info_ptr->is_global && _select_idx != _table_id) {
             _main_path.path(_table_id)->calc_index_range();
         }
     }

--- a/include/exec/scan_node.h
+++ b/include/exec/scan_node.h
@@ -358,16 +358,12 @@ public:
         return _current_global_backup;
     }
 
-    void set_expr_field_map(std::map<ExprNode*, std::unordered_set<int32_t>> * expr_field_map) {
+    void set_expr_field_map(const std::map<ExprNode*, std::unordered_set<int32_t>>& expr_field_map) {
         _expr_field_map = expr_field_map;
     }
     void calc_index_range() {
-        if (_select_idx != -1) {
-            _main_path.path(_select_idx)->calc_index_range();
-            if (_expr_field_map != nullptr) {
-                _main_path.path(_select_idx)->insert_no_cut_condition(*_expr_field_map);
-            }
-        }
+        _main_path.path(_select_idx)->calc_index_range();
+        _main_path.path(_select_idx)->insert_no_cut_condition(_expr_field_map);
         if (!_main_path.path(_select_idx)->index_info_ptr->is_global && _select_idx != _table_id) {
             _main_path.path(_table_id)->calc_index_range();
         }
@@ -392,7 +388,7 @@ protected:
     std::vector<ScanIndexInfo> _scan_indexs;
     bthread::Mutex _current_index_mutex;
     bool _current_global_backup = false;
-    std::map<ExprNode*, std::unordered_set<int32_t>>* _expr_field_map = nullptr;
+    std::map<ExprNode*, std::unordered_set<int32_t>>_expr_field_map;
 };
 }
 

--- a/include/exec/scan_node.h
+++ b/include/exec/scan_node.h
@@ -388,7 +388,7 @@ protected:
     std::vector<ScanIndexInfo> _scan_indexs;
     bthread::Mutex _current_index_mutex;
     bool _current_global_backup = false;
-    std::map<ExprNode*, std::unordered_set<int32_t>>_expr_field_map;
+    std::map<ExprNode*, std::unordered_set<int32_t>> _expr_field_map;
 };
 }
 

--- a/include/exec/select_manager_node.h
+++ b/include/exec/select_manager_node.h
@@ -17,6 +17,7 @@
 #include "exec_node.h"
 #include "sort_node.h"
 #include "scan_node.h"
+#include "limit_node.h"
 #include "table_record.h"
 #include "proto/store.interface.pb.h"
 #include "sorter.h"
@@ -33,7 +34,7 @@ struct FetcherInfo {
     int64_t dynamic_timeout_ms = -1;
     GlobalBackupType global_backup_type = GBT_INIT;
     ScanIndexInfo* scan_index = nullptr;
-    std::atomic<Status> status = { S_INIT }; 
+    std::atomic<Status> status = { S_INIT };
     FetcherStore fetcher_store;
 };
 
@@ -71,7 +72,7 @@ public:
     }
     int single_fetcher_store_open(FetcherInfo* fetcher, RuntimeState* state, ExecNode* exec_node);
 
-    void multi_fetcher_store_open(FetcherInfo* self_fetcher, FetcherInfo* other_fetcher,  
+    void multi_fetcher_store_open(FetcherInfo* self_fetcher, FetcherInfo* other_fetcher,
         RuntimeState* state, ExecNode* exec_node);
     int fetcher_store_run(RuntimeState* state, ExecNode* exec_node);
     int open_global_index(FetcherInfo* fetcher, RuntimeState* state,
@@ -84,6 +85,14 @@ public:
                           RuntimeState* state,
                           ExecNode* exec_node,
                           int64_t main_table_id);
+
+    int construct_primary_possible_index_use_limit(
+                          FetcherStore& fetcher_store,
+                          ScanIndexInfo* scan_index_info,
+                          RuntimeState* state,
+                          ExecNode* exec_node,
+                          int64_t main_table_id,
+                          LimitNode* limit);
 
     void set_sub_query_runtime_state(RuntimeState* state) {
         _sub_query_runtime_state = state;

--- a/include/exec/select_manager_node.h
+++ b/include/exec/select_manager_node.h
@@ -79,20 +79,14 @@ public:
                           ExecNode* exec_node,
                           int64_t global_index_id,
                           int64_t main_table_id);
+
     int construct_primary_possible_index(
                           FetcherStore& fetcher_store,
                           ScanIndexInfo* scan_index_info,
                           RuntimeState* state,
                           ExecNode* exec_node,
-                          int64_t main_table_id);
-
-    int construct_primary_possible_index_use_limit(
-                          FetcherStore& fetcher_store,
-                          ScanIndexInfo* scan_index_info,
-                          RuntimeState* state,
-                          ExecNode* exec_node,
                           int64_t main_table_id,
-                          LimitNode* limit);
+                          LimitNode* limit = nullptr);
 
     void set_sub_query_runtime_state(RuntimeState* state) {
         _sub_query_runtime_state = state;

--- a/include/physical_plan/index_selector.h
+++ b/include/physical_plan/index_selector.h
@@ -67,6 +67,7 @@ private:
     }
 
     SchemaFactory* _factory = SchemaFactory::get_instance();
+    QueryContext*  _ctx = nullptr;
 
 };
 }

--- a/src/exec/access_path.cpp
+++ b/src/exec/access_path.cpp
@@ -236,6 +236,7 @@ void AccessPath::calc_normal(Property& sort_property) {
     if (_left_field_cnt != 0 || _right_field_cnt != 0) {
         is_possible = true;
     }
+    index_other_condition_count = field_range_map.size() - hit_index_field_ids.size();
 }
 
 // 填充索引的range

--- a/src/exec/access_path.cpp
+++ b/src/exec/access_path.cpp
@@ -223,6 +223,10 @@ void AccessPath::calc_normal(Property& sort_property) {
             break;
         }
     }
+    if (hit_index_field_ids.size() < field_range_map.size()) {
+	//除cut contition外有过滤条件
+	_need_filter = true;
+    }
     is_sort_index = check_sort_use_index(sort_property);
     DB_DEBUG("is_sort_index:%d, eq_count:%d, sort_property:%lu", 
         is_sort_index, eq_count, sort_property.slot_order_exprs.size());

--- a/src/exec/rocksdb_scan_node.cpp
+++ b/src/exec/rocksdb_scan_node.cpp
@@ -94,7 +94,8 @@ int RocksdbScanNode::choose_index(RuntimeState* state) {
         }
     }
     // 以baikaldb的判断为准
-    if (pos_index.is_covering_index()) {
+    if (pos_index.is_covering_index() && _is_covering_index == false) {
+	DB_WARNING("covering_index conflict, index_id = [%d]", _index_id);
         _is_covering_index = true;
     }
 

--- a/src/exec/scan_node.cpp
+++ b/src/exec/scan_node.cpp
@@ -376,6 +376,12 @@ int AccessPathMgr::compare_two_path(SmartPath& outer_path, SmartPath& inner_path
             return 0;
         }
 
+        if (!inner_path->need_filter() && outer_path->is_sort_index <= inner_path->is_sort_index) {
+	    outer_path->is_possible = false;
+            return -1;
+	}
+
+
         if (!outer_path->is_cover_index() && !outer_path->is_sort_index) {
             outer_path->is_possible = false;
             return -1;
@@ -390,6 +396,11 @@ int AccessPathMgr::compare_two_path(SmartPath& outer_path, SmartPath& inner_path
         if (!full_coverage(inner_path->hit_index_field_ids, outer_path->hit_index_field_ids)) {
             return 0;
         }
+
+        if (!outer_path->need_filter() && inner_path->is_sort_index <= outer_path->is_sort_index) {
+	    inner_path->is_possible = false;
+            return -2;
+	}
 
         if (!inner_path->is_cover_index() && !inner_path->is_sort_index) {
             inner_path->is_possible = false;

--- a/src/exec/scan_node.cpp
+++ b/src/exec/scan_node.cpp
@@ -179,7 +179,8 @@ void ScanNode::show_explain(std::vector<std::map<std::string, std::string>>& out
             explain_info["possible_keys"].pop_back();
         }
         std::string tmp;
-        int64_t index_id = select_index_in_baikaldb(tmp);
+        //int64_t index_id = select_index_in_baikaldb(tmp);
+        int64_t index_id = _select_idx;
         auto index_info = factory->get_index_info(index_id);
         auto pri_info = factory->get_index_info(_table_id);
         explain_info["key"] = index_info.short_name;
@@ -516,6 +517,8 @@ int64_t ScanNode::select_index_in_baikaldb(const std::string& sample_sql) {
     }
 
     std::vector<ExprNode*> filter_condition;
+    _select_idx = select_idx;
+    calc_index_range();
     std::vector<int64_t> multi_reverse_index = _main_path.multi_reverse_index();
     if (multi_reverse_index.size() > 0) {
         _scan_indexs.clear();

--- a/src/exec/scan_node.cpp
+++ b/src/exec/scan_node.cpp
@@ -322,12 +322,12 @@ int AccessPathMgr::compare_two_path(SmartPath& outer_path, SmartPath& inner_path
 
         if (outer_path->is_cover_index() == inner_path->is_cover_index() &&
             outer_path->is_sort_index == inner_path->is_sort_index) {
-            if (outer_path->index_other_condition.size() > 
-                inner_path->index_other_condition.size()) {
+            if (outer_path->index_other_condition_count > 
+                inner_path->index_other_condition_count) {
                 inner_path->is_possible = false;
                 return -2;
-            } else if (outer_path->index_other_condition.size() < 
-                    inner_path->index_other_condition.size()) {
+            } else if (outer_path->index_other_condition_count < 
+                    inner_path->index_other_condition_count) {
                 outer_path->is_possible = false;
                 return -1;
             } else {

--- a/src/exec/select_manager_node.cpp
+++ b/src/exec/select_manager_node.cpp
@@ -341,7 +341,20 @@ int SelectManagerNode::open_global_index(FetcherInfo* fetcher, RuntimeState* sta
                 state->txn_id, state->log_id());
         return ret;
     }
-    ret = construct_primary_possible_index(fetcher->fetcher_store, fetcher->scan_index, state, scan_node, main_table_id);
+    ExecNode* parent = get_parent();
+    while (parent != nullptr && parent->node_type() != pb::LIMIT_NODE) {
+        if (parent->node_type() != pb::SORT_NODE) {
+            parent = nullptr;
+            break;
+        }
+        parent = parent->get_parent();
+    }
+    LimitNode* limit = static_cast<LimitNode*>(parent);
+    if (need_pushdown && limit != nullptr) {
+        ret = construct_primary_possible_index_use_limit(fetcher->fetcher_store, fetcher->scan_index, state, scan_node, main_table_id, limit);
+    } else {
+        ret = construct_primary_possible_index(fetcher->fetcher_store, fetcher->scan_index, state, scan_node, main_table_id);
+    }
     if (ret < 0) {
         DB_WARNING("construct primary possible index failed");
         return ret;
@@ -355,6 +368,99 @@ int SelectManagerNode::open_global_index(FetcherInfo* fetcher, RuntimeState* sta
         return ret; 
     }
     return ret;
+}
+
+int SelectManagerNode::construct_primary_possible_index_use_limit(
+                      FetcherStore& fetcher_store,
+                      ScanIndexInfo* scan_index_info,
+                      RuntimeState* state,
+                      ExecNode* exec_node,
+                      int64_t main_table_id,
+                      LimitNode* limit) {
+    RocksdbScanNode* scan_node = static_cast<RocksdbScanNode*>(exec_node);
+    int32_t tuple_id = scan_node->tuple_id();
+    auto pri_info = _factory->get_index_info_ptr(main_table_id);
+    if (pri_info == nullptr) {
+        DB_WARNING("pri index info not found table_id:%ld", main_table_id);
+        return -1;
+    }
+    // 不能直接清理所有索引，可能有backup请求使用scan_node
+    // scan_node->clear_possible_indexes();
+    // pb::ScanNode* pb_scan_node = scan_node->mutable_pb_node()->mutable_derive_node()->mutable_scan_node();
+    // auto pos_index = pb_scan_node->add_indexes();
+    // pos_index->set_index_id(main_table_id);
+    // scan_node->set_router_index_id(main_table_id);
+
+    scan_index_info->router_index = nullptr;
+    scan_index_info->raw_index.clear();
+    scan_index_info->region_infos.clear();
+    scan_index_info->region_primary.clear();
+    scan_index_info->router_index_id = main_table_id;
+    scan_index_info->index_id = main_table_id;
+    pb::PossibleIndex pos_index;
+    pos_index.set_index_id(main_table_id);
+    SmartRecord record_template = _factory->new_record(main_table_id);
+    auto mem_row_compare = std::make_shared<MemRowCompare>(_slot_order_exprs, _is_asc, _is_null_first);
+    auto tsorter = std::make_shared<Sorter>(_mem_row_compare.get());
+    for (auto& pair : fetcher_store.start_key_sort) {
+        auto& batch = fetcher_store.region_batch[pair.second];
+        if (batch == nullptr) {
+            continue;
+        }
+        if (batch->size() > 0){ 
+            tsorter->add_batch(batch);
+        }
+    }
+    if (tsorter->batch_size() == 0){ 
+        return 0;
+    }
+    tsorter->merge_sort();
+    bool eos = false;
+    int64_t limit_cnt = limit->get_limit();
+    while (!eos) {
+        std::shared_ptr<RowBatch> batch = std::make_shared<RowBatch>();
+        auto ret = tsorter->get_next(batch.get(), &eos);
+        if (ret < 0) {
+            DB_WARNING("sort get_next fail");
+            return ret;
+        }
+        for (batch->reset(); !batch->is_traverse_over(); batch->next()) {
+            std::unique_ptr<MemRow>& mem_row = batch->get_row();
+            SmartRecord record = record_template->clone(false);
+            for (auto& pri_field : pri_info->fields) {
+                int32_t field_id = pri_field.id;
+                int32_t slot_id = state->get_slot_id(tuple_id, field_id);
+                if (slot_id == -1) {
+                    DB_WARNING("field_id:%d tuple_id:%d, slot_id:%d", field_id, tuple_id, slot_id);
+                    return -1;
+                }
+                record->set_value(record->get_field_by_tag(field_id), mem_row->get_value(tuple_id, slot_id));
+            }
+            auto range = pos_index.add_ranges();
+            MutTableKey  key;
+            if (record->encode_key(*pri_info.get(), key, pri_info->fields.size(), false, false) != 0) {
+                DB_FATAL("Fail to encode_key left, table:%ld", pri_info->id);
+                return -1;
+            }
+            range->set_left_key(key.data());
+            range->set_left_full(key.get_full());
+            range->set_right_key(key.data());
+            range->set_right_full(key.get_full());
+            range->set_left_field_cnt(pri_info->fields.size());
+            range->set_right_field_cnt(pri_info->fields.size());
+            range->set_left_open(false);
+            range->set_right_open(false);
+            limit_cnt --;
+            if(!limit_cnt) {
+                eos = true;
+                break;
+            }
+        }
+    }
+    //重新做路由选择
+    pos_index.SerializeToString(&scan_index_info->raw_index);
+    return _factory->get_region_by_key(*pri_info, &pos_index, scan_index_info->region_infos,
+                                       &scan_index_info->region_primary);
 }
 
 int SelectManagerNode::construct_primary_possible_index(

--- a/src/exec/select_manager_node.cpp
+++ b/src/exec/select_manager_node.cpp
@@ -427,6 +427,10 @@ int SelectManagerNode::construct_primary_possible_index_use_limit(
         for (batch->reset(); !batch->is_traverse_over(); batch->next()) {
             std::unique_ptr<MemRow>& mem_row = batch->get_row();
             SmartRecord record = record_template->clone(false);
+            if (limit->get_num_rows_skipped() < limit->get_offset()) {
+		limit->add_num_rows_skipped(1);
+		continue;
+            }
             for (auto& pri_field : pri_info->fields) {
                 int32_t field_id = pri_field.id;
                 int32_t slot_id = state->get_slot_id(tuple_id, field_id);

--- a/src/logical_plan/prepare_planner.cpp
+++ b/src/logical_plan/prepare_planner.cpp
@@ -253,6 +253,8 @@ int PreparePlanner::stmt_execute(const std::string& stmt_name, std::vector<pb::E
     _ctx->row_ttl_duration = prepare_ctx->row_ttl_duration;
     _ctx->is_complex = prepare_ctx->is_complex;
     _ctx->mutable_tuple_descs()->assign(tuple_descs.begin(), tuple_descs.end());
+    _ctx->ref_slot_id_mapping.insert(prepare_ctx->ref_slot_id_mapping.begin(),
+                                     prepare_ctx->ref_slot_id_mapping.end());
     // TODO dml的plan复用
     if (!prepare_ctx->is_select) {
         // enable_2pc=true or table has global index need generate txn_id

--- a/src/physical_plan/index_selector.cpp
+++ b/src/physical_plan/index_selector.cpp
@@ -599,12 +599,12 @@ int64_t IndexSelector::index_selector(const std::vector<pb::TupleDescriptor>& tu
         if (sort_node != nullptr) {
             sort_property = sort_node->sort_property();
         }
-        access_path->calc_index_range(sort_property);
-        access_path->insert_no_cut_condition(expr_field_map);
+        access_path->calc_index_match(sort_property);
         access_path->calc_is_covering_index(tuple_descs[tuple_id]);
         scan_node->add_access_path(access_path);
     }
     scan_node->set_fulltext_index_tree(std::move(fulltext_index_tree));
+    scan_node->set_expr_field_map(&expr_field_map);
     return scan_node->select_index_in_baikaldb(sample_sql); 
 }
 

--- a/src/physical_plan/index_selector.cpp
+++ b/src/physical_plan/index_selector.cpp
@@ -620,7 +620,7 @@ int64_t IndexSelector::index_selector(const std::vector<pb::TupleDescriptor>& tu
         scan_node->add_access_path(access_path);
     }
     scan_node->set_fulltext_index_tree(std::move(fulltext_index_tree));
-    scan_node->set_expr_field_map(&expr_field_map);
+    scan_node->set_expr_field_map(std::move(expr_field_map));
     return scan_node->select_index_in_baikaldb(sample_sql); 
 }
 


### PR DESCRIPTION
### 全局索引先limit后回表优化

- 背景：针对分页查询的需求， SQL类似于 select ... order by id limit 10000, 10 ，这种一般是用户翻到了第1001页，每页展示10条，为了找到这10条数据，即使limit可以下推，也需先要找到id最小的10010条，然后再取最后10条数据， 此时扫描的数据量= 10010； 此时如果业务侧能知道第10000条数据id，例如ID(10000) = 10000，则查询可以改写为：select ... where id > 10000 order by id limit 10，此时需要用户存储第1000页的最大id， 这增加了用户写sql的复杂度，更重要的时，有的场景是用户直接跳转到底1001页，业务侧也不知道上一页的最大id，针对分页场景，进行了limit的回表优化。
- 实现：
    - 首先对用户查询条件创建索引，由于索引返回的数据只包含索引字段与主键字段，扫描与返回的数据量均远小于主表，所以在索引环节完成limit的下推与过滤
    - 通过索引进行回表阶段，已完成limit，此时回表的数据量由原来的10010条减少到10条，从而大大提升了分页场景的优化速度

### 索引选择和索引range生成拆分，减少生成range开销
- 背景：查询过滤条件复杂的sql，例如 in （v1 ... v1000），生成索引的同时会生成range信息（即索引的扫描区间），对于索引较多时，一般不止一种可用的查询计划，如果全部都生成range信息，会造成额外的overhead
- 实现：虽然查询计划有多种，但经过索引选择后，最终只会有一个查询计划胜出，该优化把range信息生成延迟到索引选择之后再生成，从而避免了多索引的range生成overhead