### PR TITLE
Use the C++'s double max value.

### DIFF
--- a/src/exec/scan_node.cpp
+++ b/src/exec/scan_node.cpp
@@ -235,7 +235,7 @@ void AccessPathMgr::show_cost(std::vector<std::map<std::string, std::string>>& p
 }
 
 int64_t AccessPathMgr::select_index_by_cost() {
-    double min_cost = DBL_MAX;
+    double min_cost = std::numeric_limits<double>::max();
     int64_t min_idx = 0;
     bool multi_0_0 = false;
     bool multi_1_0 = false;


### PR DESCRIPTION
The code with DBL_MAX cannot compiled in newer c++ compilers, this commit fix it.

In face the value of DBL_MAX and std::numeric_limits<double>::max() is same, so this change will not break any logic.

Signed-off-by: Ketor <d.ketor@gmail.com>