### PR TITLE
Fix compile error in gcc 11.

### DIFF
--- a/include/store/backup.h
+++ b/include/store/backup.h
@@ -71,7 +71,7 @@ public:
         const pb::BackupRequest* request, pb::BackupResponse* response);
 private:
     struct ProgressiveAttachmentWritePolicy {
-        ProgressiveAttachmentWritePolicy(brpc::ProgressiveAttachment* attach) : attachment(attach) {}
+        ProgressiveAttachmentWritePolicy(butil::intrusive_ptr<brpc::ProgressiveAttachment> attach) : attachment(attach) {}
         int Write(const void* data, size_t n) {
             return attachment->Write(data, n);
         }
@@ -79,7 +79,7 @@ private:
         int WriteStreamingSize(int64_t) {
             return 0;
         }
-        brpc::ProgressiveAttachment* attachment;
+        butil::intrusive_ptr<brpc::ProgressiveAttachment> attachment;
     };
 
     struct StreamingWritePolicy {


### PR DESCRIPTION
This commit is like https://github.com/brpc/media-server/pull/8, just replace original ptr to intrusive_ptr.

Signed-off-by: Ketor <d.ketor@gmail.com>