### PR TITLE
fix: calc_index_range like prefix append key type bug

### DIFF
--- a/src/exec/access_path.cpp
+++ b/src/exec/access_path.cpp
@@ -355,7 +355,7 @@ void AccessPath::calc_index_range(int64_t partition_field_id, const std::map<std
             case EQ:
             case LIKE_EQ:
             case LIKE_PREFIX:
-                if (_like_prefix) {
+                if (_like_prefix && range.type == LIKE_PREFIX) {
                     if (in_records.empty()) {
                         left_key.append_string_prefix(range.eq_in_values[0].get_string());
                         right_key.append_string_prefix(range.eq_in_values[0].get_string());


### PR DESCRIPTION
联合索引(a, b)// (int, string) ，查询条件where a  = 1 and b like "b%"， calc_index_range时，对a=1的判断错误，走append_string_prefix分支了，实际应该走append_value分支。