### PR TITLE
fix: binlog region ttl bug; abs function invalid for bigint

### DIFF
--- a/include/engine/split_compaction_filter.h
+++ b/include/engine/split_compaction_filter.h
@@ -65,7 +65,7 @@ public:
         TableKey table_key(key);
         int64_t region_id = table_key.extract_i64(0);
         FilterRegionInfo* filter_info  = get_filter_region_info(region_id);
-        if (filter_info == nullptr || filter_info->end_key.empty()) {
+        if (filter_info == nullptr || (!is_binlog_region(region_id) && filter_info->end_key.empty())) {
             return false;
         }
         const std::string& end_key = filter_info->end_key;

--- a/src/expr/internal_functions.cpp
+++ b/src/expr/internal_functions.cpp
@@ -78,7 +78,7 @@ ExprValue abs(const std::vector<ExprValue>& input) {
         return ExprValue::Null();
     }
     ExprValue tmp(pb::DOUBLE);
-    tmp._u.double_val = ::abs(input[0].get_numberic<double>());
+    tmp._u.double_val = ::llabs(input[0].get_numberic<double>());
     return tmp;
 }
 


### PR DESCRIPTION
1. 修复Binlog region无法删除过期数据的问题；
2. 增加abs函数对bigint的支持