### PR TITLE
feat: add FLAGS_check_condition_again_for_global_index

### DIFF
--- a/include/exec/lock_primary_node.h
+++ b/include/exec/lock_primary_node.h
@@ -18,6 +18,8 @@
 #include "dml_node.h"
 
 namespace baikaldb {
+DECLARE_bool(check_condition_again_for_global_index);
+
 class LockPrimaryNode : public DMLNode {
 public:
     LockPrimaryNode() {}
@@ -48,7 +50,9 @@ public:
         return true;
     }
     void add_conjunct(ExprNode* conjunct) {
-        _conjuncts.push_back(conjunct);
+        if (FLAGS_check_condition_again_for_global_index) {
+            _conjuncts.push_back(conjunct);
+        }
     }
 
     void set_affected_index_ids(const std::vector<int64_t>& ids) {

--- a/src/exec/lock_primary_node.cpp
+++ b/src/exec/lock_primary_node.cpp
@@ -17,6 +17,8 @@
 
 namespace baikaldb {
 
+DEFINE_bool(check_condition_again_for_global_index, false, "avoid write skew for global index if true");
+
 int LockPrimaryNode::init(const pb::PlanNode& node) {
     int ret = 0;
     ret = ExecNode::init(node);


### PR DESCRIPTION
在prepare模式下，LockPrimaryNode的_conjuncts有时候没有被正确析构，会造成偶发性的core，加一个开关，默认关闭添加conjunct校验的逻辑。