### PR TITLE
fix: A large number of delete ranges exist when building an sst, resulting in a large amount of memory consumption

### DIFF
--- a/src/raft/my_raft_log_storage.cpp
+++ b/src/raft/my_raft_log_storage.cpp
@@ -451,6 +451,10 @@ int MyRaftLogStorage::truncate_prefix(const int64_t first_index_kept) {
     DB_WARNING("Truncating region_id: %ld to first index kept:%ld from first log index:%ld",
             _region_id, first_index_kept, _first_log_index.load());
     
+    int64_t start_index = _first_log_index.load();
+    if (start < 0){
+        return 0;
+    }
     _first_log_index.store(first_index_kept);
     if (first_index_kept > _last_log_index.load()) {
         _last_log_index.store(first_index_kept - 1);
@@ -485,7 +489,7 @@ int MyRaftLogStorage::truncate_prefix(const int64_t first_index_kept) {
 
     //替换为remove_range
     char start_key[LOG_DATA_KEY_SIZE];
-    _encode_log_data_key(start_key, LOG_DATA_KEY_SIZE, 0);
+    _encode_log_data_key(start_key, LOG_DATA_KEY_SIZE, start_index);
     char end_key[LOG_DATA_KEY_SIZE];
     _encode_log_data_key(end_key, LOG_DATA_KEY_SIZE, first_index_kept);
    

--- a/src/raft/my_raft_log_storage.cpp
+++ b/src/raft/my_raft_log_storage.cpp
@@ -452,7 +452,7 @@ int MyRaftLogStorage::truncate_prefix(const int64_t first_index_kept) {
             _region_id, first_index_kept, _first_log_index.load());
     
     int64_t start_index = _first_log_index.load();
-    if (start < 0){
+    if (start_index < 0){
         return 0;
     }
     _first_log_index.store(first_index_kept);


### PR DESCRIPTION
如果长时间不使用baikaldb，但baikaldb将会每隔一段时间定期触发save snapshot，该操作将会调用raft reset 从而调用delete range，但在该操作中delete range的start key相同，但delete range是由 两方面来描述的一个是 key range， 另一个是seq 。当前start key 相同， seq不同，这会使得在构建sst文件时，在函数FragmentedRangeTombstoneList::FragmentTombstones 中每个重叠范围都需要一个vector来保存不同的sequence。这将随着delete range 数目的增加成 平方次增长。例如4000个delete range将消耗1.6GB的内存。通常在10天不使用baikaldb就会复现该场景。
我们通过记录每个raft log的起始索引，来保证每个delete range都不会重复，从而避免了大量无效的vector<SequenceNumber>，经过我们的测试，将避免大量delete range场景下构造sst的内存开销

If baikaldb is not used for a long time, but baikaldb will periodically trigger the save snapshot at intervals, this operation will call raft reset to call delete range, but the start key of delete range in this operation is the same. But the delete range is described in two ways: the key range and the seq. The current start key is the same, but the seq is different, which will cause when building the sst file, In function FragmentedRangeTombstoneList: : FragmentTombstones() every overlapping range needs a vector to store different sequence. This will grow exponentially as the number of delete ranges increases. For example, 4000 delete ranges will consume 1.6GB of memory. This scenario usually reappears after 10 days without using baikaldb.

By recording the start index of each raft log, we ensure that each delete range is not overlapped, thus avoiding a large number of invalid vector<SequenceNumber>; After our tests, the memory overhead of constructing sst in a large number of delete range scenarios will be avoided.