### PR TITLE
bug fix

### DIFF
--- a/include/runtime/runtime_state.h
+++ b/include/runtime/runtime_state.h
@@ -408,6 +408,17 @@ public:
     int64_t get_cost_time() {
         return time_cost.get_time();
     }
+    void prepare_reset() {
+        time_cost.reset();
+        region_count = 0;
+        _num_increase_rows = 0;
+        _num_affected_rows = 0;
+        _num_returned_rows = 0;
+        _num_scan_rows = 0;
+        _num_filter_rows = 0;
+        _read_disk_size = 0;
+        _is_cancelled = false;
+    }
     bool is_timeout() {
         return _sql_exec_timeout > 0 && time_cost.get_time()  > _sql_exec_timeout * 1000L;
     }

--- a/src/exec/filter_node.cpp
+++ b/src/exec/filter_node.cpp
@@ -683,7 +683,8 @@ int FilterNode::get_next(RuntimeState* state, RowBatch* batch, bool* eos) {
             state->memory_limit_release(state->num_scan_rows(), row->used_size());
         }
         if (reached_limit()) {
-            DB_WARNING_STATE(state, "reach limit size:%lu", batch->size());
+            // DB_WARNING_STATE(state, "reach limit size:%lu", batch->size());
+            DB_DEBUG("reach limit size:%lu, logid: %lu", batch->size(), state->log_id());
             *eos = true;
             return 0;
         }

--- a/src/exec/update_manager_node.cpp
+++ b/src/exec/update_manager_node.cpp
@@ -259,6 +259,9 @@ void UpdateManagerNode::update_record(RuntimeState* state, SmartRecord record) {
             state->last_insert_id = last_insert_id_expr->get_value(row).get_numberic<int64_t>();
             state->client_conn()->last_insert_id = state->last_insert_id;
         }
+        if (last_insert_id_expr != nullptr) {
+            state->client_conn()->last_insert_id = last_insert_id_expr->get_value(row).get_numberic<int64_t>();
+        }
     }
 }
 }

--- a/src/logical_plan/prepare_planner.cpp
+++ b/src/logical_plan/prepare_planner.cpp
@@ -236,6 +236,22 @@ int PreparePlanner::stmt_execute(const std::string& stmt_name, std::vector<pb::E
     }
 
     std::shared_ptr<QueryContext> prepare_ctx = iter->second;
+    prepare_ctx->get_runtime_state()->prepare_reset();
+    _ctx->stat_info.family = prepare_ctx->stat_info.family;
+    _ctx->stat_info.table = prepare_ctx->stat_info.table;
+    _ctx->stat_info.sample_sql << prepare_ctx->stat_info.sample_sql.str();
+    _ctx->stat_info.sign = prepare_ctx->stat_info.sign;
+    _ctx->is_full_export = prepare_ctx->is_full_export;
+    _ctx->debug_region_id = prepare_ctx->debug_region_id;
+    _ctx->execute_global_flow = prepare_ctx->execute_global_flow;
+    if (params.size() != prepare_ctx->placeholders.size()) {
+        _ctx->stat_info.error_code = ER_WRONG_ARGUMENTS;
+        _ctx->stat_info.error_msg << "Incorrect arguments to EXECUTE: " 
+                                  << params.size() << ", " 
+                                  << prepare_ctx->placeholders.size();
+        return -1;
+    }
+    auto& tuple_descs = prepare_ctx->tuple_descs();
     // ttl沿用prepare的注释
     DB_DEBUG("row_ttl_duration %ld", prepare_ctx->row_ttl_duration);
     _ctx->row_ttl_duration = prepare_ctx->row_ttl_duration;

--- a/src/logical_plan/prepare_planner.cpp
+++ b/src/logical_plan/prepare_planner.cpp
@@ -251,7 +251,6 @@ int PreparePlanner::stmt_execute(const std::string& stmt_name, std::vector<pb::E
                                   << prepare_ctx->placeholders.size();
         return -1;
     }
-    auto& tuple_descs = prepare_ctx->tuple_descs();
     // ttl沿用prepare的注释
     DB_DEBUG("row_ttl_duration %ld", prepare_ctx->row_ttl_duration);
     _ctx->row_ttl_duration = prepare_ctx->row_ttl_duration;
