### PR TITLE
tso: fix next tso update when prev_logical exceed half of max_logical

### DIFF
--- a/src/meta_server/tso_state_machine.cpp
+++ b/src/meta_server/tso_state_machine.cpp
@@ -357,7 +357,7 @@ void TSOStateMachine::update_timestamp() {
     if (delta > tso::update_timestamp_guard_ms) {
         next = now;
     } else if (prev_logical > tso::max_logical / 2) {
-        next = now + tso::update_timestamp_guard_ms;
+        next = prev_physical + tso::update_timestamp_guard_ms;
     } else {
         DB_WARNING("don't need update timestamp prev:%ld now:%ld save:%ld", prev_physical, now, last_save);
         return;


### PR DESCRIPTION
如果 `prev_logical > tso::max_logical / 2`
next physical 应该为 `prev_physical + tso::update_timestamp_guard_ms;`
因为 now 可能小于 `prev_physical`, 从而违反了线性增长的要求。