### PR TITLE
Merge internal 04-19

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Cache cmake modules
       uses: actions/cache@v2
       with:
-        key: cmake-buildenv3
+        key: cmake-buildenv1
         path: |
            buildenv
     - name: Install Dependencies

--- a/include/common/datetime.h
+++ b/include/common/datetime.h
@@ -17,7 +17,7 @@
 #include "common.h"
 
 namespace baikaldb {
-extern std::string timestamp_to_str(time_t timestamp);
+extern std::string timestamp_to_str(time_t timestamp, bool is_utc = false);
 extern time_t str_to_timestamp(const char* str_time);
 
 // encode DATETIME to string format

--- a/include/common/memory_profile.h
+++ b/include/common/memory_profile.h
@@ -57,7 +57,8 @@ public:
         return _bytes_limit > 0 && _bytes_consumed > _bytes_limit;
     }
     bool any_limit_exceeded() {
-        if (limit_exceeded() || (_parent !=nullptr && _parent->limit_exceeded())) {
+        if (limit_exceeded() || (_parent !=nullptr && _parent->any_limit_exceeded())) {
+            _limit_exceeded = true;
             return true;
         }
         return false;

--- a/include/engine/qos.h
+++ b/include/engine/qos.h
@@ -241,11 +241,11 @@ public:
 
     void sql_statistics_adder(int64_t count);
 
-    int increase_timed_wait(const int64_t reject_timeout);
+    int increase_timed_wait_with_max_wait_cnt(const int max_wait_cnt, const int64_t reject_timeout);
 
-    int increase_wait();
+    int increase_wait_with_max_wait_cnt(const int max_wait_cnt);
    
-    int decrease_signal();
+    int decrease_signal_with_wait_cnt();
 
     void inc_index_count(const int64_t index_id) {
         bool print_log = false;
@@ -297,10 +297,10 @@ public:
         if (get_qps != 0 || scan_qps != 0) {
             DB_WARNING("sign: %lu, get_qps: %ld, scan_qps: %ld, sql_qps: %ld,"
                        " get_real: %ld, scan_real: %ld, token_fetch_qps: %ld,"
-                       " concurrency: %d", 
+                       " concurrency: %d, wait_count: %d", 
                         _sign, get_qps, scan_qps, _sql_qps, 
                         _get_real.get_qps_value(), _scan_real.get_qps_value(), _token_fetch.get_qps_value(), 
-                        _concurrency.count());
+                        _concurrency.count(),  _concurrency.total_count());
         }
 
         std::lock_guard<bthread::Mutex> lock(_mutex);

--- a/include/engine/transaction.h
+++ b/include/engine/transaction.h
@@ -321,7 +321,7 @@ public:
         return _in_process.compare_exchange_strong(expected, desire);
     }
 
-    void select_update_txn_status(int seq_id) {
+    void normal_select_update_txn_status(int seq_id) {
         _current_req_point_seq.clear();
         _current_req_point_seq.insert(seq_id);
         _in_process = false;
@@ -472,6 +472,8 @@ public:
     int fits_region_range_for_primary(IndexInfo& pk_index,
         SmartRecord record,
         bool& result);
+    bool fits_region_range_for_primary(IndexInfo& pk_index,
+        MutTableKey& pk_key);
     
     pb::StoreReq* get_raftreq() {
         return &_store_req;
@@ -558,6 +560,7 @@ public:
     int         dml_num_affected_rows = 0; //for autocommit dml return
     int64_t     batch_num_increase_rows = 0;//用于batch txn
     pb::ErrCode err_code = pb::SUCCESS;
+    std::string remote_side = ""; // 便于定位超时事务来源
 
 private:
     int get_update_primary(

--- a/include/engine/transaction_pool.h
+++ b/include/engine/transaction_pool.h
@@ -128,9 +128,13 @@ private:
         bool is_primary_region = true;
         bool is_finished = false;
         bool is_prepared = false;
+        bool is_exist = false;
         int seq_id = 0;
         int64_t primary_region_id = -1;
     };
+    bool process_out_of_order_txn(Region* region, uint64_t txn_id, TxnParams& txn_params);
+
+private:
     int64_t _region_id = 0;
     int64_t _latest_active_txn_ts = 0;
     bool _use_ttl = false;

--- a/include/exec/access_path.h
+++ b/include/exec/access_path.h
@@ -44,7 +44,7 @@ enum IndexHint {
         return true;
     }
 
-    void calc_index_range();
+    void calc_index_range(int64_t partition_field_id, const std::map<std::string, int64_t>& expr_partition_map);
 
     void calc_index_match(Property& sort_property) {
         fetch_field_ids();

--- a/include/exec/exec_node.h
+++ b/include/exec/exec_node.h
@@ -23,7 +23,27 @@
 #include "mem_row_descriptor.h"
 #include "runtime_state.h"
 
-namespace baikaldb { 
+namespace baikaldb {
+
+inline bool is_dml_op_type(const pb::OpType& op_type) {
+        if (op_type == pb::OP_INSERT
+             || op_type == pb::OP_DELETE
+             || op_type == pb::OP_UPDATE
+             || op_type == pb::OP_SELECT_FOR_UPDATE
+             || op_type == pb::OP_PARTIAL_ROLLBACK
+             || op_type == pb::OP_KV_BATCH) {
+            return true;
+        }
+        return false;
+    }
+inline bool is_2pc_op_type(const pb::OpType& op_type) {
+    if (op_type == pb::OP_PREPARE
+            || op_type == pb::OP_ROLLBACK
+            || op_type == pb::OP_COMMIT) {
+        return true;
+    }
+    return false;
+}
 
 class RuntimeState;
 class QueryContext;

--- a/include/exec/full_export_node.h
+++ b/include/exec/full_export_node.h
@@ -39,6 +39,7 @@ public:
     bool get_batch(RowBatch* batch);
     // fullexport分批获取region
     int get_next_region_infos();
+    void get_next_partition();
     // 达到limit后，记录最后一条数据，下次查询可以接着上次查询
     // 用于inner join后数据变少，可以再次获取数据
     int calc_last_key(RuntimeState* state, MemRow* mem_row);
@@ -50,6 +51,8 @@ public:
 private:
     FetcherStore _fetcher_store;
     std::deque<int64_t> _send_region_ids;
+    std::map<int64_t, std::map<int64_t, pb::RegionInfo>> _origin_region_infos;
+    int64_t _current_partition = 0;
     // <partition_id, <start_key,region_id>>
     std::map<int64_t, std::map<std::string, int64_t>> _start_key_sort;
     RocksdbScanNode* _scan_node = nullptr;

--- a/include/exec/insert_manager_node.h
+++ b/include/exec/insert_manager_node.h
@@ -107,6 +107,9 @@ public:
     void set_records(std::vector<SmartRecord>& records) {
         _origin_records.swap(records);
     }
+    void copy_records(std::vector<SmartRecord>& records) {
+        _origin_records.insert(_origin_records.end(), records.begin(), records.end());
+    }
 
     int subquery_open(RuntimeState* state);
 

--- a/include/expr/operators.h
+++ b/include/expr/operators.h
@@ -63,8 +63,8 @@ BINARY_OP_PREDICATE_ALL_TYPES_DEFINE(ge);
 BINARY_OP_PREDICATE_ALL_TYPES_DEFINE(lt);
 BINARY_OP_PREDICATE_ALL_TYPES_DEFINE(le);
 // && || xor
-BINARY_OP_DEFINE(logic_and, bool);
-BINARY_OP_DEFINE(logic_or, bool);
+//BINARY_OP_DEFINE(logic_and, bool);
+//BINARY_OP_DEFINE(logic_or, bool);
 //BINARY_OP_DEFINE(logic_xor, bool);
 }
 

--- a/include/logical_plan/ddl_work_planner.h
+++ b/include/logical_plan/ddl_work_planner.h
@@ -58,7 +58,8 @@ public:
 
         _router_start_key = _work.start_key();
         _router_end_key = _work.end_key();
-        DB_NOTICE("process table_id_%ld index_id_%ld field_num %d", _table_id, _index_id, _field_num);
+        DB_NOTICE("process table_id_%ld index_id_%ld _is_global_index:%d field_num %d", _table_id,
+            _index_id, _is_global_index, _field_num);
         return 0;
     }
 

--- a/include/meta_server/query_region_manager.h
+++ b/include/meta_server/query_region_manager.h
@@ -36,6 +36,8 @@ public:
                 const std::string& instance,
                 std::set<int64_t>& peer_ids);
 
+    void get_binlog_timestamps(const pb::QueryRequest* request, pb::QueryResponse* response);
+
     void send_transfer_leader(const pb::QueryRequest* request, pb::QueryResponse* response);
     void send_set_peer(const pb::QueryRequest* request, pb::QueryResponse* response);
     void get_region_peer_status(const pb::QueryRequest* request, pb::QueryResponse* response);

--- a/include/physical_plan/auto_inc.h
+++ b/include/physical_plan/auto_inc.h
@@ -29,6 +29,10 @@ public:
                                NetworkSocket* client_conn,
                                bool use_backup,
                                std::vector<SmartRecord>& insert_records);
+    static bool need_degrade;
+    static TimeCost last_degrade_time;
+    static bvar::Adder<int64_t> auto_inc_count;
+    static bvar::Adder<int64_t> auto_inc_error;
 };
 }
 

--- a/include/protocol/network_server.h
+++ b/include/protocol/network_server.h
@@ -74,6 +74,8 @@ public:
     // Stop server.
     void stop();
 
+    void fast_stop();
+
     // Gracefully shutdown.
     void graceful_shutdown();
 

--- a/include/protocol/show_helper.h
+++ b/include/protocol/show_helper.h
@@ -30,6 +30,9 @@ const std::string SQL_SHOW_NAMESPACE             = "namespace";             // s
 const std::string SQL_SHOW_META                  = "meta";                  // show meta;
 const std::string SQL_SHOW_TABLE_STATUS          = "table";                 // show table status;
 const std::string SQL_SHOW_TABLES                = "tables";                // show tables;
+const std::string SQL_SHOW_FUNCTION_STATUS       = "function";              // show function status;
+const std::string SQL_SHOW_PROCEDURE_STATUS      = "procedure";             // show procedure status;
+const std::string SQL_SHOW_TRIGGERS              = "triggers";              // show triggers;
 const std::string SQL_SHOW_SOCKET                = "socket";                // show socket;
 const std::string SQL_SHOW_WARNINGS              = "warnings";              // show warnings;
 const std::string SQL_SHOW_PROCESSLIST           = "processlist";           // show processlist;
@@ -63,6 +66,7 @@ const std::string SQL_SHOW_INDEXES               = "indexes";               // s
 const std::string SQL_SHOW_KEYS                  = "keys";                  // show keys; same as `show index`
 const std::string SQL_SHOW_PARTITION_TABLE       = "partition_tables";      // show partition table info
 const std::string SQL_SHOW_ABNORMAL_SWITCH       = "abnormal_switch";       // show abnormal_switch
+const std::string SQL_SHOW_META_BINLOG           = "meta_binlog";           // show meta_binlog db.table
 
 namespace baikaldb {
 typedef std::shared_ptr<NetworkSocket> SmartSocket;
@@ -109,6 +113,12 @@ private:
     bool _show_cost(const SmartSocket& client, const std::vector<std::string>& split_vec);
     // sql: show full tables;
     bool _show_full_tables(const SmartSocket& client, const std::vector<std::string>& split_vec);
+    // sql: show function status;
+    bool _show_function_status(const SmartSocket& client, const std::vector<std::string>& split_vec);
+    // sql: show procedure status;
+    bool _show_procedure_status(const SmartSocket& client, const std::vector<std::string>& split_vec);
+    // sql: show triggers;
+    bool _show_triggers(const SmartSocket& client, const std::vector<std::string>& split_vec);
     // sql: show full columns from tableName;
     bool _show_full_columns(const SmartSocket& client, const std::vector<std::string>& split_vec);
     // sql: show schema_conf database_table;
@@ -151,6 +161,9 @@ private:
     // sql: show abnormal_switch
     // 异常的switch，如快速导入超一天，表split_lines超1kw行，peer_loadbalance，migrate关闭等
     bool _show_abnormal_switch(const SmartSocket& client, const std::vector<std::string>& split_vec);
+
+    bool _show_meta_binlog(const SmartSocket& client, const std::vector<std::string>& split_vec);
+
     bool _handle_client_query_template_dispatch(const SmartSocket& client, const std::vector<std::string>& split_vec);
     int _make_common_resultset_packet(const SmartSocket& sock, 
             std::vector<ResultField>& fields,

--- a/include/reverse/boolean_engine/boolean_executor.h
+++ b/include/reverse/boolean_engine/boolean_executor.h
@@ -150,7 +150,7 @@ public:
     void set_merge_func(MergeFuncT merge_func);
 
 protected:
-    //子节点
+    //子节点，针对or做堆
     std::vector<BooleanExecutor<Schema>*> _sub_clauses;
     //布尔操作的函数（and or weight）
     MergeFuncT _merge_func;
@@ -200,8 +200,9 @@ public:
 
 private:
 
-    BooleanExecutor<Schema>* _miter = nullptr;
     const PostingNodeT* find_next();
+    void make_heap();
+    void shiftdown(size_t index);
 };
 
 template <typename Schema>

--- a/include/session/binlog_context.h
+++ b/include/session/binlog_context.h
@@ -24,11 +24,13 @@
 #include <baidu/rpc/channel.h>
 #include <baidu/rpc/server.h>
 #include <baidu/rpc/controller.h>
+#include <raft/repeated_timer_task.h>
 #else
 #include <butil/endpoint.h>
 #include <brpc/channel.h>
 #include <brpc/server.h>
 #include <brpc/controller.h>
+#include <braft/repeated_timer_task.h>
 #endif
 
 #include <memory>
@@ -36,11 +38,64 @@
 namespace baikaldb {
 
 DECLARE_string(meta_server_bns);
-class TsoFetcher {
+class TsoFetcher : public braft::RepeatedTimerTask {
 public:
-    static int64_t get_tso();
+    static TsoFetcher* get_instance() {
+        static TsoFetcher ins;
+        return &ins;
+    }
+    ~TsoFetcher() {
+        stop();
+        destroy();
+    }
+    int init();
+    int64_t get_tso(int64_t count);
+    void set_instance_id(uint64_t instance_id) {
+        _instance_id = instance_id;
+    }
+    void run() override;
+    void on_destroy() override {}
+    void set_degrade() {
+        _need_degrade = true;
+    }
+
+    bvar::Adder<int64_t> tso_count;
+    bvar::Adder<int64_t> tso_error;
+private:
+    pb::TsoTimestamp _tso_obj;
+    bthread::Mutex _tso_mutex;  // 保护_tso_time
+    bool _need_degrade = false;
+    uint64_t _instance_id = 0;
 };
 
+struct PartitionBinlog {
+    int64_t           start_ts = -1;
+    int64_t           commit_ts = -1;
+    pb::RegionInfo        binlog_region;
+    pb::PrewriteValue     binlog_value;
+    std::set<std::string> db_tables;
+    TimeCost              binlog_prewrite_time;
+    uint64_t              partition_id = 0;
+    int64_t               binlog_row_cnt = 0;
+    std::set<uint64_t>    signs;
+    void calc_binlog_row_cnt() {
+        binlog_row_cnt = 0;
+        for (const auto& mutation : binlog_value.mutations()) {
+            binlog_row_cnt += mutation.insert_rows_size();
+            binlog_row_cnt += mutation.update_rows_size();
+            binlog_row_cnt += mutation.deleted_rows_size();
+        }
+    }
+};
+
+typedef std::shared_ptr<PartitionBinlog> SmartPartitionBinlog;
+
+struct BinlogInfo {
+    SmartTable       binlog_table_info = nullptr;
+    bool             partition_is_same_hint = true;
+    std::map<int64_t, SmartPartitionBinlog> binlog_by_partition;
+};
+struct WriteBinlogParam;
 class BinlogContext {
 public:
     BinlogContext() {
@@ -48,87 +103,113 @@ public:
     };
     ~BinlogContext() { };
 
-    int get_binlog_regions(uint64_t log_id);
-
-    pb::PrewriteValue* mutable_binlog_value() {
-        return &_binlog_value;
-    }
-    const pb::PrewriteValue& binlog_value() const {
-        return _binlog_value;
-    }
-
-    int64_t start_ts() const {
-        return _start_ts;
-    }
-
+    // 每个partition设置自己的start_ts和commit_ts
     void set_start_ts(int64_t start_ts) {
         _start_ts = start_ts;
-    }
-
-    int64_t commit_ts() const {
-        return _commit_ts;
+        for (auto& pair : _table_binlogs) {
+            for (auto& pair2 : pair.second.binlog_by_partition) {
+                pair2.second->start_ts = start_ts++;
+            }
+        }
     }
 
     void set_commit_ts(int64_t commit_ts) {
-        _commit_ts = commit_ts;
-    }
-    
-    pb::RegionInfo& binglog_region() {
-        return _binlog_region;
+        for (auto& pair : _table_binlogs) {
+            for (auto& pair2 : pair.second.binlog_by_partition) {
+                pair2.second->commit_ts = commit_ts++;
+            }
+        }
+        _commit_ts = --commit_ts;
     }
 
-    void set_partition_record(SmartRecord partition_record) {
-        _partition_record = partition_record;
+    int64_t get_first_start_ts() const {
+        return _start_ts;
+    }
+    // binlog反查primary_region时使用
+    int64_t get_last_commit_ts() const {
+        return _commit_ts;
     }
 
     bool has_data_changed() {
-        return _partition_record != nullptr;
+        return _table_binlogs.size() > 0;
     }
 
-    void set_table_info(SmartTable table_info) {
-        _table_info = table_info;
+    int tso_count() const {
+        return _tso_count;
     }
 
-    uint64_t get_partition_key() const {
-        return _partition_key;
+    void set_repl_mark_info(SmartTable& table_info,
+                          const std::string& sql,
+                          const uint64_t sign,
+                          SmartRecord& record) {
+        _repl_mark_table_info = table_info;
+        _repl_mark_sql = sql;
+        _repl_mark_sign = sign;
+        _repl_mark_record = record;
     }
 
-    void calc_binlog_row_cnt() {
-         _binlog_row_cnt = 0;
-         for (const auto& mutation : _binlog_value.mutations()) {
-             _binlog_row_cnt += mutation.insert_rows_size();
-             _binlog_row_cnt += mutation.update_rows_size();
-             _binlog_row_cnt += mutation.deleted_rows_size();
-         }
+    SmartPartitionBinlog get_partition_binlog_ptr(int64_t binlog_id,
+                                                  BinlogInfo& binlog_info,
+                                                  int64_t partition_id);
+    
+    void add_mutation(SmartPartitionBinlog& binlog_ptr,
+                    int64_t table_id,
+                    const std::string& sql,
+                    const uint64_t sign,
+                    pb::MutationType type,
+                    int64_t partition_id,
+                    bool all_in_one,
+                    const std::map<int64_t, std::vector<std::string>>& retrun_records,
+                    const std::map<int64_t, std::vector<std::string>>& retrun_old_records);
+
+    int64_t get_partition_id(const SmartTable& binlog_table_info,
+                                  const SmartRecord& record,
+                                  const FieldInfo& link_field) {
+        if (binlog_table_info->partition_num == 1) {
+            return 0;
+        }
+        auto field_desc = record->get_field_by_idx(link_field.pb_idx);
+        ExprValue value = record->get_value(field_desc);
+        int64_t partition_id = 0;
+        if (binlog_table_info->partition_ptr != nullptr) {
+            partition_id = binlog_table_info->partition_ptr->calc_partition(value);
+        } else {
+            DB_WARNING("partition info error, value:%s", value.get_string().c_str());
+            return -1;
+        }
+        _partition_keys[partition_id] = value.get_numberic<uint64_t>();
+        return partition_id;
     }
 
-    int64_t get_binlog_row_cnt() const { return _binlog_row_cnt; }
-
-    void add_sql_info(const std::string& db, const std::string& table, const uint64_t sign) {
-        _db_tables.insert(db + "." + table);
-        _signs.insert(sign);
-    }
-
-    std::set<std::string>& get_db_tables() {
-        return _db_tables;
-    } 
-
-    std::set<uint64_t>& get_signs() {  
-        return _signs;
-    }
+    int add_binlog_values(SmartTable& table_info,
+                          const std::string& sql,
+                          const uint64_t sign,
+                          pb::MutationType type,
+                          const std::map<int64_t, std::vector<std::string>>& retrun_records,
+                          const std::map<int64_t, std::vector<std::string>>& retrun_old_records);
+    
+    int add_binlog_values(SmartTable& table_info,
+                          const std::string& sql,
+                          const uint64_t sign,
+                          pb::MutationType type,
+                          const std::vector<SmartRecord>& retrun_records,
+                          const std::vector<SmartRecord>& retrun_old_records);
+    
+    int write_binlog(const WriteBinlogParam* param);
+    int send_binlog_data(const WriteBinlogParam* param, const SmartPartitionBinlog& partition_binlog_ptr);
 
 private:
-    SmartTable            _table_info = nullptr;
+    SchemaFactory*        _factory = nullptr;
+    SmartTable            _repl_mark_table_info = nullptr;
+    SmartRecord           _repl_mark_record;
+    std::string           _repl_mark_sql;
+    uint64_t              _repl_mark_sign = 0;
+    std::map<int64_t, uint64_t>  _partition_keys;
+    int                   _tso_count = 0;
     int64_t               _start_ts = -1;
     int64_t               _commit_ts = -1;
-    pb::PrewriteValue     _binlog_value;
-    SmartRecord           _partition_record;
-    pb::RegionInfo        _binlog_region;
-    SchemaFactory*        _factory = nullptr;
-    uint64_t              _partition_key = 0;
-    int64_t               _binlog_row_cnt = 0;
-    std::set<std::string> _db_tables;
-    std::set<uint64_t>    _signs;
+    // binlog_table_id-->Binlog
+    std::map<int64_t, BinlogInfo> _table_binlogs;
 };
 
 } // namespace baikaldb

--- a/include/session/network_socket.h
+++ b/include/session/network_socket.h
@@ -192,6 +192,7 @@ struct NetworkSocket {
     bool            autocommit = true;       // The autocommit flag set by SET AUTOCOMMIT=0/1
     uint64_t        txn_id = 0;              // ID of the current transaction, 0 means out-transaction query
     int             seq_id = 0;              // The query sequence id within a transaction, starting from 1
+    std::atomic<int64_t> txn_affected_rows {0}; // txn中所有sql的affected_rows累加，用来限制大事务
     uint64_t        server_instance_id = 0;  // The global unique instance id of the current BaikalDB process, 
                                              // fetched from BaikalMeta when a BaikalDB instance starts,
     std::set<int>   need_rollback_seq;       // The sequence id for the commands need rollback within the transaction

--- a/include/session/user_info.h
+++ b/include/session/user_info.h
@@ -62,31 +62,37 @@ public:
         }
     }
 
-    bool allow_write(int64_t db, int64_t tbl) {
+    bool allow_write(int64_t db, int64_t tbl, const std::string& tbl_name) {
         if (database.count(db) == 1 && database[db] == pb::WRITE) {
             return true;
         }
         if (table.count(tbl) == 1 && table[tbl] == pb::WRITE) {
             return true;
         }
+        if (table_name.count(tbl_name) == 1 && table_name[tbl_name] == pb::WRITE) {
+            return true;
+        }
         return false;
     }
 
-    bool allow_read(int64_t db, int64_t tbl) {
+    bool allow_read(int64_t db, int64_t tbl, const std::string& tbl_name) {
         if (database.count(db) == 1) {
             return true;
         }
         if (table.count(tbl) == 1) {
             return true;
         }
+        if (table_name.count(tbl_name) == 1) {
+            return true;
+        }
         return false;
     }
 
-    bool allow_op(pb::OpType op_type, int64_t db, int64_t tbl) {
+    bool allow_op(pb::OpType op_type, int64_t db, int64_t tbl, const std::string& table_name) {
         if (op_type == pb::OP_SELECT) {
-            return allow_read(db, tbl);
+            return allow_read(db, tbl, table_name);
         } else {
-            return allow_write(db, tbl);
+            return allow_write(db, tbl, table_name);
         }
     }
 
@@ -136,6 +142,7 @@ public:
     std::atomic<uint32_t>    query_count;
     std::map<int64_t, pb::RW> database;
     std::map<int64_t, pb::RW> table;
+    std::map<std::string, pb::RW> table_name;
     // show databases使用
     std::set<int64_t> all_database;
     std::unordered_set<std::string> auth_ip_set;

--- a/include/store/rpc_sender.h
+++ b/include/store/rpc_sender.h
@@ -40,7 +40,10 @@ public:
                                     pb::BatchStoreRes& response,
                                     const std::string& instance,
                                     butil::IOBuf* attachment_data);
-    static int get_leader_read_index(const std::string& leader, int64_t region_id, pb::StoreRes& response);
+    static int get_leader_read_index(const std::string& leader, 
+                                int64_t region_id, 
+                                pb::StoreRes& response, 
+                                bool need_raft_log_index);
     static void send_remove_region_method(int64_t drop_region_id, const std::string& instance);
     static int send_init_region_method(const std::string& instance_address, 
                 const pb::InitRegion& init_region_request, 

--- a/include/store/store.h
+++ b/include/store/store.h
@@ -319,7 +319,8 @@ private:
              dml_time_cost("dml_time_cost", 60),
              select_time_cost("select_time_cost", 60),
              peer_delay_latency("peer_delay_latency", 60),
-             heart_beat_count("heart_beat_count") {
+             heart_beat_count("heart_beat_count"),
+             follow_read_wait_time("follow_read_wait_time", 60) {
         bthread_mutex_init(&_param_mutex, NULL);
     }
 
@@ -462,6 +463,7 @@ public:
     bvar::LatencyRecorder select_time_cost;
     bvar::LatencyRecorder peer_delay_latency;
     bvar::Adder<int64_t>  heart_beat_count;
+    bvar::LatencyRecorder follow_read_wait_time;
 
     //for fake binlog tso
     TimeCost gen_tso_time;

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -107,6 +107,7 @@ message SchemaConf {
     optional string sign_forceindex         = 12;
     optional int32 tail_split_num           = 13; // 尾分裂新region数
     optional int32 tail_split_step          = 14;
+    optional int64 auto_inc_rand_max        = 15; //meta挂掉后降级到随机id
 };
 
 enum Engine {

--- a/proto/meta.interface.proto
+++ b/proto/meta.interface.proto
@@ -85,8 +85,17 @@ message SplitKey {
 
 message BinlogInfo {
     repeated int64 target_table_ids = 1;
-    optional int64 binlog_table_id = 2;
+    optional int64 binlog_table_id = 2; // binlog表自己不设置
+    optional FieldInfo link_field  = 3;
+    optional bool partition_is_same_hint = 4; // 普通表和binlog表分区方式不一样的hit
 };
+/*
+    普通表    binlog表
+    不分区     不分区    binlog分发无需处理分区
+    分区       不分区    binlog分发无需处理分区
+    不分区      分区     binlog分发必须处理分区
+    分区        分区     binlog分发在分区方式一样时可以简化处理，默认分区认为一样，通过partition_is_same_hint显示指定 
+*/
 
 enum PartitionType {
     PT_HASH = 1;
@@ -155,7 +164,7 @@ message SchemaInfo {
     repeated SplitKey split_keys            = 36;
     optional SchemaConf schema_conf         = 37; //一些可以随意修改的配置放在这里
     optional int64 ttl_duration             = 38; //0表示无ttl，>0表示有ttl，建表时指定
-    optional BinlogInfo    binlog_info      = 39;
+    optional BinlogInfo    binlog_info      = 39; // 主binlog信息，订阅以此为准
     optional PartitionInfo partition_info   = 40;
     optional bool is_binlog                 = 41;
     optional FieldInfo link_field           = 42;
@@ -164,6 +173,8 @@ message SchemaInfo {
     optional int64 online_ttl_expire_time_us = 45; 
     optional string comment                 = 46;
     optional bool  if_exist                 = 47;
+    optional bool partition_is_same_hint    = 48;
+    repeated BinlogInfo    binlog_infos     = 49;
 };
 
 message PartitionRegion {
@@ -536,6 +547,11 @@ enum PeerStatus {
     STATUS_INITED             = 8;
 };
 
+message BinlogPeerState {
+    required int64   region_id = 1;
+    optional uint32  oldest_timestamp_to_now_interval = 2;
+};
+
 message PeerStateInfo {
     optional string      peer_id     = 1;
     optional PeerStatus  peer_status = 2;
@@ -601,6 +617,7 @@ message StoreHeartBeatRequest {
     optional bool need_peer_balance             = 6;
     repeated DdlWorkInfoHeartBeat ddlwork_infos = 7;
     repeated LearnerHeartBeat learner_regions   = 8;
+    repeated BinlogPeerState binlog_ts_infos    = 9;
 };
 
 message StoreHeartBeatResponse {
@@ -721,6 +738,7 @@ enum QueryOpType {
     QUERY_SHOW_VIRINDX_INFO_SQL                   = 309;//展示虚拟索引的影响   
     QUERY_REGION_LEARNER_STATUS                   = 310;
     QUERY_FAST_IMPORTER_TABLES                    = 311;
+    QUERY_BINLOG_TIMESTAMPS                       = 312;
 };
 
 message PhysicalInstance {
@@ -759,6 +777,13 @@ message VirtualInfoAndSqls{
     optional string   affected_sign      =2;
     optional string   affected_sqls      =3;
 }
+
+message BinlogRegionInfo {
+    required int64    region_id          =1;
+    repeated string   peer_id            =2;
+    repeated uint32   oldest_ts_to_now   =3;
+}
+
 message QueryResponse {
     required ErrCode            errcode             = 1;
     optional string             errmsg              = 2;
@@ -785,6 +810,7 @@ message QueryResponse {
     repeated RegionDdlWork      region_ddl_infos    = 23;
     repeated ResourceTagInfo    resource_tag_infos  = 24;
     repeated VirtualInfoAndSqls virtual_index_influence_info = 25;
+    repeated BinlogRegionInfo   binlog_region_state = 26;
 };
 
 message DdlPeerInfo {

--- a/proto/plan.proto
+++ b/proto/plan.proto
@@ -89,6 +89,7 @@ message PossibleIndex {
         optional bytes right_key = 12;
         optional bool  left_full = 13;
         optional bool  right_full = 14;
+        optional int32 partition_id = 15;
     };
 
     message SortIndex {

--- a/proto/store.interface.proto
+++ b/proto/store.interface.proto
@@ -240,6 +240,7 @@ message InitRegion {
 message GetAppliedIndex {
     required int64 region_id    = 1;
     optional bool  use_read_idx = 2;
+    optional bool  use_raft_log_index = 3;
 };
 
 message RemoveRegion {

--- a/proto/test_decode.proto
+++ b/proto/test_decode.proto
@@ -28,3 +28,16 @@ message TestTupleRecord {
 	optional bool col13 = 13;
 	optional bytes col14 = 14;
 }
+
+message Pg {
+    repeated int32 a = 1;
+	optional int32 b = 2;
+};
+
+message Packed {
+  repeated Pg a = 1;
+}
+
+message Optional {
+  optional Pg a = 1;
+}

--- a/src/common/common.cpp
+++ b/src/common/common.cpp
@@ -68,6 +68,8 @@ DEFINE_bool(disambiguate_select_name, false, "whether use the first when select 
 DEFINE_int32(new_sign_read_concurrency, 10, "new_sign_read concurrency, default:20");
 DEFINE_bool(open_new_sign_read_concurrency, false, "open new_sign_read concurrency, default: false");
 DEFINE_bool(need_verify_ddl_permission, false, "default true");
+DEFINE_bool(use_cond_decrease_signal, false, "default false");
+
 
 int64_t timestamp_diff(timeval _start, timeval _end) {
     return (_end.tv_sec - _start.tv_sec) * 1000000 

--- a/src/common/datetime.cpp
+++ b/src/common/datetime.cpp
@@ -18,19 +18,23 @@
 #include "expr_value.h"
 
 namespace baikaldb {
-std::string timestamp_to_str(time_t timestamp) {
+std::string timestamp_to_str(time_t timestamp, bool is_utc) {
     // 内部存储采用了uint32，因此小于0的都不合法
     if (timestamp <= 0) {
         return "0000-00-00 00:00:00";
     }
-    char str_time[21] = {0};
     struct tm tm;
-    localtime_r(&timestamp, &tm);  
-    // 夏令时影响
-    if (tm.tm_isdst == 1) {
-        timestamp = timestamp - 3600;
-        localtime_r(&timestamp, &tm);
+    if (is_utc) {
+        gmtime_r(&timestamp, &tm);
+    } else {
+        localtime_r(&timestamp, &tm);  
+        // 夏令时影响
+        if (tm.tm_isdst == 1) {
+            timestamp = timestamp - 3600;
+            localtime_r(&timestamp, &tm);
+        }
     }
+    char str_time[21] = {0};
     strftime(str_time, sizeof(str_time), "%Y-%m-%d %H:%M:%S", &tm);
     return std::string(str_time);
 }

--- a/src/common/hll_common.cpp
+++ b/src/common/hll_common.cpp
@@ -629,7 +629,7 @@ uint64_t hll_estimate(const ExprValue& hll) {
 
 int hll_merge_agg(std::string& hll1, std::string& hll2) {
     if (!is_hll_object(hll1) || !is_hll_object(hll2)) {
-        DB_WARNING("waong hll object");
+        DB_WARNING("wrong hll object");
         return -1;
     }
     struct hllhdr *hdr1 = (struct hllhdr *)hll1.data();
@@ -759,7 +759,7 @@ int hll_merge(uint8_t *max, std::string& hll) {
 
 int hll_merge(std::string& hll1, std::string& hll2) {
     if (!is_hll_object(hll1) || !is_hll_object(hll2)) {
-        DB_WARNING("waong hll object");
+        DB_WARNING("wrong hll object");
         return -1;
     }
     uint8_t max[HLL_REGISTERS];

--- a/src/common/schema_factory.cpp
+++ b/src/common/schema_factory.cpp
@@ -370,18 +370,6 @@ int SchemaFactory::update_table_internal(SchemaMapping& background, const pb::Sc
                 DB_DEBUG("sign_str: %s", sign_str.c_str());
             }
         }
-        if (tbl_info.schema_conf.has_sign_forceindex() && tbl_info.schema_conf.sign_forceindex() != "") {
-            DB_DEBUG("sign_forceindex: %s",
-                    tbl_info.schema_conf.sign_forceindex().c_str());
-            std::vector<std::string> vec;
-            boost::split(vec,
-                    tbl_info.schema_conf.sign_forceindex(),
-                    boost::is_any_of(","));
-            for (auto& sign_str : vec) {
-                tbl_info.sign_forceindex.emplace(sign_str);
-                DB_DEBUG("sign_str: %s", sign_str.c_str());
-            }
-        }
         if (tbl_info.schema_conf.auto_inc_rand_max() > 0) {
             tbl_info.auto_inc_rand_max = tbl_info.schema_conf.auto_inc_rand_max();
         }

--- a/src/engine/qos.cpp
+++ b/src/engine/qos.cpp
@@ -255,17 +255,17 @@ void SqlQos::return_tokens(const int64_t tokens, const bool is_committed_bucket,
     }
 }
 
-int SqlQos::increase_timed_wait(const int64_t reject_timeout) {
-    return _concurrency.increase_timed_wait(reject_timeout);
+int SqlQos::increase_timed_wait_with_max_wait_cnt(const int max_wait_cnt, const int64_t reject_timeout) {
+    return _concurrency.increase_timed_wait_with_max_wait_cnt(max_wait_cnt, reject_timeout);
 } 
 
-int SqlQos::increase_wait() {
-    _concurrency.increase_wait();
+int SqlQos::increase_wait_with_max_wait_cnt(const int max_wait_cnt) {
+    _concurrency.increase_wait_with_max_wait_cnt(max_wait_cnt);
     return 0;
 } 
 
-int SqlQos::decrease_signal() {
-    _concurrency.decrease_signal();
+int SqlQos::decrease_signal_with_wait_cnt() {
+    _concurrency.decrease_signal_with_wait_cnt();
     return 0;
 } 
 

--- a/src/engine/transaction.cpp
+++ b/src/engine/transaction.cpp
@@ -222,6 +222,17 @@ int Transaction::fits_region_range_for_global_index(IndexInfo& pk_index,
             index_info);
     return 0;
 }
+
+bool Transaction::fits_region_range_for_primary(IndexInfo& pk_index,
+        MutTableKey& pk_key) {
+    return fits_region_range(rocksdb::Slice(pk_key.data()), 
+            rocksdb::Slice(""), 
+            &_region_info->start_key(), 
+            &_region_info->end_key(), 
+            pk_index, 
+            pk_index);
+}
+
 int Transaction::fits_region_range_for_primary(IndexInfo& pk_index,
         SmartRecord record,
         bool& result) {

--- a/src/exec/agg_node.cpp
+++ b/src/exec/agg_node.cpp
@@ -216,8 +216,9 @@ void AggNode::process_row_batch(RuntimeState* state, RowBatch& batch, int64_t& u
                     continue;
                 }
             }
-            used_size += cur_row->used_size();
             AggFnCall::initialize_all(_agg_fn_calls, key.data(), *agg_row, used_size, false);
+            used_size += cur_row->used_size();
+            used_size += key.size();
             // 可能会rehash
             _hash_map.insert(key.data(), *agg_row);
         } else {

--- a/src/exec/dml_node.cpp
+++ b/src/exec/dml_node.cpp
@@ -243,6 +243,10 @@ int DMLNode::insert_row(RuntimeState* state, SmartRecord record, bool is_update)
             old_record = record->clone(true);
         }
         if (FLAGS_replace_no_get && _is_replace && _all_indexes.size() == 1) {
+            if (!_txn->fits_region_range_for_primary(*_pri_info, pk_key)) {
+                // DB_DEBUG("replace_no_get fail to fit: %s", rocksdb::Slice(pk_key.data()).ToString(true).c_str());
+                return 0;
+            }
             ret = -2;
         } else {
             ret = _txn->get_update_primary(_region_id, *_pri_info, old_record, _field_ids, GET_LOCK, true);

--- a/src/exec/exec_node.cpp
+++ b/src/exec/exec_node.cpp
@@ -40,6 +40,7 @@
 #include "runtime_state.h"
 
 namespace baikaldb {
+
 int ExecNode::init(const pb::PlanNode& node) {
     _pb_node = node;
     _limit = node.limit();
@@ -381,10 +382,7 @@ int ExecNode::push_cmd_to_cache(RuntimeState* state,
     }
     auto client = state->client_conn();
     // cache dml cmd in baikaldb before sending to store
-    if (op_type != pb::OP_INSERT
-            && op_type != pb::OP_DELETE
-            && op_type != pb::OP_UPDATE
-            && op_type != pb::OP_BEGIN) {
+    if (!is_dml_op_type(op_type) && op_type != pb::OP_BEGIN) {
         return 0;
     }
     if (client->cache_plans.count(seq_id)) {

--- a/src/exec/index_ddl_manager_node.cpp
+++ b/src/exec/index_ddl_manager_node.cpp
@@ -84,6 +84,10 @@ int IndexDDLManagerNode::open(RuntimeState* state) {
             _fetcher_store.region_batch.erase(iter);
             continue;
         }
+        if (!_is_global_index && !max_pk_str.empty()) {
+            DB_WARNING("split only return first region, task_%s", _task_id.c_str());
+            break;
+        }
         auto& ttl_batch = _fetcher_store.region_id_ttl_timestamp_batch[pair.second];
         if (global_ddl_with_ttl && batch->size() != ttl_batch.size()) {
             DB_FATAL("region_id: %ld, batch size diff with ttl size %ld vs %ld", pair.second, batch->size(), ttl_batch.size());

--- a/src/exec/load_node.cpp
+++ b/src/exec/load_node.cpp
@@ -330,9 +330,10 @@ int LoadNode::handle_lines(RuntimeState* state, std::vector<std::string>& row_li
     records.reserve(row_lines.size());
     for (auto& line : row_lines) {
         std::vector<std::string> split_vec;
+        /*
         if (ends_with(line, _terminated)) {
             line.erase(line.length() - _terminated.length(), line.length());
-        }
+        }*/
         boost::split(split_vec, line, boost::is_any_of(_terminated));
         if (split_vec.size() != _field_ids.size() + _ingore_field_indexes.size()) {
             DB_FATAL("size diffrent %lu %lu", split_vec.size(), _field_ids.size() + _ingore_field_indexes.size());

--- a/src/expr/fn_manager.cpp
+++ b/src/expr/fn_manager.cpp
@@ -67,7 +67,7 @@ bool FunctionManager::swap_op(pb::Function& fn) {
 void FunctionManager::register_operators() {
     // ~ ! -1 -1.1
     register_object("bit_not_uint", bit_not_uint);
-    register_object("logic_not_bool", logic_not_bool);
+    //register_object("logic_not_bool", logic_not_bool);
     register_object("minus_int", minus_int);
     register_object("minus_uint", minus_uint);
     register_object("minus_double", minus_double);
@@ -92,8 +92,8 @@ void FunctionManager::register_operators() {
     REGISTER_SWAP_PREDICATE_ALL_TYPES(lt, gt);
     REGISTER_SWAP_PREDICATE_ALL_TYPES(le, ge);
     // && ||
-    REGISTER_BINARY_OP(logic_and, bool);
-    REGISTER_BINARY_OP(logic_or, bool);
+    //REGISTER_BINARY_OP(logic_and, bool);
+    //REGISTER_BINARY_OP(logic_or, bool);
     auto register_object_ret = [this](const std::string& name, 
             std::function<ExprValue(const std::vector<ExprValue>&)> T, 
             pb::PrimitiveType ret_type) {

--- a/src/expr/operators.cpp
+++ b/src/expr/operators.cpp
@@ -102,8 +102,8 @@ BINARY_OP_PREDICATE_ALL_TYPES_FN(ge, >=);
 BINARY_OP_PREDICATE_ALL_TYPES_FN(lt, <);
 BINARY_OP_PREDICATE_ALL_TYPES_FN(le, <=);
 // && || ; not used, see predicate.h
-BINARY_OP_PREDICATE_FN(logic_and, bool, _u.bool_val, &&);
-BINARY_OP_PREDICATE_FN(logic_or, bool, _u.bool_val, ||);
+//BINARY_OP_PREDICATE_FN(logic_and, bool, _u.bool_val, &&);
+//BINARY_OP_PREDICATE_FN(logic_or, bool, _u.bool_val, ||);
 }
 
 /* vim: set ts=4 sw=4 sts=4 tw=100 */

--- a/src/logical_plan/ddl_planner.cpp
+++ b/src/logical_plan/ddl_planner.cpp
@@ -828,6 +828,10 @@ int DDLPlanner::parse_create_table(pb::SchemaInfo& table) {
                     }
                     get_expr_field_name(expr);
                 }
+                if (p_option->partition_num <= 1) {
+                    DB_WARNING("partition_num need > 1");
+                    return -1;
+                }
                 table.set_partition_num(p_option->partition_num);
             }
             if (expr_field_names.size() != 1) {

--- a/src/logical_plan/ddl_work_planner.cpp
+++ b/src/logical_plan/ddl_work_planner.cpp
@@ -202,7 +202,7 @@ std::unique_ptr<ScanNode> DDLWorkPlanner::create_scan_node() {
         range_index->set_left_key(_start_key);
         range_index->set_left_full(_ddl_pk_key_is_full);
         range_index->set_left_field_cnt(_field_num);
-        range_index->set_left_open(false);
+        range_index->set_left_open(true);
     }
     // 暂时用不上
     // if (_end_key != "") {

--- a/src/logical_plan/kill_planner.cpp
+++ b/src/logical_plan/kill_planner.cpp
@@ -46,12 +46,10 @@ int KillPlanner::plan() {
             DB_WARNING("conn_id equal %ld is_query:%d", k->conn_id, k->is_query);
             _ctx->kill_ctx = sock->query_ctx;
             _ctx->kill_ctx->kill_all_ctx();
-            // kill xxx 复用client_free,会导致被kill的sock的DataBuffer被继续占用，导致下一次建立连接失败
-            // 但是kill指令用的很少，后续再考虑优化
-            // kill query xx没问题
             if (!k->is_query) {
-//                client->state = STATE_ERROR;
-                StateMachine::get_instance()->client_free(sock, epoll_info);
+                sock->state = STATE_ERROR;
+                //client_free 会core
+//                StateMachine::get_instance()->client_free(sock, epoll_info);
             }
             break;
         }

--- a/src/logical_plan/logical_planner.cpp
+++ b/src/logical_plan/logical_planner.cpp
@@ -791,7 +791,7 @@ int LogicalPlanner::add_table(const std::string& database, const std::string& ta
         if (_ctx->stmt_type == parser::NT_SELECT) {
             op_type = pb::OP_SELECT;
         }
-        if (!_ctx->user_info->allow_op(op_type, db.id, tbl.id)) {
+        if (!_ctx->user_info->allow_op(op_type, db.id, tbl.id, table)) {
             DB_WARNING("user %s has no permission to access: %s.%s, db.id:%ld, tbl.id:%ld", 
                 _username.c_str(), database.c_str(), table.c_str(), db.id, tbl.id);
             _ctx->stat_info.error_code = ER_TABLEACCESS_DENIED_ERROR;

--- a/src/logical_plan/update_planner.cpp
+++ b/src/logical_plan/update_planner.cpp
@@ -193,6 +193,13 @@ int UpdatePlanner::parse_kv_list() {
                 node->set_col_type(pb::STRING);
                 node->mutable_derive_node()->set_string_val(ExprValue::Now().get_string());
             }
+        } else if (value_expr.nodes(0).node_type() == pb::NULL_LITERAL
+            && !field_info->can_null) {
+            auto node = value_expr.mutable_nodes(0);
+            node->set_num_children(0);
+            node->set_node_type(pb::STRING_LITERAL);
+            node->set_col_type(pb::STRING);
+            node->mutable_derive_node()->set_string_val(field_info->default_value);
         }
         _update_values.push_back(value_expr);
     }

--- a/src/meta_server/meta_server.cpp
+++ b/src/meta_server/meta_server.cpp
@@ -510,6 +510,17 @@ void MetaServer::query(google::protobuf::RpcController* controller,
         ClusterManager::get_instance()->get_switch(request, response);
         break;
     }
+    case pb::QUERY_BINLOG_TIMESTAMPS: {
+        if (!_meta_state_machine->is_leader()) {
+            response->set_errcode(pb::NOT_LEADER);
+            response->set_errmsg("not leader");
+            response->set_leader(butil::endpoint2str(_meta_state_machine->get_leader()).c_str());
+            DB_WARNING("meta state machine is not leader, request: %s", request->ShortDebugString().c_str());
+            return;
+        }
+        QueryRegionManager::get_instance()->get_binlog_timestamps(request, response);
+        break;
+    }
     case pb::QUERY_SHOW_VIRINDX_INFO_SQL: {
         QueryTableManager::get_instance()->get_virtual_index_influence_info(request, response);
         break;   

--- a/src/meta_server/meta_state_machine.cpp
+++ b/src/meta_server/meta_state_machine.cpp
@@ -690,6 +690,7 @@ void MetaStateMachine::on_leader_stop() {
     }
     RegionManager::get_instance()->clear_region_peer_state_map();
     RegionManager::get_instance()->clear_region_learner_peer_state_map();
+    RegionManager::get_instance()->clear_binlog_region_state_map();
     DB_WARNING("leader stop");
     CommonStateMachine::on_leader_stop();
     DBManager::get_instance()->clear_all_tasks();

--- a/src/meta_server/tso_state_machine.cpp
+++ b/src/meta_server/tso_state_machine.cpp
@@ -106,6 +106,8 @@ void TSOStateMachine::gen_tso(const pb::TsoRequest* request, pb::TsoResponse* re
                     _tso_obj.current_timestamp.set_logical(new_logical);
                     need_retry = false;
                 } else {
+                    // TODO 需要等50ms，physical是精确到1ms，这样会浪费50倍的buffer
+                    // 可以选择physical增加1ms来利用，需要限制到上次update的50ms内
                     DB_WARNING("logical part outside of max logical interval, retry later, please check ntp time");
                     need_retry = true;
                 }

--- a/src/physical_plan/auto_inc.cpp
+++ b/src/physical_plan/auto_inc.cpp
@@ -22,8 +22,7 @@
 #include "meta_server_interact.hpp"
 
 namespace baikaldb {
-DEFINE_bool(meta_tso_autoinc_degrade, false, "meta_tso_autoinc_degrade");
-BRPC_VALIDATE_GFLAG(meta_tso_autoinc_degrade, brpc::PassValidate);
+DECLARE_bool(meta_tso_autoinc_degrade);
 
 bool AutoInc::need_degrade = false;
 TimeCost AutoInc::last_degrade_time;

--- a/src/physical_plan/limit_calc.cpp
+++ b/src/physical_plan/limit_calc.cpp
@@ -33,8 +33,7 @@ void LimitCalc::_analyze_limit(QueryContext* ctx, ExecNode* node, int64_t limit)
     node->set_limit(limit);
     switch (node->node_type()) {
         case pb::TABLE_FILTER_NODE:
-        case pb::WHERE_FILTER_NODE:
-        case pb::HAVING_FILTER_NODE: {
+        case pb::WHERE_FILTER_NODE: {
             // 空filter可以下推
             if (static_cast<FilterNode*>(node)->pruned_conjuncts().empty()) {
                 break;
@@ -42,6 +41,7 @@ void LimitCalc::_analyze_limit(QueryContext* ctx, ExecNode* node, int64_t limit)
                 return;
             }
         }
+        case pb::HAVING_FILTER_NODE: 
         case pb::SORT_NODE:
         case pb::MERGE_AGG_NODE:
         case pb::AGG_NODE:

--- a/src/protocol/handle_helper.cpp
+++ b/src/protocol/handle_helper.cpp
@@ -1284,6 +1284,14 @@ bool HandleHelper::_handle_binlog(const SmartSocket& client, const std::vector<s
     if (split_vec.size() > 6) {
         table_info->mutable_link_field()->set_field_name(split_vec[6]);
     }
+    if (split_vec.size() > 7) {
+        if (split_vec[7] != "true" && split_vec[7] != "false") {
+            DB_FATAL("partition_is_same_hint invalid");
+            client->state = STATE_ERROR;
+            return false;
+        }
+        table_info->set_partition_is_same_hint(split_vec[7] == "true" ? true : false);
+    }
     auto binlog_info = request.mutable_binlog_info();
     binlog_info->set_namespace_name(client->user_info->namespace_);
     binlog_info->set_database(binlog_table_db);
@@ -1439,6 +1447,9 @@ bool HandleHelper::_handle_schema_conf(const SmartSocket& client, const std::vec
     } else if (key == "tail_split_step") {
         int32_t tail_split_step = strtol(split_vec[4].c_str(), NULL, 10);
         schema_conf->set_tail_split_step(tail_split_step);
+    } else if (key == "auto_inc_rand_max") {
+        int64_t num = strtol(split_vec[4].c_str(), NULL, 10);
+        schema_conf->set_auto_inc_rand_max(num);
     } else if (key == "backup_table") {
         int32_t number = pb::BackupTable_descriptor()->FindValueByName(split_vec[4])->number();
         DB_WARNING("backup table enum %s => %d", split_vec[4].c_str(), number);

--- a/src/protocol/show_helper.cpp
+++ b/src/protocol/show_helper.cpp
@@ -3851,9 +3851,9 @@ bool ShowHelper::_show_meta_binlog(const SmartSocket& client, const std::vector<
         row.reserve(4);
         row.emplace_back(std::to_string(region_info.region_id()));
         for (auto i = 0; i < region_info.peer_id_size(); ++i) {
-            std::string peer_state_str = region_info.peer_id().at(i) + ": ";
+            std::string peer_state_str = region_info.peer_id(i) + ": ";
             if (i < region_info.oldest_ts_to_now_size()) {
-                peer_state_str += std::to_string(region_info.oldest_ts_to_now().at(i) / (3600.0 * 24)) + "day";
+                peer_state_str += std::to_string(region_info.oldest_ts_to_now(i) / (3600.0 * 24)) + "day";
             } else {
                 peer_state_str += "0";
             }

--- a/src/protocol/show_helper.cpp
+++ b/src/protocol/show_helper.cpp
@@ -102,6 +102,14 @@ void ShowHelper::init() {
             this, std::placeholders::_1, std::placeholders::_2);
     _calls[SQL_SHOW_ABNORMAL_SWITCH] = std::bind(&ShowHelper::_show_abnormal_switch,
             this, std::placeholders::_1, std::placeholders::_2);
+    _calls[SQL_SHOW_META_BINLOG] = std::bind(&ShowHelper::_show_meta_binlog,
+            this, std::placeholders::_1, std::placeholders::_2);
+    _calls[SQL_SHOW_FUNCTION_STATUS] = std::bind(&ShowHelper::_show_function_status,
+            this, std::placeholders::_1, std::placeholders::_2);
+    _calls[SQL_SHOW_PROCEDURE_STATUS] = std::bind(&ShowHelper::_show_procedure_status,
+            this, std::placeholders::_1, std::placeholders::_2);
+    _calls[SQL_SHOW_TRIGGERS] = std::bind(&ShowHelper::_show_triggers,
+            this, std::placeholders::_1, std::placeholders::_2);
     _wrapper = MysqlWrapper::get_instance();
 }
 
@@ -136,8 +144,15 @@ bool ShowHelper::execute(const SmartSocket& client) {
     }
     auto iter = _calls.find(key);
     if (iter == _calls.end() || iter->second == nullptr) {
-        _wrapper->make_simple_ok_packet(client);
-        client->state = STATE_READ_QUERY_RESULT;
+        // Make mysql packet.
+        std::vector<ResultField> fields;
+        std::vector< std::vector<std::string> > rows;
+        if (_make_common_resultset_packet(client, fields, rows) != 0) {
+            DB_FATAL_CLIENT(client, "Failed to make result packet.");
+            _wrapper->make_err_packet(client, ER_MAKE_RESULT_PACKET, "Failed to make result packet.");
+            client->state = STATE_ERROR;
+            return true;
+        }
         return true;
     }
     return iter->second(client, split_vec);
@@ -366,6 +381,316 @@ bool ShowHelper::_show_databases(const SmartSocket& client, const std::vector<st
     return true;
 }
 
+bool ShowHelper::_show_function_status(const SmartSocket& client, const std::vector<std::string>& split_vec) {
+    if (client == nullptr || !client->user_info) {
+        DB_FATAL("param invalid");
+        //client->state = STATE_ERROR;
+        return false;
+    }
+
+    // Make fields.
+    std::vector<ResultField> fields;
+    fields.reserve(1);
+    do {
+        ResultField field;
+        field.name = "Db";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Name";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Type";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Definer";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Modified";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Created";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Security_type";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Comment";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "path (VARCHAR(512))";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "character_set_client";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "collation_connection";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Database Collation";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+
+    // Make rows.
+    std::vector< std::vector<std::string> > rows;
+    // Make mysql packet.
+    if (_make_common_resultset_packet(client, fields, rows) != 0) {
+        DB_FATAL_CLIENT(client, "Failed to make result packet.");
+        _wrapper->make_err_packet(client, ER_MAKE_RESULT_PACKET, "Failed to make result packet.");
+        client->state = STATE_ERROR;
+        return false;
+    }
+    client->state = STATE_READ_QUERY_RESULT;
+    return true;
+}
+
+bool ShowHelper::_show_triggers(const SmartSocket& client, const std::vector<std::string>& split_vec) {
+    if (client == nullptr || !client->user_info) {
+        DB_FATAL("param invalid");
+        //client->state = STATE_ERROR;
+        return false;
+    }
+
+    // Make fields.
+    std::vector<ResultField> fields;
+    fields.reserve(1);
+    do {
+        ResultField field;
+        field.name = "Trigger";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Event";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Table";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Statement";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Timing";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Created";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "sql_mode";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Definer";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "character_set_client";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "collation_connection";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Database Collation";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+
+    // Make rows.
+    std::vector< std::vector<std::string> > rows;
+    // Make mysql packet.
+    if (_make_common_resultset_packet(client, fields, rows) != 0) {
+        DB_FATAL_CLIENT(client, "Failed to make result packet.");
+        _wrapper->make_err_packet(client, ER_MAKE_RESULT_PACKET, "Failed to make result packet.");
+        client->state = STATE_ERROR;
+        return false;
+    }
+    client->state = STATE_READ_QUERY_RESULT;
+    return true;
+}
+
+bool ShowHelper::_show_procedure_status(const SmartSocket& client, const std::vector<std::string>& split_vec) {
+    if (client == nullptr || !client->user_info) {
+        DB_FATAL("param invalid");
+        //client->state = STATE_ERROR;
+        return false;
+    }
+
+    // Make fields.
+    std::vector<ResultField> fields;
+    fields.reserve(1);
+    do {
+        ResultField field;
+        field.name = "Db";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Name";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Type";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Definer";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Modified";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Created";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Security_type";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Comment";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "character_set_client";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "collation_connection";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+    do {
+        ResultField field;
+        field.name = "Database Collation";
+        field.type = MYSQL_TYPE_VARCHAR;
+        field.length = 1024;
+        fields.emplace_back(field);
+    } while (0);
+
+    // Make rows.
+    std::vector< std::vector<std::string> > rows;
+    // Make mysql packet.
+    if (_make_common_resultset_packet(client, fields, rows) != 0) {
+        DB_FATAL_CLIENT(client, "Failed to make result packet.");
+        _wrapper->make_err_packet(client, ER_MAKE_RESULT_PACKET, "Failed to make result packet.");
+        client->state = STATE_ERROR;
+        return false;
+    }
+    client->state = STATE_READ_QUERY_RESULT;
+    return true;
+}
+
 bool ShowHelper::_show_tables(const SmartSocket& client, const std::vector<std::string>& split_vec) {
     SchemaFactory* factory = SchemaFactory::get_instance();
     if (client == nullptr || client->query_ctx == nullptr || client->user_info == nullptr || factory == nullptr) {
@@ -377,7 +702,7 @@ bool ShowHelper::_show_tables(const SmartSocket& client, const std::vector<std::
     std::string namespace_ = client->user_info->namespace_;
     std::string db = client->current_db;
     if (split_vec.size() == 4) {
-        db = split_vec[3];
+        db = remove_quote(split_vec[3].c_str(), '`');
     }
     if (db == "") {
         DB_WARNING("no database selected");
@@ -995,8 +1320,13 @@ bool ShowHelper::_show_full_tables(const SmartSocket& client, const std::vector<
         option.set_utf8(false);
         option.set_case_sensitive(false);
         regex_ptr.reset(new re2::RE2(like_pattern, option));
-
+    } else if (split_vec.size() > 7 && (split_vec[5] == "where")) {
+        // show full tables from `db` where table_type = 'BASE TABLE';
+        current_db = remove_quote(split_vec[4].c_str(), '`');
     } else {
+        for (int i = 0; i < split_vec.size();i++) {
+            DB_WARNING("vec[%d] %s", i, split_vec[i].c_str());
+        }
         client->state = STATE_ERROR;
         return false;
     }
@@ -1426,76 +1756,106 @@ bool ShowHelper::_show_table_status(const SmartSocket& client, const std::vector
         }
         assign_table = table;
     }
-
-    // 查看cache是否有效
-    {
-        BAIDU_SCOPED_LOCK(_mutex);
-        if (_table_info_cache_time.find(key) != _table_info_cache_time.end()
-            && butil::gettimeofday_us() - _table_info_cache_time[key] < FLAGS_show_table_status_cache_time) {
-            if (assign_table != "") {
-                // 指定了table，遍历找到table信息
-                for (auto& row : _table_info_cache[key]) {
-                    if (row.size() > 0 && row[0] == assign_table) {
-                        assign_rows.emplace_back(row);
-                        break;
+    if (db == "information_schema") {
+        std::vector<std::string> tables =  factory->get_table_list(
+                namespace_, db, client->user_info.get());
+        for (uint32_t cnt = 0; cnt < tables.size(); ++cnt) {
+            if (!assign_table.empty() && assign_table != tables[cnt]) {
+                continue;
+            }
+            // Make rows.
+            std::vector<std::string> row;
+            row.emplace_back(tables[cnt]);
+            row.emplace_back("Innodb");
+            row.emplace_back("1");
+            row.emplace_back("Compact");
+            row.emplace_back("1");
+            row.emplace_back("1");
+            row.emplace_back("0");
+            row.emplace_back("0");
+            row.emplace_back("0");
+            row.emplace_back("0");
+            row.emplace_back("0");
+            row.emplace_back("null");
+            row.emplace_back("");
+            row.emplace_back("");
+            row.emplace_back("utf8_general_ci");
+            row.emplace_back("");
+            row.emplace_back("");
+            row.emplace_back("");
+            rows.emplace_back(row);
+        }
+    } else {
+        // 查看cache是否有效
+        {
+            BAIDU_SCOPED_LOCK(_mutex);
+            if (_table_info_cache_time.find(key) != _table_info_cache_time.end()
+                && butil::gettimeofday_us() - _table_info_cache_time[key] < FLAGS_show_table_status_cache_time) {
+                if (assign_table != "") {
+                    // 指定了table，遍历找到table信息
+                    for (auto& row : _table_info_cache[key]) {
+                        if (row.size() > 0 && row[0] == assign_table) {
+                            assign_rows.emplace_back(row);
+                            break;
+                        }
                     }
                 }
+                if (_make_common_resultset_packet(client,
+                                                fields,
+                                                assign_table == "" ? _table_info_cache[key] : assign_rows) != 0) {
+                    DB_FATAL_CLIENT(client, "Failed to make result packet.");
+                    _wrapper->make_err_packet(client, ER_MAKE_RESULT_PACKET, "Failed to make result packet.");
+                    client->state = STATE_ERROR;
+                    return false;
+                }
+                client->state = STATE_READ_QUERY_RESULT;
+                return true;
             }
-            if (_make_common_resultset_packet(client,
-                                              fields,
-                                              assign_table == "" ? _table_info_cache[key] : assign_rows) != 0) {
-                DB_FATAL_CLIENT(client, "Failed to make result packet.");
-                _wrapper->make_err_packet(client, ER_MAKE_RESULT_PACKET, "Failed to make result packet.");
-                client->state = STATE_ERROR;
-                return false;
-            }
-            client->state = STATE_READ_QUERY_RESULT;
-            return true;
         }
-    }
 
-    pb::QueryRequest req;
-    req.set_op_type(pb::QUERY_TABLE_FLATTEN);
-    req.set_namespace_name(client->user_info->namespace_);
-    req.set_database(db);
-    pb::QueryResponse res;
-    // 这个请求meta会对table_mutex加锁并copy所有table元数据，比较重
-    MetaServerInteract::get_instance()->send_request("query", req, res);
-    for (auto& table_info : res.flatten_tables()) {
-        std::string create_time = "2018-08-09 15:01:40";
-        if (!table_info.create_time().empty()) {
-            create_time = table_info.create_time();
+        pb::QueryRequest req;
+        req.set_op_type(pb::QUERY_TABLE_FLATTEN);
+        req.set_namespace_name(client->user_info->namespace_);
+        req.set_database(db);
+        pb::QueryResponse res;
+        // 这个请求meta会对table_mutex加锁并copy所有table元数据，比较重
+        MetaServerInteract::get_instance()->send_request("query", req, res);
+        for (auto& table_info : res.flatten_tables()) {
+            std::string create_time = "2018-08-09 15:01:40";
+            if (!table_info.create_time().empty()) {
+                create_time = table_info.create_time();
+            }
+            // Make rows.
+            std::vector<std::string> row;
+            row.emplace_back(table_info.table_name());
+            row.emplace_back("Innodb");
+            row.emplace_back(std::to_string(table_info.version()));
+            row.emplace_back("Compact");
+            row.emplace_back(std::to_string(table_info.row_count()));
+            row.emplace_back(std::to_string(table_info.byte_size_per_record()));
+            row.emplace_back("0");
+            row.emplace_back("0");
+            row.emplace_back("0");
+            row.emplace_back("0");
+            row.emplace_back("0");
+            row.emplace_back(create_time);
+            row.emplace_back("");
+            row.emplace_back("");
+            row.emplace_back("utf8_general_ci");
+            row.emplace_back("");
+            row.emplace_back("");
+            row.emplace_back("");
+            rows.emplace_back(row);
+            if (assign_table != "" && table_info.table_name() == assign_table) {
+                assign_rows.emplace_back(row);
+            }
         }
-        // Make rows.
-        std::vector<std::string> row;
-        row.emplace_back(table_info.table_name());
-        row.emplace_back("Innodb");
-        row.emplace_back(std::to_string(table_info.version()));
-        row.emplace_back("Compact");
-        row.emplace_back(std::to_string(table_info.row_count()));
-        row.emplace_back(std::to_string(table_info.byte_size_per_record()));
-        row.emplace_back("0");
-        row.emplace_back("0");
-        row.emplace_back("0");
-        row.emplace_back("0");
-        row.emplace_back("0");
-        row.emplace_back(create_time);
-        row.emplace_back("");
-        row.emplace_back("");
-        row.emplace_back("utf8_general_ci");
-        row.emplace_back("");
-        row.emplace_back("");
-        row.emplace_back("");
-        rows.emplace_back(row);
-        if (assign_table != "" && table_info.table_name() == assign_table) {
-            assign_rows.emplace_back(row);
+        {
+            // 更新缓存
+            BAIDU_SCOPED_LOCK(_mutex);
+            _table_info_cache_time[key] = butil::gettimeofday_us();
+            _table_info_cache[key] = rows;
         }
-    }
-    {
-        // 更新缓存
-        BAIDU_SCOPED_LOCK(_mutex);
-        _table_info_cache_time[key] = butil::gettimeofday_us();
-        _table_info_cache[key] = rows;
     }
     // Make mysql packet.
     if (_make_common_resultset_packet(client,
@@ -1835,7 +2195,7 @@ bool ShowHelper::_show_all_tables(const SmartSocket& client, const std::vector<s
     std::vector<std::string> database_table;
     std::map<std::string, std::function<bool(const SmartTable&)>> type_func_map;
     type_func_map["binlog"] = [](const SmartTable& table) {
-        return table != nullptr && table->binlog_id > 0;
+        return table != nullptr && !table->binlog_ids.empty();
     };
     type_func_map["ttl"] = [](const SmartTable& table) {
         return table != nullptr && table->ttl_info.ttl_duration_s > 0;
@@ -3346,6 +3706,13 @@ bool ShowHelper::_show_index(const SmartSocket& client, const std::vector<std::s
                 index_info.fields[i].short_name, "A", "2", "NULL", "NULL", "", "BTREE", "", ""});
         }
     }
+    // Make mysql packet.
+    if (_make_common_resultset_packet(client, fields, rows) != 0) {
+        DB_FATAL_CLIENT(client, "Failed to make result packet.");
+        _wrapper->make_err_packet(client, ER_MAKE_RESULT_PACKET, "Failed to make result packet.");
+        client->state = STATE_ERROR;
+        return false;
+    }
     client->state = STATE_READ_QUERY_RESULT;
     return true;
 }
@@ -3432,6 +3799,104 @@ bool ShowHelper::_show_abnormal_switch(const SmartSocket& client, const std::vec
     client->state = STATE_READ_QUERY_RESULT;
     return true;
 }
+
+//  handle meta_binlog instance;
+//  handle meta_binlog db table;
+bool ShowHelper::_show_meta_binlog(const SmartSocket& client, const std::vector<std::string>& split_vec) {
+    SchemaFactory* factory = SchemaFactory::get_instance();
+    if (client == nullptr || client->query_ctx == nullptr || factory == nullptr) {
+        DB_FATAL("param invalid");
+        //client->state = STATE_ERROR;
+        return false;
+    }
+
+    std::string instance = "";
+    std::string db = "";
+    std::string table = "";
+    int64_t table_id = 0;
+    if (split_vec.size() == 3) {
+        instance = split_vec[2];
+    } else if (split_vec.size() == 4) {
+        db = split_vec[2];
+        table = split_vec[3];
+        
+        std::string namespace_ = client->user_info->namespace_;
+        if (db == "information_schema") {
+            namespace_ = "INTERNAL";
+        }
+        std::string full_name = namespace_ + "." + db + "." + table;
+        int64_t table_id = -1;
+        if (factory->get_table_id(full_name, table_id) != 0) {
+            client->state = STATE_ERROR;
+            return false;
+        }
+    } else {
+        client->state = STATE_ERROR;
+        return false;
+    }
+
+    pb::QueryRequest request;
+    pb::QueryResponse response;
+    
+    request.set_op_type(pb::QUERY_BINLOG_TIMESTAMPS);
+    request.set_table_id(table_id);
+    request.set_instance_address(instance);
+    MetaServerInteract::get_instance()->send_request("query", request, response);
+    DB_WARNING("req:%s res:%s", request.ShortDebugString().c_str(), response.ShortDebugString().c_str());
+    std::vector< std::vector<std::string> > rows;
+    rows.reserve(10);
+    size_t max_size = 0;
+    for (auto& region_info : response.binlog_region_state()) {
+        std::vector<std::string> row;
+        row.reserve(4);
+        row.emplace_back(std::to_string(region_info.region_id()));
+        for (auto i = 0; i < region_info.peer_id_size(); ++i) {
+            std::string peer_state_str = region_info.peer_id().at(i) + ": ";
+            if (i < region_info.oldest_ts_to_now_size()) {
+                peer_state_str += std::to_string(region_info.oldest_ts_to_now().at(i) / (3600.0 * 24)) + "day";
+            } else {
+                peer_state_str += "0";
+            }
+            row.emplace_back(peer_state_str);
+        }
+        if (max_size < row.size()) {
+            max_size = row.size();
+        }
+        rows.emplace_back(row);
+    }
+
+    for (auto& row : rows) {
+        if (row.size() < max_size) {
+            for (size_t i = 0; i < max_size - row.size(); i++) {
+                row.emplace_back("NULL");
+            }
+        }
+    }
+
+    std::vector<std::string> names = { "region_id" };
+    for (size_t i = 1; max_size > 1 && i <= max_size - 1; i++) {
+        names.emplace_back("peer" + std::to_string(i));
+    }
+
+    std::vector<ResultField> fields;
+    fields.reserve(4);
+    for (auto& name : names) {
+        ResultField field;
+        field.name = name;
+        field.type = MYSQL_TYPE_STRING;
+        fields.emplace_back(field);
+    }
+    // Make mysql packet.
+    if (_make_common_resultset_packet(client, fields, rows) != 0) {
+        DB_FATAL_CLIENT(client, "Failed to make result packet.");
+        _wrapper->make_err_packet(client, ER_MAKE_RESULT_PACKET, "Failed to make result packet.");
+        client->state = STATE_ERROR;
+        return false;
+    }
+    client->state = STATE_READ_QUERY_RESULT;
+    return true;
+}
+
 
 bool ShowHelper::_handle_client_query_template_dispatch(const SmartSocket& client, const std::vector<std::string>& split_vec) {
     if (boost::iequals(split_vec[1], "meta")) {

--- a/src/protocol/state_machine.cpp
+++ b/src/protocol/state_machine.cpp
@@ -1649,13 +1649,6 @@ bool StateMachine::_handle_client_query_common_query(SmartSocket client) {
     client->query_ctx->stat_info.sql_length = client->query_ctx->sql.size();
     client->query_ctx->charset = client->charset_name;
 
-    if (SchemaFactory::get_instance()->is_big_sql(client->query_ctx->sql)) {
-        _wrapper->make_err_packet(client,
-            ER_SQL_TOO_BIG, "%s",
-            "sql too big");
-        return false;
-    }
-
     // sql planner.
     TimeCost cost;
     TimeCost cost1;
@@ -1815,9 +1808,6 @@ bool StateMachine::_handle_client_query_common_query(SmartSocket client) {
         client->query_ctx->stat_info.send_buf_size += client->send_buf->_size;
     }
     if (ret < 0) {
-        if (client->query_ctx->stat_info.error_code == ER_SQL_TOO_BIG) {
-            SchemaFactory::get_instance()->update_big_sql(client->query_ctx->sql);
-        }
         DB_WARNING_CLIENT(client, "Failed to PhysicalPlanner::execute: %s",
             client->query_ctx->sql.c_str());
         if (client->query_ctx->stat_info.error_code == ER_ERROR_FIRST) {

--- a/src/runtime/sorter.cpp
+++ b/src/runtime/sorter.cpp
@@ -71,7 +71,7 @@ void Sorter::merge_sort() {
     }
 }
 void Sorter::make_heap() {
-    for (int i = _min_heap.size() / 2 - 1; i >= 0; i--) {
+    for (int i = static_cast<int>(_min_heap.size()) / 2 - 1; i >= 0; i--) {
         shiftdown(i);
     }
 }

--- a/src/session/binlog_context.cpp
+++ b/src/session/binlog_context.cpp
@@ -13,17 +13,85 @@
 // limitations under the License.
 
 #include "binlog_context.h"
+#include "fetcher_store.h"
 #include "meta_server_interact.hpp"
+#ifdef BAIDU_INTERNAL
+#include <baidu/rpc/channel.h>
+#include <baidu/rpc/selective_channel.h>
+#else
+#include <brpc/channel.h>
+#include <brpc/selective_channel.h>
+#endif
 
 namespace baikaldb {
+DECLARE_bool(meta_tso_autoinc_degrade);
+DECLARE_int64(print_time_us);
+DECLARE_int64(retry_interval_us);
+DECLARE_int32(fetcher_connect_timeout);
+DECLARE_int32(fetcher_request_timeout);
+DEFINE_int64(binlog_alarm_time_s, 30, "alarm, > binlog_alarm_time_s from prewrite to commit");
+int TsoFetcher::init() {
+    int ret = RepeatedTimerTask::init(tso::update_timestamp_interval_ms);
+    if (ret != 0) {
+        return ret;
+    }
+    start();
+    return 0;
+}
 
-int64_t TsoFetcher::get_tso() {
+void TsoFetcher::run() {
+    int64_t now = tso::clock_realtime_ms();
+    int64_t prev_physical = 0;
+    int64_t prev_logical = 0;
+    {
+        BAIDU_SCOPED_LOCK(_tso_mutex);
+        prev_physical = _tso_obj.physical();
+        prev_logical  = _tso_obj.logical();
+    }
+    int64_t delta = now - prev_physical;
+    if (delta < 0) {
+        DB_WARNING("physical time slow now:%ld prev:%ld", now, prev_physical);
+    }
+    int64_t next = now;
+    if (delta > tso::update_timestamp_guard_ms) {
+        next = now;
+    } else if (prev_logical > tso::max_logical / 2) {
+        next = now + tso::update_timestamp_guard_ms;
+    } else {
+        DB_WARNING("don't need update timestamp prev:%ld now:%ld ", prev_physical, now);
+        return;
+    }
+    {
+        BAIDU_SCOPED_LOCK(_tso_mutex);
+        _tso_obj.set_physical(next);
+        _tso_obj.set_logical(0);
+    }
+}
+
+int64_t TsoFetcher::get_tso(int64_t count) {
+    if (FLAGS_meta_tso_autoinc_degrade && _need_degrade) {
+        //max_logical前8字节用作区分不同db
+        //后10字节用作分配使用
+        uint64_t mast_id = _instance_id & 0xFF;
+        BAIDU_SCOPED_LOCK(_tso_mutex);
+        _tso_obj.set_logical(_tso_obj.logical() + count);
+        //超过1<<10就使用下一个ms
+        //降级情况单db总共能支持(1000*1024/2)=50w/s的写事务
+        if (_tso_obj.logical() & 0x3FF >= 1 << 10) {
+            _tso_obj.set_physical(_tso_obj.physical() + 1);
+            _tso_obj.set_logical(mast_id << 10 + count);
+        }
+        DB_WARNING("meta_tso_autoinc_degrade, local tso, physical:%ld, logical:%ld, count:%ld", 
+                _tso_obj.physical(), _tso_obj.logical(), count);
+        return (_tso_obj.physical() << tso::logical_bits) + _tso_obj.logical() - count;
+    }
     pb::TsoRequest request;
     request.set_op_type(pb::OP_GEN_TSO);
-    request.set_count(1);
+    request.set_count(count);
     pb::TsoResponse response;
     int retry_time = 0;
     int ret = 0;
+    tso_count << 1;
     for (;;) {
         retry_time++;
         ret = MetaServerInteract::get_tso_instance()->send_request("tso_service", request, response);
@@ -33,6 +101,7 @@ int64_t TsoFetcher::get_tso() {
                 continue;  
             } else {
                 DB_FATAL("get tso failed, response:%s", response.ShortDebugString().c_str());
+                tso_error << 1;
                 return ret;
             }
         }
@@ -45,32 +114,541 @@ int64_t TsoFetcher::get_tso() {
     return timestamp;
 }
 
-int BinlogContext::get_binlog_regions(uint64_t log_id) {
-    if (_table_info == nullptr || _partition_record == nullptr) {
-        DB_WARNING("wrong state log_id:%lu", log_id);
-        return -1;
+SmartPartitionBinlog BinlogContext::get_partition_binlog_ptr(int64_t binlog_id,
+                                                            BinlogInfo& binlog_info,
+                                                            int64_t partition_id) {
+    auto part_iter = binlog_info.binlog_by_partition.find(partition_id);
+    if (part_iter != binlog_info.binlog_by_partition.end()) {
+        return part_iter->second;
+    } else {
+        SmartPartitionBinlog partition_binlog_ptr = std::make_shared<PartitionBinlog>();
+        int ret = _factory->get_binlog_region_by_partition_id(binlog_id, partition_id, partition_binlog_ptr->binlog_region);
+        if (ret < 0) {
+            DB_WARNING("get binlog region failed binlog_id:%lu",  binlog_id);
+            return nullptr;
+        }
+        if (_repl_mark_record != nullptr) {
+            partition_binlog_ptr->db_tables.insert(_repl_mark_table_info->name);
+            pb::TableMutation* mutation = partition_binlog_ptr->binlog_value.add_mutations();
+            mutation->add_sequence(pb::MutationType::INSERT);
+            mutation->set_table_id(_repl_mark_table_info->id);
+            mutation->set_sql(_repl_mark_sql);
+            mutation->set_sign(_repl_mark_sign);
+            std::string row;
+            _repl_mark_record->encode(row);
+            mutation->add_insert_rows(std::move(row));
+        }
+        _tso_count++;
+        partition_binlog_ptr->partition_id = partition_id;
+        binlog_info.binlog_by_partition[partition_id] = partition_binlog_ptr;
+        return partition_binlog_ptr;
     }
-    if (!_table_info->is_linked) {
-        DB_WARNING("table %ld not link to binlog table log_id:%lu", _table_info->id, log_id);
-        return -1;      
+}
+
+void BinlogContext::add_mutation(SmartPartitionBinlog& binlog_ptr,
+                    int64_t table_id,
+                    const std::string& sql,
+                    const uint64_t sign,
+                    pb::MutationType type,
+                    int64_t partition_id,
+                    bool all_in_one,
+                    const std::map<int64_t, std::vector<std::string>>& retrun_records,
+                    const std::map<int64_t, std::vector<std::string>>& retrun_old_records) {
+    pb::TableMutation* mutation = binlog_ptr->binlog_value.add_mutations();
+    mutation->add_sequence(type);
+    mutation->set_table_id(table_id);
+    mutation->set_sql(sql);
+    mutation->set_sign(sign);
+    DB_DEBUG("sql:%s type:%s %ld,%ld", sql.c_str(), pb::MutationType_Name(type).c_str(), retrun_records.size(),
+        retrun_records.size());
+    switch (type) {
+        case pb::MutationType::DELETE: {
+            if (all_in_one) {
+                for (auto& pair : retrun_records) {
+                    for (auto& str_record : pair.second) {
+                        mutation->add_deleted_rows(str_record);
+                    }
+                }
+            } else {
+                auto iter = retrun_records.find(partition_id);
+                if (iter != retrun_records.end()) {
+                    for (auto& str_record : iter->second) {
+                        mutation->add_deleted_rows(str_record);
+                    }
+                }
+            }
+            break;
+        }
+        case pb::MutationType::INSERT: {
+            if (all_in_one) {
+                for (auto& pair : retrun_records) {
+                    for (auto& str_record : pair.second) {
+                        mutation->add_insert_rows(str_record);
+                    }
+                }
+            } else {
+                auto iter = retrun_records.find(partition_id);
+                if (iter != retrun_records.end()) {
+                    for (auto& str_record : iter->second) {
+                        mutation->add_insert_rows(str_record);
+                    }
+                }
+            }
+            break;
+        }
+        case pb::MutationType::UPDATE: {
+            if (all_in_one) {
+                for (auto& pair : retrun_records) {
+                    for (auto& str_record : pair.second) {
+                        mutation->add_insert_rows(str_record);
+                    }
+                }
+                for (auto& pair : retrun_old_records) {
+                    for (auto& str_record : pair.second) {
+                        mutation->add_deleted_rows(str_record);
+                    }
+                }
+            } else {
+                auto iter = retrun_records.find(partition_id);
+                if (iter != retrun_records.end()) {
+                    for (auto& str_record : iter->second) {
+                        mutation->add_insert_rows(str_record);
+                    }
+                }
+                auto old_iter = retrun_old_records.find(partition_id);
+                if (old_iter != retrun_old_records.end()) {
+                    for (auto& str_record : old_iter->second) {
+                        mutation->add_deleted_rows(str_record);
+                    }
+                }
+            }
+            break;
+        }
+        default:
+            break;
+    } 
+}
+
+int BinlogContext::add_binlog_values(SmartTable& table_info,
+                          const std::string& sql,
+                          const uint64_t sign,
+                          pb::MutationType type,
+                          const std::map<int64_t, std::vector<std::string>>& retrun_records,
+                          const std::map<int64_t, std::vector<std::string>>& retrun_old_records) {
+    auto iter = table_info->binlog_ids.begin();
+    while (iter != table_info->binlog_ids.end()) {
+        int64_t binlog_id = iter->first;
+        DB_DEBUG("add binlog_id :%ld retrun_records:%ld retrun_old_records:%ld", binlog_id,
+            retrun_records.size(), retrun_old_records.size());
+        auto binlog_iter = _table_binlogs.find(binlog_id);
+        if (binlog_iter == _table_binlogs.end()) {
+            auto binlog_table_info = _factory->get_table_info_ptr(binlog_id);
+            if (binlog_table_info == nullptr) {
+                ++iter;
+                DB_WARNING("get table info for binlog_id: %ld failed", binlog_id);
+                continue;
+            }
+            _table_binlogs[binlog_id] = BinlogInfo{.binlog_table_info = binlog_table_info,
+                                                   .partition_is_same_hint = iter->second,
+                                                   .binlog_by_partition = {}};
+        }
+        auto& binlog_info = _table_binlogs[binlog_id];
+        if (binlog_info.binlog_table_info->partition_num == 1) { // binlog表不分区
+            auto binlog_ptr = get_partition_binlog_ptr(binlog_id, binlog_info, 0);
+            if (binlog_ptr == nullptr) {
+                DB_WARNING("get binlog region failed binlog_id:%ld",  binlog_id);
+                return -1;
+            }
+            binlog_ptr->db_tables.insert(table_info->name);
+            binlog_ptr->signs.insert(sign);
+            _partition_keys[0] = 0;
+            add_mutation(binlog_ptr, table_info->id, sql, sign, type, 0, true,
+                retrun_records, retrun_old_records);
+        } else if (table_info->partition_num == binlog_info.binlog_table_info->partition_num
+            && binlog_info.partition_is_same_hint) { // 分区方式一样
+            SmartRecord record_template = _factory->new_record(table_info->id);
+            if (record_template == nullptr) {
+                DB_WARNING(" table_id: %ld binlog_id:%ld not found", table_info->id, binlog_id);
+                return -1;
+            }
+            FieldInfo link_field;
+            auto link_iter = table_info->link_field_map.find(binlog_id);
+            if (link_iter != table_info->link_field_map.end()) {
+                link_field = link_iter->second;
+            } else {
+                DB_WARNING("binlog link_field not found table_id: %ld binlog_id:%ld",
+                table_info->id, binlog_id);
+                return -1;
+            }
+            for (auto& pair : retrun_records) {
+                int64_t partition_id = pair.first;
+                auto binlog_ptr = get_partition_binlog_ptr(binlog_id, binlog_info, partition_id);
+                if (binlog_ptr == nullptr) {
+                    DB_WARNING("get binlog region failed binlog_id:%ld",  binlog_id);
+                    return -1;
+                }
+                if (_partition_keys.count(partition_id) == 0) {
+                    // 反解第一条record获取parttiton_key
+                    auto& str_record = pair.second.front();
+                    SmartRecord record = record_template->clone(false);
+                    int ret = record->decode(str_record);
+                    if (ret < 0) {
+                        DB_FATAL("decode to record fail");
+                        return -1;
+                    }
+                    auto field_desc = record->get_field_by_idx(link_field.pb_idx);
+                    ExprValue value = record->get_value(field_desc);
+                    _partition_keys[partition_id] = value.get_numberic<uint64_t>();
+                }
+                binlog_ptr->db_tables.insert(table_info->name);
+                binlog_ptr->signs.insert(sign);
+                add_mutation(binlog_ptr, table_info->id, sql, sign, type, partition_id, false,
+                    retrun_records, retrun_old_records);
+            }
+        } else {
+            std::map<int64_t, std::vector<std::string>>  return_str_records;
+            std::map<int64_t, std::vector<std::string>>  return_str_old_records;
+            SmartRecord record_template = _factory->new_record(table_info->id);
+            if (record_template == nullptr) {
+                DB_WARNING(" table_id: %ld binlog_id:%ld not found", table_info->id, binlog_id);
+                return -1;
+            }
+            FieldInfo link_field;
+            auto link_iter = table_info->link_field_map.find(binlog_id);
+            if (link_iter != table_info->link_field_map.end()) {
+                link_field = link_iter->second;
+            } else {
+                DB_WARNING("binlog link_field not found table_id: %ld binlog_id:%ld",
+                table_info->id, binlog_id);
+                return -1;
+            }
+            DB_DEBUG("binlog_id:%ld link_field:%s", binlog_id, link_field.name.c_str());
+            for (auto& pair : retrun_records) {
+                for (auto& str_record : pair.second) {
+                    SmartRecord record = record_template->clone(false);
+                    int ret = record->decode(str_record);
+                    if (ret < 0) {
+                        DB_FATAL("decode to record fail");
+                        return -1;
+                    }
+                    int64_t partition_id = get_partition_id(binlog_info.binlog_table_info, record, link_field);
+                    if (partition_id < 0) {
+                        DB_WARNING("get partition_id failed table_id: %ld binlog_id:%ld",
+                            table_info->id, binlog_id);
+                        return -1;
+                    }
+                    return_str_records[partition_id].emplace_back(std::move(str_record));
+                }
+            }
+            for (auto& pair : retrun_old_records) {
+                for (auto& str_record : pair.second) {
+                    SmartRecord record = record_template->clone(false);
+                    int ret = record->decode(str_record);
+                    if (ret < 0) {
+                        DB_FATAL("decode to record fail");
+                        return -1;
+                    }
+                    int64_t partition_id = get_partition_id(binlog_info.binlog_table_info, record, link_field);
+                    if (partition_id < 0) {
+                        DB_WARNING("get partition_id failed table_id: %ld binlog_id:%ld",
+                            table_info->id, binlog_id);
+                        return -1;
+                    }
+                    return_str_old_records[partition_id].emplace_back(std::move(str_record));
+                }
+            }
+            for (auto& pair : return_str_records) {
+                int64_t partition_id = pair.first;
+                auto binlog_ptr = get_partition_binlog_ptr(binlog_id, binlog_info, partition_id);
+                if (binlog_ptr == nullptr) {
+                    DB_WARNING("get binlog region failed binlog_id:%ld",  binlog_id);
+                    return -1;
+                }
+                binlog_ptr->db_tables.insert(table_info->name);
+                binlog_ptr->signs.insert(sign);
+                add_mutation(binlog_ptr, table_info->id, sql, sign, type, partition_id, false,
+                    return_str_records, return_str_old_records);
+            }
+        }
+        ++iter;
+    }
+    return 0;
+}
+
+int BinlogContext::add_binlog_values(SmartTable& table_info,
+                          const std::string& sql,
+                          const uint64_t sign,
+                          pb::MutationType type,
+                          const std::vector<SmartRecord>& retrun_records,
+                          const std::vector<SmartRecord>& retrun_old_records) {
+    auto iter = table_info->binlog_ids.begin();
+    while (iter != table_info->binlog_ids.end()) {
+        int64_t binlog_id = iter->first;
+        DB_DEBUG("add binlog_id :%ld retrun_records:%ld retrun_old_records:%ld", binlog_id,
+            retrun_records.size(), retrun_old_records.size());
+        auto binlog_iter = _table_binlogs.find(binlog_id);
+        if (binlog_iter == _table_binlogs.end()) {
+            auto binlog_table_info = _factory->get_table_info_ptr(binlog_id);
+            if (binlog_table_info == nullptr) {
+                ++iter;
+                continue;
+            }
+            _table_binlogs[binlog_id] = BinlogInfo{.binlog_table_info = binlog_table_info,
+                                                   .partition_is_same_hint = iter->second,
+                                                   .binlog_by_partition = {}};
+        }
+        auto& binlog_info = _table_binlogs[binlog_id];
+        if (binlog_info.binlog_table_info->partition_num == 1) { // binlog表不分区
+            std::map<int64_t, std::vector<std::string>> return_str_records;
+            std::map<int64_t, std::vector<std::string>> return_str_old_records;
+            SmartRecord record_template = _factory->new_record(table_info->id);
+            if (record_template == nullptr) {
+                DB_WARNING(" table_id: %ld binlog_id:%ld not found", table_info->id, binlog_id);
+                return -1;
+            }
+            for (auto& record : retrun_records) {
+                std::string row;
+                record->encode(row);
+                return_str_records[0].emplace_back(std::move(row));
+            }
+            for (auto& record : retrun_old_records) {
+                std::string row;
+                record->encode(row);
+                return_str_old_records[0].emplace_back(std::move(row));
+            }
+            _partition_keys[0] = 0;
+            auto binlog_ptr = get_partition_binlog_ptr(binlog_id, binlog_info, 0);
+            if (binlog_ptr == nullptr) {
+                DB_WARNING("get binlog region failed binlog_id:%ld",  binlog_id);
+                return -1;
+            }
+            binlog_ptr->db_tables.insert(table_info->name);
+            binlog_ptr->signs.insert(sign);
+            add_mutation(binlog_ptr, table_info->id, sql, sign, type, 0, true,
+                return_str_records, return_str_old_records);
+        } else {
+            std::map<int64_t, std::vector<std::string>>  return_str_records;
+            std::map<int64_t, std::vector<std::string>>  return_str_old_records;
+            FieldInfo link_field;
+            auto link_iter = table_info->link_field_map.find(binlog_id);
+            if (link_iter != table_info->link_field_map.end()) {
+                link_field = link_iter->second;
+            } else {
+                DB_WARNING("binlog link_field not found table_id: %ld binlog_id:%ld",
+                table_info->id, binlog_id);
+                return -1;
+            }
+            DB_DEBUG("binlog_id:%ld link_field:%s", binlog_id, link_field.name.c_str());
+            for (auto& record : retrun_records) {
+                int64_t partition_id = get_partition_id(binlog_info.binlog_table_info, record, link_field);
+                if (partition_id < 0) {
+                    DB_WARNING("get partition_id failed table_id: %ld binlog_id:%ld",
+                        table_info->id, binlog_id);
+                    return -1;
+                }
+                std::string row;
+                record->encode(row);
+                return_str_records[partition_id].emplace_back(std::move(row));
+            }
+            for (auto& record : retrun_old_records) {
+                int64_t partition_id = get_partition_id(binlog_info.binlog_table_info, record, link_field);
+                if (partition_id < 0) {
+                    DB_WARNING("get partition_id failed table_id: %ld binlog_id:%ld",
+                        table_info->id, binlog_id);
+                    return -1;
+                }
+                std::string row;
+                record->encode(row);
+                return_str_old_records[partition_id].emplace_back(std::move(row));
+            }
+            for (auto& pair : return_str_records) {
+                int64_t partition_id = pair.first;
+                auto binlog_ptr = get_partition_binlog_ptr(binlog_id, binlog_info, partition_id);
+                if (binlog_ptr == nullptr) {
+                    DB_WARNING("get binlog region failed binlog_id:%ld",  binlog_id);
+                    return -1;
+                }
+                binlog_ptr->db_tables.insert(table_info->name);
+                binlog_ptr->signs.insert(sign);
+                add_mutation(binlog_ptr, table_info->id, sql, sign, type, partition_id, false,
+                    return_str_records, return_str_old_records);
+            }
+        }
+        ++iter;
+    }
+    return 0;
+}
+
+int BinlogContext::send_binlog_data(const WriteBinlogParam* param, const SmartPartitionBinlog& partition_binlog_ptr) {
+    TimeCost write_binlog_cost; 
+    pb::StoreReq req;
+    pb::StoreRes res;
+
+    req.set_db_conn_id(param->global_conn_id);
+    req.set_log_id(param->log_id);
+    auto binlog_desc = req.mutable_binlog_desc();
+    binlog_desc->set_txn_id(param->txn_id);
+    binlog_desc->set_start_ts(partition_binlog_ptr->start_ts);
+    binlog_desc->set_primary_region_id(param->primary_region_id);
+    binlog_desc->set_user_name(param->username);
+    binlog_desc->set_user_ip(param->ip);
+    auto binlog = req.mutable_binlog();
+    binlog->set_start_ts(partition_binlog_ptr->start_ts);
+    binlog->set_partition_key(_partition_keys[partition_binlog_ptr->partition_id]);
+    if (param->op_type == pb::OP_PREPARE) {
+        binlog->set_type(pb::BinlogType::PREWRITE);
+        req.set_op_type(pb::OP_PREWRITE_BINLOG);
+        binlog_desc->set_binlog_ts(partition_binlog_ptr->start_ts);
+        partition_binlog_ptr->calc_binlog_row_cnt();
+        binlog_desc->set_binlog_row_cnt(partition_binlog_ptr->binlog_row_cnt);
+        auto prewrite_value = binlog->mutable_prewrite_value();
+        prewrite_value->CopyFrom(partition_binlog_ptr->binlog_value);
+    } else if (param->op_type == pb::OP_COMMIT) {
+        binlog->set_type(pb::BinlogType::COMMIT);
+        req.set_op_type(pb::OP_COMMIT_BINLOG);
+        binlog_desc->set_binlog_ts(partition_binlog_ptr->commit_ts);
+        binlog_desc->set_binlog_row_cnt(partition_binlog_ptr->binlog_row_cnt);
+        binlog->set_commit_ts(partition_binlog_ptr->commit_ts);
+        for (const std::string& db_table : partition_binlog_ptr->db_tables) {
+            binlog_desc->add_db_tables(db_table);
+        }
+        for (uint64_t sign : partition_binlog_ptr->signs) {
+            binlog_desc->add_signs(sign);
+        }        
+    } else if (param->op_type == pb::OP_ROLLBACK) {
+        binlog->set_type(pb::BinlogType::ROLLBACK);
+        req.set_op_type(pb::OP_ROLLBACK_BINLOG);
+        binlog_desc->set_binlog_ts(partition_binlog_ptr->start_ts);
+    } else {
+        // todo DDL
     }
     int ret = 0;
-    if (_table_info->link_field.empty()) {
-        ret = _factory->get_binlog_regions(_table_info->id, _binlog_region);
-    } else {
-        FieldInfo& link_filed = _table_info->link_field[0];
-        auto field_desc = _partition_record->get_field_by_idx(link_filed.pb_idx);
-        ExprValue value = _partition_record->get_value(field_desc);
-        _partition_key = value.get_numberic<uint64_t>();
-        ret = _factory->get_binlog_regions(_table_info->id, _binlog_region, value);
-    }
+    pb::RegionInfo& info = partition_binlog_ptr->binlog_region;
+    int64_t region_id = info.region_id();
+    req.set_region_id(region_id);
+    req.set_region_version(info.version());
+    int retry_times = 0;
+    do {
+        brpc::Channel channel;
+        brpc::Controller cntl;
+        cntl.set_log_id(param->log_id);
+        brpc::ChannelOptions option;
+        option.max_retry = 1;
+        option.connect_timeout_ms = FLAGS_fetcher_connect_timeout;
+        option.timeout_ms = FLAGS_fetcher_request_timeout;
+        std::string addr = info.leader();
+        if (retry_times == 0) {
+            // 重试前已经选择了normal的实例
+            // 或者store返回了正确的leader
+            param->fetcher_store->choose_other_if_dead(info, addr);
+        }
+        ret = channel.Init(addr.c_str(), &option);
+        if (ret != 0) {
+            DB_WARNING("binlog channel init failed, addr:%s, ret:%d, log_id:%lu",
+                    addr.c_str(), ret, param->log_id);
+            return -1;
+        }
 
-    if (ret < 0) {
-        DB_WARNING("get binlog region failed table_id: %ld log_id:%lu",
-            _table_info->id, log_id);
+        param->client_conn->insert_callid(addr, region_id, cntl.call_id());
+
+        pb::StoreService_Stub(&channel).query_binlog(&cntl, &req, &res, NULL);
+        if (cntl.Failed()) {
+            DB_WARNING("binlog call failed  errcode:%d, error:%s, region_id:%ld log_id:%lu",
+                cntl.ErrorCode(), cntl.ErrorText().c_str(), region_id, param->log_id);
+            // 只有网络相关错误码才重试
+            if (!param->fetcher_store->rpc_need_retry(cntl.ErrorCode())) {
+                return -1;
+            }
+            if (cntl.ErrorCode() == ECANCELED) {
+                return -1;
+            }
+            param->fetcher_store->other_normal_peer_to_leader(info, addr);
+            bthread_usleep(FLAGS_retry_interval_us);
+            retry_times++;
+            continue;
+        }
+        DB_DEBUG("binlog fetch store req: %s log_id:%lu", req.ShortDebugString().c_str(), param->log_id);
+        DB_DEBUG("binlog fetch store res: %s log_id:%lu", res.ShortDebugString().c_str(), param->log_id);
+        if (res.errcode() == pb::NOT_LEADER) {
+            DB_WARNING("binlog NOT_LEADER, addr:%s region_id:%ld retry:%d, new_leader:%s, log_id:%lu", addr.c_str(),
+                region_id, retry_times, res.leader().c_str(), param->log_id);
+
+            if (res.leader() != "0.0.0.0:0") {
+                // store返回了leader，则相信store，不判断normal
+                info.set_leader(res.leader());
+                _factory->update_leader(info);
+            } else {
+                param->fetcher_store->other_normal_peer_to_leader(info, addr);
+            }
+            retry_times++;
+            bthread_usleep(retry_times * FLAGS_retry_interval_us);
+        } else if (res.errcode() == pb::VERSION_OLD) {
+            DB_WARNING("VERSION_OLD, region_id: %ld, retry:%d, now:%s, log_id:%lu",
+                    region_id, retry_times, info.ShortDebugString().c_str(), param->log_id);
+            for (auto r : res.regions()) {
+                DB_WARNING("new version region:%s", r.ShortDebugString().c_str());
+                info.CopyFrom(r);
+            }
+            req.set_region_id(info.region_id());
+            req.set_region_version(info.version());
+        } else if (res.errcode() == pb::REGION_NOT_EXIST) {
+            param->fetcher_store->other_normal_peer_to_leader(info, addr);
+            retry_times++;
+        } else if (res.errcode() != pb::SUCCESS) {
+            DB_WARNING("errcode:%s, write_binlog failed, instance:%s region_id:%ld retry:%d log_id:%lu",
+                    pb::ErrCode_Name(res.errcode()).c_str(), addr.c_str(), region_id, retry_times, param->log_id);
+            return -1;
+        } else {
+            // success
+            param->fetcher_store->binlog_prepare_success = true;
+            break;
+        }
+    } while (retry_times < 5);
+    int64_t query_cost = write_binlog_cost.get_time();
+    if (query_cost > FLAGS_print_time_us || retry_times > 0) {
+        DB_WARNING("write binlog region_id:%ld log_id:%lu txn_id:%ld cost time:%ld op_type:%s ip:%s",
+            region_id, param->log_id, param->txn_id, query_cost, pb::OpType_Name(param->op_type).c_str(), info.leader().c_str());
+    }
+    if (param->fetcher_store->binlog_prepare_success) {
+        if (param->op_type == pb::OP_PREPARE) {
+            partition_binlog_ptr->binlog_prewrite_time.reset();
+        } else if (param->op_type == pb::OP_COMMIT) {
+            if (partition_binlog_ptr->binlog_prewrite_time.get_time() > FLAGS_binlog_alarm_time_s * 1000 * 1000LL) {
+                // 报警日志
+                DB_WARNING("binlog takes too long from prewrite to commit, txn_id: %ld, binlog_region_id: %ld, start_ts: %s, commit_ts: %s",
+                    param->txn_id, region_id, ts_to_datetime_str(partition_binlog_ptr->start_ts).c_str(),
+                    ts_to_datetime_str(partition_binlog_ptr->commit_ts).c_str());
+            }
+        } else {
+            // do nothing
+        }
+    } else {
+        DB_WARNING("exec failed log_id:%lu", param->log_id);
         return -1;
     }
     return 0;
+}
+
+int BinlogContext::write_binlog(const WriteBinlogParam* param) {
+    ConcurrencyBthread write_bth(_tso_count, &BTHREAD_ATTR_NORMAL);
+    int error = 0;
+    for (auto& pair : _table_binlogs) {
+        for (auto& pair2 : pair.second.binlog_by_partition) {
+            if (error != 0) {
+                break;
+            }
+            auto partition_binlog_ptr = pair2.second;
+            auto write_binlog_func = [this, &error, param, partition_binlog_ptr]() {
+                auto ret = send_binlog_data(param, partition_binlog_ptr);
+                if (ret != 0) {
+                    error = ret;
+                }
+            };
+            write_bth.run(write_binlog_func);
+        }
+    }
+    write_bth.join();
+    return error;
 }
 
 } // namespace baikaldb

--- a/src/session/binlog_context.cpp
+++ b/src/session/binlog_context.cpp
@@ -24,7 +24,8 @@
 #endif
 
 namespace baikaldb {
-DECLARE_bool(meta_tso_autoinc_degrade);
+DEFINE_bool(meta_tso_autoinc_degrade, false, "meta_tso_autoinc_degrade");
+BRPC_VALIDATE_GFLAG(meta_tso_autoinc_degrade, brpc::PassValidate);
 DECLARE_int64(print_time_us);
 DECLARE_int64(retry_interval_us);
 DECLARE_int32(fetcher_connect_timeout);

--- a/src/session/binlog_context.cpp
+++ b/src/session/binlog_context.cpp
@@ -249,7 +249,8 @@ int BinlogContext::add_binlog_values(SmartTable& table_info,
                 continue;
             }
             _table_binlogs[binlog_id] = BinlogInfo{.binlog_table_info = binlog_table_info,
-                                                   .partition_is_same_hint = iter->second };
+                                                   .partition_is_same_hint = iter->second,
+                                                   .binlog_by_partition = {}};
         }
         auto& binlog_info = _table_binlogs[binlog_id];
         if (binlog_info.binlog_table_info->partition_num == 1) { // binlog表不分区
@@ -393,7 +394,8 @@ int BinlogContext::add_binlog_values(SmartTable& table_info,
                 continue;
             }
             _table_binlogs[binlog_id] = BinlogInfo{.binlog_table_info = binlog_table_info,
-                                                   .partition_is_same_hint = iter->second };
+                                                   .partition_is_same_hint = iter->second,
+                                                   .binlog_by_partition = {}};
         }
         auto& binlog_info = _table_binlogs[binlog_id];
         if (binlog_info.binlog_table_info->partition_num == 1) { // binlog表不分区

--- a/src/session/binlog_context.cpp
+++ b/src/session/binlog_context.cpp
@@ -249,8 +249,7 @@ int BinlogContext::add_binlog_values(SmartTable& table_info,
                 continue;
             }
             _table_binlogs[binlog_id] = BinlogInfo{.binlog_table_info = binlog_table_info,
-                                                   .partition_is_same_hint = iter->second,
-                                                   .binlog_by_partition = {}};
+                                                   .partition_is_same_hint = iter->second };
         }
         auto& binlog_info = _table_binlogs[binlog_id];
         if (binlog_info.binlog_table_info->partition_num == 1) { // binlog表不分区
@@ -394,8 +393,7 @@ int BinlogContext::add_binlog_values(SmartTable& table_info,
                 continue;
             }
             _table_binlogs[binlog_id] = BinlogInfo{.binlog_table_info = binlog_table_info,
-                                                   .partition_is_same_hint = iter->second,
-                                                   .binlog_by_partition = {}};
+                                                   .partition_is_same_hint = iter->second };
         }
         auto& binlog_info = _table_binlogs[binlog_id];
         if (binlog_info.binlog_table_info->partition_num == 1) { // binlog表不分区

--- a/src/session/binlog_context.cpp
+++ b/src/session/binlog_context.cpp
@@ -248,9 +248,10 @@ int BinlogContext::add_binlog_values(SmartTable& table_info,
                 DB_WARNING("get table info for binlog_id: %ld failed", binlog_id);
                 continue;
             }
-            _table_binlogs[binlog_id] = BinlogInfo{.binlog_table_info = binlog_table_info,
-                                                   .partition_is_same_hint = iter->second,
-                                                   .binlog_by_partition = {}};
+            BinlogInfo info;
+            info.binlog_table_info = binlog_table_info;
+            info.partition_is_same_hint = iter->second;
+            _table_binlogs[binlog_id] = info;
         }
         auto& binlog_info = _table_binlogs[binlog_id];
         if (binlog_info.binlog_table_info->partition_num == 1) { // binlog表不分区
@@ -393,9 +394,10 @@ int BinlogContext::add_binlog_values(SmartTable& table_info,
                 ++iter;
                 continue;
             }
-            _table_binlogs[binlog_id] = BinlogInfo{.binlog_table_info = binlog_table_info,
-                                                   .partition_is_same_hint = iter->second,
-                                                   .binlog_by_partition = {}};
+            BinlogInfo info;
+            info.binlog_table_info = binlog_table_info;
+            info.partition_is_same_hint = iter->second;
+            _table_binlogs[binlog_id] = info;
         }
         auto& binlog_info = _table_binlogs[binlog_id];
         if (binlog_info.binlog_table_info->partition_num == 1) { // binlog表不分区

--- a/src/store/meta_writer.cpp
+++ b/src/store/meta_writer.cpp
@@ -601,8 +601,8 @@ int MetaWriter::read_pre_commit_key(int64_t region_id, uint64_t txn_id,
     }
     num_table_lines = TableKey(rocksdb::Slice(value)).extract_i64(0);
     applied_index = TableKey(rocksdb::Slice(value)).extract_i64(sizeof(int64_t));
-    DB_WARNING("region_id: %ld read pre commit value, num_table_lines: %ld, applied_index: %ld",
-                region_id, num_table_lines, applied_index);
+    DB_WARNING("region_id: %ld read pre commit value, txn_id: %lu num_table_lines: %ld, applied_index: %ld",
+                region_id, txn_id, num_table_lines, applied_index);
     return 0;
 }
 

--- a/src/store/region_binlog.cpp
+++ b/src/store/region_binlog.cpp
@@ -121,6 +121,7 @@ void Region::binlog_query_primary_region(const int64_t& start_ts, const int64_t&
                 binlog_desc->set_binlog_ts(commit_ts);
                 binlog_desc->set_txn_id(txn_info.txn_id());
                 binlog_desc->set_start_ts(start_ts);
+                binlog_desc->set_primary_region_id(region_info.region_id());
 
                 butil::IOBuf data;
                 butil::IOBufAsZeroCopyOutputStream wrapper(&data);
@@ -1332,7 +1333,7 @@ void Region::read_binlog(const pb::StoreReq* request,
             return;
         }
 
-        oldest_ts = _binlog_param.oldest_ts;
+        oldest_ts = std::max(_rocksdb->get_oldest_ts_in_binlog_cf(), _binlog_param.oldest_ts);
         if (oldest_ts < 0) {
             DB_FATAL("region_id: %ld, get oldest ts failed", _region_id);
             response->set_errcode(pb::GET_VALUE_FAIL); 

--- a/src/store/rpc_sender.cpp
+++ b/src/store/rpc_sender.cpp
@@ -126,10 +126,11 @@ int RpcSender::send_init_region_method(const std::string& instance,
     return store_interact.send_request("init_region", init_region_request, response);
 }
 
-int RpcSender::get_leader_read_index(const std::string& leader, int64_t region_id, pb::StoreRes& response) {
+int RpcSender::get_leader_read_index(const std::string& leader, int64_t region_id, pb::StoreRes& response, bool need_raft_log_index) {
     pb::GetAppliedIndex request;
     request.set_region_id(region_id);
     request.set_use_read_idx(true);
+    request.set_use_raft_log_index(need_raft_log_index);
     StoreReqOptions req_options;
     req_options.request_timeout = 1000; // 1s
     req_options.connect_timeout = 1000; // 1s

--- a/src/store/store.cpp
+++ b/src/store/store.cpp
@@ -712,7 +712,7 @@ void Store::get_applied_index(google::protobuf::RpcController* controller,
         return;
     }
     if (request->use_read_idx()) {
-        region->get_read_index(response);
+        region->get_read_index(request, response);
         return;
     }
     response->set_region_status(region->region_status());
@@ -1934,7 +1934,7 @@ void Store::process_heart_beat_response(const pb::StoreHeartBeatResponse& respon
                     remove_item.drop_region_id());
                 continue;
             }
-            DB_WARNING("receive delete region response from meta server heart beat, delete_region_id:%ld %lu",
+            DB_WARNING("real begin delete region from meta server heart beat, delete_region_id:%ld %lu",
                     remove_item.drop_region_id(), region->region_uuid());
             drop_region_from_store(remove_item.drop_region_id(), true);
         }

--- a/test/test_decode_proto.cpp
+++ b/test/test_decode_proto.cpp
@@ -205,9 +205,37 @@ void test_proto_invalid_field() {
     }
 }
 
+void test_optional_to_repeated() {
+    Packed packed;
+    Pg pg;
+    pg.add_a(10000);
+    pg.set_b(20000);
+    (*packed.add_a()) = pg;
+    
+    std::string buffer;
+    packed.SerializeToString(&buffer);
+    
+    Optional optional;
+    optional.ParseFromString(buffer);
+    DB_WARNING("optional %s", optional.ShortDebugString().c_str());
+
+    Pg pg1;
+    pg1.add_a(20000);
+    pg1.set_b(30000);
+    Optional optional1;
+    optional1.mutable_a()->CopyFrom(pg1);
+    std::string buffer1;
+    optional1.SerializeToString(&buffer1);
+
+    Packed packed1;
+    packed1.ParseFromString(buffer1);
+    DB_WARNING("packed1 %s", packed1.ShortDebugString().c_str());
+}
+
 int main(int argc, char** argv) {
     //baidu::rpc::StartDummyServerAt(8800);
     DB_WARNING("thread num:%d", bthread::FLAGS_bthread_concurrency);
+    test_optional_to_repeated();
     sleep(10);
     
 	int batch_cnt = std::stoi(argv[1]);


### PR DESCRIPTION
将发布成v2.2.0
## New Features：
* 增加store单sign读请求的并发控制，去除new sign识别；两级并发参数，服务器配置高可以调大：sign_concurrency=8，global_select_concurrency=24，开关：open_sign_concurrency=true
* 通过表名鉴权，防止新表rename后无权限问题
* table可以分发给多个binlog表（可以不同partition）

## Bug Fixes：
* 修复sort_limit_by_range问题
*  read index广播采用log index
*  update set null时binlog发送默认值
*  修复full export+partition表问题
*  修复ddl+分裂时可能丢index数据问题
*  修复update别名问题

## Performance Improvements:
* 倒排index里不使用pb
* partition路由优化
* 倒排or堆排序
* partition多项性能优化