@@ -261,9 +260,7 @@ int PreparePlanner::stmt_execute(const std::string& stmt_name, std::vector<pb::E
     if (!prepare_ctx->is_select) {
         // TODO dml的plan复用
         // enable_2pc=true or table has global index need generate txn_id
-        if (!prepare_ctx->is_select && prepare_ctx->prepared_table_id != -1) {
-            set_dml_txn_state(prepare_ctx->prepared_table_id);
-        }
+        set_dml_txn_state(prepare_ctx->prepared_table_id);
         _ctx->plan.CopyFrom(prepare_ctx->plan);
         int ret = set_dml_local_index_binlog(prepare_ctx->prepared_table_id);
         if (ret < 0) {

--- a/src/logical_plan/prepare_planner.cpp
+++ b/src/logical_plan/prepare_planner.cpp
@@ -245,7 +245,9 @@ int PreparePlanner::stmt_execute(const std::string& stmt_name, std::vector<pb::E
     if (!prepare_ctx->is_select) {
         // TODO dml的plan复用
         // enable_2pc=true or table has global index need generate txn_id
-        set_dml_txn_state(prepare_ctx->prepared_table_id);
+        if (!prepare_ctx->is_select && prepare_ctx->prepared_table_id != -1) {
+            set_dml_txn_state(prepare_ctx->prepared_table_id);
+        }
         _ctx->plan.CopyFrom(prepare_ctx->plan);
         int ret = set_dml_local_index_binlog(prepare_ctx->prepared_table_id);
         if (ret < 0) {

--- a/src/logical_plan/select_planner.cpp
+++ b/src/logical_plan/select_planner.cpp
@@ -108,7 +108,7 @@ int SelectPlanner::plan() {
     //print_debug_log();
     //_create_group_tuple_desc();
 
-    if (is_full_export()) {
+    if (!_ctx->is_full_export && is_full_export()) {
         _ctx->is_full_export = true;
     }
     get_slot_column_mapping();
@@ -150,12 +150,18 @@ bool SelectPlanner::is_full_export() {
     if (_ctx->explain_type != EXPLAIN_NULL) {
         return false;
     }
+    if (_ctx->debug_region_id != -1) {
+        return false;
+    }
     if (_ctx->has_derived_table || _ctx->has_information_schema) {
         return false;
     }
     if (_select->group != nullptr) {
         return false;
     } 
+    if (!_agg_funcs.empty() || !_order_ascs.empty()) {
+        return false;
+    }
     if (_select->having != nullptr) {
         return false;
     } 

--- a/src/logical_plan/select_planner.cpp
+++ b/src/logical_plan/select_planner.cpp
@@ -159,13 +159,10 @@ bool SelectPlanner::is_full_export() {
     if (_select->group != nullptr) {
         return false;
     } 
-    if (!_agg_funcs.empty() || !_order_ascs.empty()) {
-        return false;
-    }
     if (_select->having != nullptr) {
         return false;
     } 
-    if (_select->order != nullptr) {
+    if (_select->order != nullptr || !_order_ascs.empty()) {
         return false;
     }
     //if (_select->limit != nullptr) {

--- a/src/physical_plan/index_selector.cpp
+++ b/src/physical_plan/index_selector.cpp
@@ -790,8 +790,9 @@ int IndexSelector::select_partition(SmartTable& table_info, ScanNode* scan_node,
         }
 
         if (partition_type == pb::PT_HASH) {
-            if (field_iter != field_range_map.end() && !field_iter->second.eq_in_values.empty()) {
-                scan_node->set_partition_field_id(field_iter->first);
+            if (field_iter != field_range_map.end()
+                && (field_iter->second.type == EQ || field_iter->second.type == IN || field_iter->second.type == LIKE_EQ) 
+                && !field_iter->second.eq_in_values.empty()) {
                 ExprValueFlatSet eq_in_values_set;
                 eq_in_values_set.init(ajust_flat_size(field_iter->second.eq_in_values.size()));
                 for (auto& value : field_iter->second.eq_in_values) {

--- a/src/physical_plan/index_selector.cpp
+++ b/src/physical_plan/index_selector.cpp
@@ -171,8 +171,6 @@ void IndexSelector::hit_row_field_range(ExprNode* expr,
         field_ids.push_back(pair.second->field_id());
     }
     RangeType tmp_type;
-    int old_weight;
-    int cur_weight;
     switch (expr->node_type()) {
         case pb::FUNCTION_CALL: {
             int32_t fn_op = static_cast<ScalarFnCall*>(expr)->fn().fn_op();

--- a/src/protocol/state_machine.cpp
+++ b/src/protocol/state_machine.cpp
@@ -383,7 +383,7 @@ void StateMachine::_print_query_time(SmartSocket client) {
                     field_range_type, err_count, stat_info->sign, subquery_signs);
         }
 
-        if (op_type == pb::OP_SELECT) {
+        if (op_type == pb::OP_SELECT || op_type == pb::OP_UNION) {
             select_time_cost << stat_info->total_time;
             std::unique_lock<std::mutex> lock(_mutex);
             if (select_by_users.find(client->username) == select_by_users.end()) {


### PR DESCRIPTION
* prepare模式QueryContext及RuntimeStatus对象部分变量需重置，比如 is_canel, 统计信息。debug_region_id, execute_global_flow等。
* update_manager_node全局索引更新时，不返回last_insert_id修复。
* union类型统计到select_time_cost
* prepare模式设置dml txt。只有非select且prepared_table_id != -1才需要设置
* index_selector中计算分区时，只有等值类型才能计算。（前缀like计算会出错）
* index_selector中生产field_range_map时，每次需要清空FieldRange对象。SQL where a like 'xx_%' and a = '111;